### PR TITLE
fix: synchronize master spec and documentation with issue #1 resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Master Specification (`README.md`)**: The authoritative definition of Trajectory IR (Spec v0.2-draft).
 - **Infrastructure Blueprint (`infrastructure.md`)**: Detailed DevOps rules targeting `local`, `server-s3`, and `k8s-fluid` profiles. Outlines the sharded CAS layout and fallback mechanisms.
 - **Community Governance**: Added CNCF `CODE_OF_CONDUCT.md`.
-- **Contribution Guidelines**: Added `CONTRIBUTING.md`, enforcing DCO sign-offs (`Signed-off-by`) and AI Agent (ECC) accountability rules.
-- **Security Policy**: Added `SECURITY.md`, detailing threat models specific to tool execution (Safety Boundary Bypasses, Seal Tampering, Cache Poisoning).
-- **Quickstart Guide**: Added `QUICKSTART.md` for rapid prototyping using the embedded DBOS backend and SQLite/FileSystem CAS.
+- **Contribution Guidelines**: Added `CONTRIBUTING.md`, enforcing DCO sign-offs (`Signed-off-by`), Everything Claude Code (ECC) subagent suite integration, and governance accountability rules.
+- **Security Policy**: Added `SECURITY.md`, detailing threat models specific to tool execution (Safety Boundary Bypasses, Seal Tampering, Cache Poisoning) and establishing GitHub Private Advisories for confidential reporting.
+- **Quickstart Guide**: Added `QUICKSTART.md` for rapid prototyping using the embedded DBOS backend and SQLite/FileSystem CAS behind an abstract `@Trajectory.workflow()` wrapper.
 
 ### Changed
-- Shifted project scope away from rebuilding custom crash detection / memory storage (formerly CLOOP/CAMI) towards wrapping the DBOS/Restate durable execution backends. 
+- **Session Storage Consolidation (formerly CLOOP)**: Folded CLOOP's session storage design (mutable short-term state, append-only event log, and sharded CAS artifact store) directly into Trajectory IR's unified database and storage schemas rather than maintaining a separate runtime project.
+- **Declarative Memory Provisioning (formerly CAMI)**: Deferred Kubernetes declarative memory-provisioning claims and storage classes to an optional future phase without blocking core package portability or Phase 1A development.
+- **Durable Execution Rebuild Strategy**: Delegated crash-safe step execution, lease/heartbeat coordination, and deterministic replay to hardened, pluggable third-party backends (**DBOS** and Restate) rather than rebuilding custom execution orchestration engines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This document outlines the workflow and strict requirements for getting your cod
 
 The `README.md` (and the technical specifications inside `spec/`) acts as the single source of truth. 
 * **Do not** implement behavior that isn't defined in the spec.
-* **Do not** derive undefined behavior from general familiarity with similar systems (e.g., Temporal, LangGraph). 
+* **Do not** derive undefined behavior from general familiarity with high-level AI orchestration or state frameworks (e.g., LangGraph, CrewAI). *Note: The one deliberate exception is our pluggable durable execution backend (§3.1, such as DBOS or Restate), whose documented transactional replay, retry, and checkpoint behavior should be relied upon directly without redundant wrapper logic.*
 * If a design point is ambiguous, open an issue tagged `SPEC-QUESTION` and wait for a resolution. **Do not guess**.
 
 ## 2. Developer Certificate of Origin (DCO) Sign-off
@@ -31,15 +31,17 @@ git commit -s -m "feat: add basic DBOS adapter framework"
 
 ## 3. Pull Request Process & Quality Gates
 
-### A. AI Agent Working Agreements (ECC)
-If you are an AI coding agent (like Claude Code or Antigravity), you are strictly bound by the rules in `README.md` Section 15. You must:
-- Use the **Planner Agent** to create an implementation plan before writing core logic.
-- Use the **TDD-Guide Agent** to enforce >80% test coverage.
-- Use the **Security-Review Agent** for anything touching `pkg/effects/` or `pkg/resume/`.
+We enforce a layered governance model combining automated continuous integration checks with rigorous human and AI developer procedural review policies.
 
-### B. Conformance Testing
-No PR will be merged if it violates the conformance tests defined in `conformance/`. 
-- **R01 (Safe Resume)** and **R02 (Block-and-Gate)** are hard blockers for Phase 1A. If you modify the adapter interface or the resume logic, you must prove those tests still pass.
+### A. AI Agent Working Agreements (ECC Integration)
+If you are an AI coding agent (like Claude Code or Antigravity) or a developer leveraging AI assistants, you are strictly bound by the rules in `README.md` Section 15. Specifically, our codebase integrates the **Everything Claude Code (ECC)** subagent suite and mandates three specialized gate roles:
+- Use the **Planner Agent** to conduct architectural research and create an `implementation_plan.md` before writing core logic.
+- Use the **TDD-Guide Agent** to build test-first modules in `pkg/` and `drivers/`, enforcing >80% test coverage.
+- Use the **Security-Review Agent** as a mandatory procedural code review step before submitting any modifications to `pkg/effects/` or `pkg/resume/`.
+
+### B. Automated vs Procedural Gates
+- **Automated Hard CI Gates**: No PR will be merged if it violates automated continuous integration checks. Commits lacking DCO sign-offs or failing static analysis (Ruff/Mypy) will be blocked. Crucially, the conformance tests defined in `conformance/`—specifically **R01 (Safe Resume)** and **R02 (Block-and-Gate)**—are automated hard blockers for Phase 1A.
+- **Procedural Governance Gates**: Peer review by a human maintainer and Security-Review Agent verification are mandatory policy rules for any PR modifying safety boundaries or block-and-gate resumption.
 
 ### C. Formatting and Linting
 We use modern Python tooling:
@@ -58,7 +60,7 @@ We look forward to reviewing your pull requests!
 
 ## 5. AI Contribution Disclosure
 
-Trajectory IR is heavily developed in collaboration with AI tools (like the Antigravity IDE, Claude Code, and the ECC agent suite). We strongly embrace AI-assisted development! However, to maintain code quality, accountability, and clarity of origin, **human contributors must adhere to the following:**
+Trajectory IR is heavily developed in collaboration with AI tools (like the Antigravity IDE, Claude Code, and the Everything Claude Code [ECC] agent suite). We strongly embrace AI-assisted development! However, to maintain code quality, accountability, and clarity of origin, **human contributors must adhere to the following:**
 
 1. **Disclosure**: If you used an AI coding assistant (Copilot, Cursor, Claude, Antigravity, ChatGPT, etc.) to generate a significant portion of the logic in your PR, please mention it in the Pull Request description (e.g., "This PR was generated with the help of Antigravity IDE").
 2. **Accountability**: You, the human contributor, are 100% responsible for the code you submit. You must review the AI-generated code to ensure it adheres to the `README.md` spec, passes all conformance tests, and does not introduce security or performance regressions. 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Welcome to Trajectory IR! This guide will get you up and running with the `local` deployment profile in under 5 minutes. 
 
-Trajectory IR acts as a semantic layer for AI agents, wrapping your agent's execution history in a portable, crash-safe format using [DBOS](https://docs.dbos.dev/).
+Trajectory IR acts as a semantic layer for AI agents, wrapping your agent's execution history in a portable, crash-safe format using pluggable durable execution backends like [DBOS](https://docs.dbos.dev/) or Restate.
 
 ## Prerequisites
 - Python 3.11+
@@ -12,10 +12,10 @@ Trajectory IR acts as a semantic layer for AI agents, wrapping your agent's exec
 
 ## 1. Installation
 
-Install the Trajectory IR SDK and the DBOS durable execution backend:
+Install the Trajectory IR SDK and the official `dbos` durable execution backend package:
 
 ```bash
-pip install trajectory-ir dbos-transact
+pip install trajectory-ir dbos
 ```
 
 ## 2. Initialize the Local Environment
@@ -32,15 +32,16 @@ This command creates `~/.trajectory-ir/local.db` and `~/.trajectory-ir/cas/`.
 
 ## 3. Your First Durable Agent
 
-Create a file called `agent.py`. In this example, we wrap a standard LLM function call inside Trajectory IR's durable execution context. If the script crashes mid-execution, running it again will safely resume from the exact same state without duplicating side-effects!
+Create a file called `agent.py`. In this example, we wrap a standard tool call inside Trajectory IR's durable execution context. 
+
+> **Pluggable Backend Architecture Note:** Notice that your code imports only from `trajectory_ir`. Under the hood, `@Trajectory.workflow()` transparently delegates crash detection and replay to the configured durable backend (such as DBOS in Phase 1A or Restate). This guarantees that switching backends in the future requires **zero modifications** to your application logic!
 
 ```python
 from trajectory_ir.runtime import Trajectory
 from trajectory_ir.effects import EffectClass
-from dbos import DBOS
 
-# 1. Initialize the durable backend (DBOS)
-DBOS.launch()
+# 1. Initialize the Trajectory runtime (auto-launches configured backend like DBOS)
+Trajectory.launch()
 
 # 2. Define a Tool with strict Effect Classification
 @Trajectory.tool(effect_class=EffectClass.NON_IDEMPOTENT_WRITE)
@@ -48,13 +49,13 @@ def deploy_server(server_name: str):
     print(f"Deploying {server_name}...")
     return f"Success: {server_name} is live."
 
-# 3. Create an Agent Workflow
-@DBOS.workflow()
+# 3. Create an Agent Workflow using the backend-agnostic decorator
+@Trajectory.workflow()
 def run_agent():
     # Start a new semantic Trajectory
     traj = Trajectory.start(tenant_id="demo-user")
     
-    # Execute the tool (Trajectory IR wraps this in a DBOS durable step)
+    # Execute the tool (Trajectory IR wraps this in a crash-safe durable step)
     result = deploy_server("prod-web-01")
     
     # Append the result to the Trajectory Log
@@ -75,7 +76,7 @@ Execute your agent:
 python agent.py
 ```
 
-Because of the **Block-and-Gate** policy, if your agent crashes inside `deploy_server`, the next time you run `python agent.py`, it will recognize the interrupted `NON_IDEMPOTENT_WRITE` and halt execution, requesting human intervention.
+Because of the **Block-and-Gate** policy, if your agent crashes inside `deploy_server`, the next time you run `python agent.py`, it will recognize the interrupted `NON_IDEMPOTENT_WRITE` and halt execution, requesting human intervention rather than blindly repeating the destructive action.
 
 ## What's Next?
 - Read the [Infrastructure Design](infrastructure.md) to learn how to scale this to `server-s3` or `k8s-fluid`.

--- a/README.md
+++ b/README.md
@@ -405,11 +405,10 @@ This section is binding for implementation choices. Do not introduce alternative
 
 ```text
 trajectory-ir/
-  README.md                     # points here, to this master spec
+  README.md                     # Master Specification (this file)
   LICENSE                       # Apache-2.0
   CODE_OF_CONDUCT.md            # CNCF Code of Conduct
   CONTRIBUTING.md                # DCO sign-off requirement, PR process
-  TRAJECTORY_IR_MASTER_SPEC.md   # this file
   spec/
     node-kinds.md
     effect-classes.md
@@ -465,9 +464,18 @@ Contributors and agents should place new code according to this layout. If a cha
 
 ---
 
-## 15. Working agreement for AI coding agents
+## 15. Working agreement for AI coding agents (ECC Integration)
 
-This section exists specifically so that multiple AI coding agents (including different Claude Code sessions, potentially working on different parts of the codebase at overlapping times) converge on the same implementation rather than producing conflicting or duplicated logic. Treat every rule below as a hard constraint, not a suggestion.
+This section exists specifically so that multiple AI coding agents (including different Claude Code sessions and Everything Claude Code [ECC] specialized subagents, working on different parts of the codebase at overlapping times) converge on the same implementation rather than producing conflicting or duplicated logic.
+
+### 15.1 Specialized Agent Roles (ECC Suite)
+When developing Trajectory IR using AI coding assistants, human maintainers and agents must operate under three mandatory procedural gate roles:
+- **Planner Agent**: Must be invoked for any major architectural change, module creation, or ambiguous task to research and draft an `implementation_plan.md` before coding begins.
+- **TDD-Guide Agent**: Enforces test-driven development for all logic in `pkg/` and `drivers/`. Modules must be built test-first with over 80% test coverage.
+- **Security-Review Agent**: A mandatory procedural peer-review gate that must analyze and sign off on any proposed modifications to `pkg/effects/` (tool safety boundaries) or `pkg/resume/` (block-and-gate semantics) before a human maintainer merges the changes.
+
+### 15.2 Hard Implementation Rules
+Treat every numbered rule below as an immutable constraint, not a suggestion:
 
 1. **This document is the spec.** Do not derive undefined behavior from general familiarity with similar systems (event sourcing frameworks, other IR designs, etc.). Where this document is silent on a design point, do not invent one, open a `SPEC-QUESTION` issue or comment and stop short of implementing the undefined behavior. This is distinct from rule 2 below: the durable execution backend is not "a similar system to avoid copying", it is a declared, intentional dependency, and its documented behavior should be relied on, not reimplemented.
 2. **Never implement custom crash detection, retry, or lease/heartbeat logic.** This is the single most important rule in this section. That responsibility belongs entirely to the durable execution backend adapter (§3.1, §12.0). If a task seems to need it, the adapter interface is incomplete, extend `drivers/durable-backend/`, and if the chosen backend (DBOS) genuinely cannot provide what's needed, raise an issue before writing a parallel mechanism in `pkg/resume/`. A pull request that adds retry loops, polling, or timeout tracking outside the adapter is a defect, not a feature, regardless of how small it looks.
@@ -517,6 +525,7 @@ Trajectory IR deliberately does not attempt to:
 | CLOOP | The earlier session storage proposal, now folded into Trajectory IR's storage layer rather than existing separately |
 | Fluid | A CNCF incubating Kubernetes native dataset orchestrator, used only as an optional read path cache accelerator (§11.3) |
 | CAS | Content addressed storage, objects identified and retrieved by the hash of their bytes |
+| ECC | Everything Claude Code: An expert suite of specialized AI developer subagents (Planner, TDD-Guide, Security-Review) and canonical workflows mandated for AI-assisted development (§15) |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,9 @@ Trajectory IR is currently in its **Phase 1A / v0.1.x** development cycle.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-If you discover a security vulnerability, please send an e-mail to the core maintainers: `siddharthagithub0007@gmail.com` *(or project owner email)*.
+To adhere to cloud-native security standards (CNCF TAG Security best practices), we enforce coordinated vulnerability disclosure:
+1. **Primary Secure Channel (GitHub Private Advisories)**: Please use the repository's native **Private Vulnerability Reporting** feature. Navigate to the repository's **Security** tab, click **Advisories**, and select **Report a vulnerability**. This allows secure, confidential communication directly with core maintainers and creation of a private staging patch before public disclosure.
+2. **Secondary Backup Channel**: If you encounter issues accessing GitHub Private Advisories, please contact the lead maintainer directly via email at `siddharthagithub0007@gmail.com`.
 
 We will acknowledge receipt of your vulnerability report within 48 hours. Please adhere to the [Code of Conduct](CODE_OF_CONDUCT.md) during this process—public zero-day drops or harassment of maintainers over patches are strict violations of our community standards.
 
@@ -40,7 +42,7 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 ## 4. Security Accountability for Contributors
 
 As defined in our [Contributing Guidelines](CONTRIBUTING.md):
-1. **AI Generation Liability**: If you use AI coding assistants (Antigravity IDE, Claude Code, ECC) to draft PRs, **you, the human contributor, are 100% accountable** for any security flaws they introduce. AI agents have zero built-in trust regarding security boundaries.
-2. **Mandatory Security Reviews**: Any pull request that modifies files in `pkg/effects/` (tool safety mapping) or `pkg/resume/` (block-and-gate semantics) is automatically flagged for maximum scrutiny and requires sign-off from the **Security-Review Agent** and a human core maintainer.
+1. **AI Generation Liability**: If you use AI coding assistants (Antigravity IDE, Claude Code, Everything Claude Code [ECC]) to draft PRs, **you, the human contributor, are 100% accountable** for any security flaws they introduce. AI agents have zero built-in trust regarding security boundaries.
+2. **Mandatory Security Reviews (Procedural Governance Gate)**: Any pull request that modifies files in `pkg/effects/` (tool safety mapping) or `pkg/resume/` (block-and-gate semantics) is automatically flagged for maximum scrutiny. As a required procedural development policy, such pull requests demand peer review verification from the **Security-Review Agent** and explicit manual sign-off from a human core maintainer prior to merge.
 
 Thank you for helping keep Trajectory IR safe and verifiable!

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -37,7 +37,7 @@ flowchart TD
 **IR Metadata Log (SQLite/Postgres)**
 - `trajectories`: `trajectory_id` (PK), `tenant_id`, `status`.
 - `nodes`: `node_id` (PK, computed via RFC 8785 JCS + SHA256), `trajectory_id`, `seq`, `kind`, `payload`.
-- `seals`: `seal_id` (PK), `node_id` (FK), `signature`.
+- `seals`: `seal_id` (PK), `node_id` (FK), `content_hash`. *(Note: Contains the deterministic RFC 8785 JCS + SHA256 content integrity hash; package-level cryptographic digital signatures are explicitly deferred out-of-scope for Phase 1A).*
 
 **Sharded CAS Object Store (S3/Filesystem)**
 Artifacts are sharded by the first two hex characters of their SHA256 hash to prevent bucket listing degradation:
@@ -69,44 +69,56 @@ To ensure high quality, deterministic builds, and rapid iteration, we enforce st
    - Type Checking: **Mypy** (Strict mode enabled for all core IR packages).
 
 2. **Core Dependencies**:
-   - `canonicaljson`: For RFC 8785 strict hashing.
-   - `dbos-transact`: For the embedded durable execution Phase 1A backend.
+   - `canonicaljson`: For RFC 8785 strict canonical hashing.
+   - `dbos`: For the embedded durable execution Phase 1A backend.
    - `pytest` & `pytest-cov`: For the conformance suite.
 
 ### 2.2 AI Agent Workflow (ECC Integration)
 
-This repository is maintained by Human owners collaborating with AI Agents (specifically the Antigravity IDE and the Everything Claude Code suite). We mandate the following agent workflow:
+This repository is maintained by human owners collaborating with AI agents (specifically the Antigravity IDE and the Everything Claude Code [ECC] specialized subagent suite). As documented in `README.md` Section 15, we mandate the following developer and AI workflow:
 
 1. **Planner Agent**: Must be invoked for any new architecture or module to draft an `implementation_plan.md` before coding.
 2. **TDD-Guide Agent**: All modules in `pkg/` and `drivers/` are built test-first. Test coverage must exceed 80%.
-3. **Security-Review Agent**: Must be invoked before merging any modifications to `pkg/effects/` (tool safety boundaries) and `pkg/resume/` (block-and-gate logic).
+3. **Security-Review Agent (Procedural Governance Gate)**: Must be invoked before merging any modifications to `pkg/effects/` (tool safety boundaries) and `pkg/resume/` (block-and-gate logic). Unlike automated CI checks, this is a mandatory procedural code review and human maintainer sign-off policy designed to ensure maximum scrutiny on sensitive boundary logic.
 
 ### 2.3 CI/CD Pipeline (GitHub Actions)
 
-Every pull request runs through a strict automated pipeline:
+Every pull request runs through a strict automated CI pipeline. All four validation stages function as hard blocking gates upon failure:
 
 ```mermaid
 sequenceDiagram
     participant PR as Pull Request
+    participant DCO as DCO Verifier
     participant Lint as Ruff & Mypy
     participant Unit as Pytest (Unit)
     participant Conf as Conformance (R01/R02)
-    participant DCO as DCO Verifier
 
-    PR->>DCO: Check "Signed-off-by"
-    PR->>Lint: Static Analysis
-    PR->>Unit: Fast localized tests
-    PR->>Conf: Run durable DBOS gates
-    
-    alt Any stage fails
-        Lint-->>PR: Block Merge
-    else All stages pass
-        Conf-->>PR: Allow Merge
+    PR->>DCO: Check "Signed-off-by" trailer
+    alt DCO Check Fails
+        DCO-->>PR: Block Merge (Missing Sign-off)
+    else DCO Check Passes
+        PR->>Lint: Static Analysis & Type Checking
+        alt Lint / Mypy Fails
+            Lint-->>PR: Block Merge (Static Analysis Error)
+        else Static Analysis Passes
+            PR->>Unit: Execute Fast Localized Unit Tests
+            alt Unit Tests Fail
+                Unit-->>PR: Block Merge (Unit Test Failure)
+            else Unit Tests Pass
+                PR->>Conf: Execute Durable Conformance Gates (R01/R02)
+                alt Conformance Suite Fails
+                    Conf-->>PR: Block Merge (Durable Gate Failure)
+                else All Stages Pass Cleanly
+                    Conf-->>PR: Allow Merge
+                end
+            end
+        end
     end
 ```
 
-- **DCO Sign-off**: Every commit must carry a Developer Certificate of Origin (`Signed-off-by: Name <email>`). Commits without this are hard-blocked by CI.
-- **Conformance Gates**: Features are not complete unless tests `R01` (Safe Resume) and `R02` (Block-and-Gate) pass cleanly.
+- **DCO Sign-off (Automated Hard Gate)**: Every commit must carry a Developer Certificate of Origin (`Signed-off-by: Name <email>`). Commits without this are hard-blocked by CI.
+- **Conformance Gates (Automated Hard Gate)**: Features are not complete unless tests `R01` (Safe Resume) and `R02` (Block-and-Gate) pass cleanly in automated CI.
+- **Security & Architectural Sign-off (Procedural Review Policy)**: Changes modifying tool effect classification or block-and-gate resumption require explicit procedural peer review and human maintainer approval before PR merge.
 
 ### 2.4 Codebase Mapping
 


### PR DESCRIPTION
Synchronizes master specification (README.md) and repository docs with website Issue #1 resolutions. Updates DBOS package name to dbos, adopts abstract @Trajectory.workflow() wrapper in Quickstart, renames seals.signature to seals.content_hash, sets GitHub Private Security Advisories as primary confidential channel, defines ECC in §15 and Glossary, clarifies hard CI blocking stages vs procedural review governance, and separates CHANGELOG architectural resolutions into clean bullet points.