### PR TITLE
chore: CI, DCO, and contribution templates (#5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something is broken or behaves differently than the spec or docs say.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please skip secrets, tokens, and private trajectory data.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened
+      description: Short description of the bug.
+      placeholder: On resume after a sealed decision, ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: Correct behavior according to the docs or your understanding.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps. Commands are welcome.
+      placeholder: |
+        1. Clone the repo
+        2. pip install -e ".[dev]"
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Environment
+      description: "OS, Python version, install method (for example Windows 11 / Python 3.12 / editable install)."
+      placeholder: Windows 11, Python 3.12.10, pip install -e ".[dev]"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant output. Redact secrets.
+      render: text
+
+  - type: input
+    id: spec
+    attributes:
+      label: Related spec section (optional)
+      description: README section, issue number, or file under spec/.
+      placeholder: README §8 / seals-and-resume.md

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Coder-s-OG-s/Trajectory-IR/security/advisories/new
+    about: Do not file public issues for security reports. Use private vulnerability reporting.
+  - name: Master specification
+    url: https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/README.md
+    about: Read the root README before opening a SPEC-QUESTION or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature or enhancement
+description: Propose new behavior or an improvement that fits the project scope.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Trajectory IR follows the master README. Features that reimplement durable execution (retry, lease, custom crash engines) or add Fluid/CAMI early are usually out of scope for Phase 1A. See issues #2 and the root README.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is hard or missing today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should change? Keep it concrete.
+    validations:
+      required: true
+
+  - type: input
+    id: spec
+    attributes:
+      label: Spec reference
+      description: Which part of README or spec/ this relates to. Use "none yet" if you are unsure.
+      placeholder: README §9 / tir-package.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Explicitly not part of this idea
+      description: Helps keep the request small.
+      placeholder: Not asking for a Restate adapter yet.

--- a/.github/ISSUE_TEMPLATE/spec_question.yml
+++ b/.github/ISSUE_TEMPLATE/spec_question.yml
@@ -1,0 +1,42 @@
+name: Spec question
+description: The master README or a file under spec/ is unclear. Do not invent behavior.
+title: "spec: "
+labels: ["SPEC-QUESTION"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the spec is ambiguous. Per CONTRIBUTING, wait for a resolution before coding around the gap.
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: File and section (README §…, spec/seals-and-resume.md, issue #2, etc.).
+      placeholder: README §8.2 / spec/seals-and-resume.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What is unclear
+      description: Quote or paraphrase the conflicting or missing text.
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Options you see (optional)
+      description: If you already have two readings, list them. Do not implement either yet.
+      placeholder: |
+        A) Treat missing MCP hints as NON_IDEMPOTENT_WRITE
+        B) ...
+
+  - type: textarea
+    id: blocked
+    attributes:
+      label: What this blocks
+      description: Which PR or task is stuck until this is answered.
+      placeholder: Cannot finish block-and-gate mid-tool path in resume.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- What changed and why. A few sentences is enough. -->
+
+## Related issues
+
+<!-- Example: Closes #123  or  Part of #2 -->
+
+## How I tested
+
+<!-- Commands you ran, or "docs only" / "templates only". -->
+
+```bash
+# example
+pip install -e ".[dev]"
+pytest
+ruff check pkg test
+```
+
+## Checklist
+
+- [ ] Commits are DCO signed (`git commit -s`)
+- [ ] Change matches the master README / `spec/` (no invented APIs)
+- [ ] CI relevant checks pass locally when this is not a docs-only PR
+- [ ] AI assistance disclosed below if a tool wrote a meaningful share of the change
+
+## Safety areas
+
+Does this touch effect classes, resume / block-and-gate, seals, or secret handling?
+
+- [ ] No
+- [ ] Yes (call it out here; expects careful review)
+
+## AI assistance (if any)
+
+<!-- Example: Assisted with Cursor for boilerplate; I reviewed all diffs. Or: None. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dco-check
+        run: pip install --upgrade pip dco-check
+
+      - name: Verify Signed-off-by on PR commits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dco-check --verbose
+
+  quality:
+    name: Quality (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and dev tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff lint
+        run: ruff check pkg test
+
+      - name: Ruff format check
+        run: ruff format --check pkg test
+
+      - name: Mypy
+        run: mypy pkg/trajectory_ir
+
+      - name: Import smoke
+        run: |
+          python -c "import trajectory_ir; print(trajectory_ir.__version__)"
+          python -c "from dbos import DBOS, DBOSConfig; print('DBOS import OK')"
+          python -c "import rfc8785; print(rfc8785.dumps({'b': 1, 'a': 2}))"
+
+      - name: Pytest
+        run: pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Boilerplate directory structure initialization for Phase 1A python components (`pkg/`, `client/`, `drivers/`, `conformance/`, `spec/`).
-- GitHub workflow CI/CD documentation and DCO requirements.
+- GitHub Actions CI (DCO, Ruff, Mypy, import smoke, pytest on Python 3.11/3.12).
+- Issue templates (bug, feature, spec question) and pull request template.
+- Maintainer notes for branch protection on `main`.
+- Unit smoke tests under `test/unit/` so CI has a real pytest entrypoint.
+
+### Changed
+- CONTRIBUTING and infrastructure docs now describe the CI gates that actually run, and mark R01/R02 as future hard gates when conformance tests land.
 
 ## [v0.1.0-draft] - 2026-07-27
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,67 +1,106 @@
 # Contributing to Trajectory IR
 
-First off, thank you for considering contributing to Trajectory IR! 
+Thanks for helping. Trajectory IR is a portable semantic layer for agent runs
+(seals, effect classes, `.tir`, honest resume). The root `README.md` is the
+master specification. Code and docs should follow it.
 
-This document outlines the workflow and strict requirements for getting your code merged. Because Trajectory IR functions as an authoritative, portable master specification, we enforce high standards for code changes and documentation.
+## 1. Spec before code
 
-## 1. The Golden Rule: Spec Before Code
+1. Read the root `README.md` and the relevant files under `spec/`.
+2. Do not implement behavior that is not defined there.
+3. Do not reimplement durable execution (retry, lease, custom crash engines).
+   That belongs to the backend adapter (`drivers/durable-backend/`), defaulting
+   to DBOS in Phase 1A.
+4. If something is ambiguous, open a **Spec question** issue and wait. Do not
+   invent APIs, node kinds, or resume rules.
 
-The `README.md` (and the technical specifications inside `spec/`) acts as the single source of truth. 
-* **Do not** implement behavior that isn't defined in the spec.
-* **Do not** derive undefined behavior from general familiarity with high-level AI orchestration or state frameworks (e.g., LangGraph, CrewAI). *Note: The one deliberate exception is our pluggable durable execution backend (§3.1, such as DBOS or Restate), whose documented transactional replay, retry, and checkpoint behavior should be relied upon directly without redundant wrapper logic.*
-* If a design point is ambiguous, open an issue tagged `SPEC-QUESTION` and wait for a resolution. **Do not guess**.
+## 2. Developer Certificate of Origin (DCO)
 
-## 2. Developer Certificate of Origin (DCO) Sign-off
-
-**This is a hard requirement.** We enforce the DCO for all commits to ensure that contributors have the right to submit the code under the Apache-2.0 license.
-
-Every single commit must contain the following trailer at the end of the commit message:
-
-```text
-Signed-off-by: Jane Doe <jane.doe@example.com>
-```
-
-You can add this automatically to your commits by using the `-s` or `--signoff` flag with git:
+Required on every commit under the Apache-2.0 license.
 
 ```bash
-git commit -s -m "feat: add basic DBOS adapter framework"
+git commit -s -m "feat: short description"
 ```
 
-**Pull Requests with unsigned commits will be automatically rejected by CI.**
+That adds a trailer like:
 
-## 3. Pull Request Process & Quality Gates
+```text
+Signed-off-by: Your Name <you@example.com>
+```
 
-We enforce a layered governance model combining automated continuous integration checks with rigorous human and AI developer procedural review policies.
+Use the same name and email as your GitHub account. Pull requests with unsigned
+commits fail the **DCO** job in CI.
 
-### A. AI Agent Working Agreements (ECC Integration)
-If you are an AI coding agent (like Claude Code or Antigravity) or a developer leveraging AI assistants, you are strictly bound by the rules in `README.md` Section 15. Specifically, our codebase integrates the **Everything Claude Code (ECC)** subagent suite and mandates three specialized gate roles:
-- Use the **Planner Agent** to conduct architectural research and create an `implementation_plan.md` before writing core logic.
-- Use the **TDD-Guide Agent** to build test-first modules in `pkg/` and `drivers/`, enforcing >80% test coverage.
-- Use the **Security-Review Agent** as a mandatory procedural code review step before submitting any modifications to `pkg/effects/` or `pkg/resume/`.
+## 3. Pull requests
 
-### B. Automated vs Procedural Gates
-- **Automated Hard CI Gates**: No PR will be merged if it violates automated continuous integration checks. Commits lacking DCO sign-offs or failing static analysis (Ruff/Mypy) will be blocked. Crucially, the conformance tests defined in `conformance/`—specifically **R01 (Safe Resume)** and **R02 (Block-and-Gate)**—are automated hard blockers for Phase 1A.
-- **Procedural Governance Gates**: Peer review by a human maintainer and Security-Review Agent verification are mandatory policy rules for any PR modifying safety boundaries or block-and-gate resumption.
+1. Prefer a linked issue (`Closes #N` or `Part of #2`).
+2. Keep the change focused. Scaffold, process, and runtime work should not land
+   in one giant PR without a good reason.
+3. Fill in the PR template (summary, tests, safety, AI disclosure if needed).
+4. Wait for CI to go green.
 
-### C. Formatting and Linting
-We use modern Python tooling:
-- Run `ruff check .` to lint.
-- Run `ruff format .` to format your code.
-- Run `mypy .` to ensure strict type safety.
+### Automated CI (what actually runs today)
 
-## 4. Setting up your environment
+Defined in `.github/workflows/ci.yml`:
 
-1. Clone the repository.
-2. We recommend using **Hatch** (`pip install hatch`) to manage the Python environment.
-3. Run `hatch shell` to enter the virtual environment.
-4. Run `pytest` to run the existing test suite.
+| Check | What it does |
+|-------|----------------|
+| **DCO** | Every commit on the PR has `Signed-off-by` |
+| **Quality** | `pip install -e ".[dev]"`, Ruff, Mypy on `pkg/trajectory_ir`, import smoke (`trajectory_ir`, `dbos`, `rfc8785`), `pytest` |
 
-We look forward to reviewing your pull requests!
+Python **3.11** and **3.12** both run the quality job.
 
-## 5. AI Contribution Disclosure
+### Conformance R01 / R02
 
-Trajectory IR is heavily developed in collaboration with AI tools (like the Antigravity IDE, Claude Code, and the Everything Claude Code [ECC] agent suite). We strongly embrace AI-assisted development! However, to maintain code quality, accountability, and clarity of origin, **human contributors must adhere to the following:**
+R01 (safe resume) and R02 (block-and-gate) are the Phase 1A product gates from
+the master README and issue #2. They are **not** wired into CI until those tests
+exist under `conformance/`. When they land, they become required checks. Do not
+treat them as already blocking merges today.
 
-1. **Disclosure**: If you used an AI coding assistant (Copilot, Cursor, Claude, Antigravity, ChatGPT, etc.) to generate a significant portion of the logic in your PR, please mention it in the Pull Request description (e.g., "This PR was generated with the help of Antigravity IDE").
-2. **Accountability**: You, the human contributor, are 100% responsible for the code you submit. You must review the AI-generated code to ensure it adheres to the `README.md` spec, passes all conformance tests, and does not introduce security or performance regressions. 
-3. **No Hallucinations**: Do not let an AI agent invent APIs, node kinds, or durable execution mechanics that are not explicitly documented in the Trajectory IR master spec.
+### Procedural review (humans + safety)
+
+Changes to tool effect classification or resume / block-and-gate need careful
+human review. Treat `pkg/trajectory_ir/effects/` and `pkg/trajectory_ir/resume/`
+as high sensitivity once real logic exists there.
+
+If you use AI tools for a meaningful share of a change, say so in the PR. You
+are still responsible for correctness against the spec.
+
+## 4. Local setup
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR
+python -m venv .venv
+# Windows: .\.venv\Scripts\activate
+# Unix:    source .venv/bin/activate
+pip install -U pip
+pip install -e ".[dev]"
+```
+
+Useful commands:
+
+```bash
+ruff check pkg test
+ruff format pkg test
+mypy pkg/trajectory_ir
+pytest
+```
+
+Hatch is optional (`hatch shell`) if you prefer it; plain venv + pip is enough.
+
+## 5. Issues
+
+Use the issue forms when you can:
+
+1. **Bug report** for broken behavior
+2. **Feature or enhancement** for new work in scope
+3. **Spec question** when the README or `spec/` is unclear
+
+Security issues go through private vulnerability reporting (see `SECURITY.md`),
+not public issues.
+
+## 6. Maintainer note
+
+After CI is green on `main`, turn on branch protection as described in
+`docs/maintainer-branch-protection.md`.

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -1,0 +1,35 @@
+# Maintainer note: branch protection on main
+
+This is settings work after the CI workflow in `.github/workflows/ci.yml` has
+run green at least once on the default branch or on a PR.
+
+## Recommended settings (GitHub → Settings → Branches → Branch protection rule)
+
+Apply to `main`:
+
+1. Require a pull request before merging
+2. Require approvals: at least 1 when more than one maintainer is active
+3. Require status checks to pass before merging
+4. Require branches to be up to date before merging (optional but preferred)
+5. Do not allow bypassing the above except for emergency break-glass accounts
+
+## Status checks to require
+
+After CI has appeared in the checks list, require at least:
+
+1. `DCO`
+2. `Quality (Python 3.11)`
+3. `Quality (Python 3.12)`
+
+Job names come from `.github/workflows/ci.yml`. If GitHub shows a slightly
+different label, match what the Actions UI shows.
+
+## Order of operations
+
+1. Merge the PR that adds `.github/workflows/ci.yml`
+2. Open a small follow-up PR or re-run CI so the check names exist
+3. Turn on the protection rule and select those checks
+4. Confirm a test PR cannot merge with a failing DCO or quality job
+
+Private vulnerability reports stay on the Security tab; they are not replaced
+by branch protection.

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -69,9 +69,9 @@ To ensure high quality, deterministic builds, and rapid iteration, we enforce st
    - Type Checking: **Mypy** (Strict mode enabled for all core IR packages).
 
 2. **Core Dependencies**:
-   - `canonicaljson`: For RFC 8785 strict canonical hashing.
-   - `dbos`: For the embedded durable execution Phase 1A backend.
-   - `pytest` & `pytest-cov`: For the conformance suite.
+   - `rfc8785`: RFC 8785 JCS for stable payload hashing (do not use `canonicaljson`).
+   - `dbos`: Embedded durable execution backend for Phase 1A.
+   - `pytest` & `pytest-cov`: Unit tests now; conformance suite when R01/R02 land.
 
 ### 2.2 AI Agent Workflow (ECC Integration)
 
@@ -83,42 +83,38 @@ This repository is maintained by human owners collaborating with AI agents (spec
 
 ### 2.3 CI/CD Pipeline (GitHub Actions)
 
-Every pull request runs through a strict automated CI pipeline. All four validation stages function as hard blocking gates upon failure:
+Workflow file: `.github/workflows/ci.yml`.
+
+**What runs on every pull request today**
 
 ```mermaid
 sequenceDiagram
     participant PR as Pull Request
-    participant DCO as DCO Verifier
-    participant Lint as Ruff & Mypy
-    participant Unit as Pytest (Unit)
-    participant Conf as Conformance (R01/R02)
+    participant DCO as DCO job
+    participant Q as Quality job
 
-    PR->>DCO: Check "Signed-off-by" trailer
-    alt DCO Check Fails
-        DCO-->>PR: Block Merge (Missing Sign-off)
-    else DCO Check Passes
-        PR->>Lint: Static Analysis & Type Checking
-        alt Lint / Mypy Fails
-            Lint-->>PR: Block Merge (Static Analysis Error)
-        else Static Analysis Passes
-            PR->>Unit: Execute Fast Localized Unit Tests
-            alt Unit Tests Fail
-                Unit-->>PR: Block Merge (Unit Test Failure)
-            else Unit Tests Pass
-                PR->>Conf: Execute Durable Conformance Gates (R01/R02)
-                alt Conformance Suite Fails
-                    Conf-->>PR: Block Merge (Durable Gate Failure)
-                else All Stages Pass Cleanly
-                    Conf-->>PR: Allow Merge
-                end
-            end
+    PR->>DCO: Signed-off-by on each commit
+    alt DCO fails
+        DCO-->>PR: Block
+    else DCO passes
+        PR->>Q: install, Ruff, Mypy, import smoke, pytest
+        alt Quality fails
+            Q-->>PR: Block
+        else Quality passes
+            Q-->>PR: Allow merge from CI side
         end
     end
 ```
 
-- **DCO Sign-off (Automated Hard Gate)**: Every commit must carry a Developer Certificate of Origin (`Signed-off-by: Name <email>`). Commits without this are hard-blocked by CI.
-- **Conformance Gates (Automated Hard Gate)**: Features are not complete unless tests `R01` (Safe Resume) and `R02` (Block-and-Gate) pass cleanly in automated CI.
-- **Security & Architectural Sign-off (Procedural Review Policy)**: Changes modifying tool effect classification or block-and-gate resumption require explicit procedural peer review and human maintainer approval before PR merge.
+| Gate | Status | Notes |
+|------|--------|--------|
+| DCO (`Signed-off-by`) | **Hard gate now** | `dco-check` job on pull requests |
+| Ruff + Mypy + import smoke + pytest | **Hard gate now** | Matrix on Python 3.11 and 3.12 |
+| R01 / R02 conformance | **Planned hard gate** | Wire into CI when tests exist under `conformance/` |
+| Branch protection on `main` | **Maintainer settings** | See `docs/maintainer-branch-protection.md` |
+| Effects / resume review | **Procedural** | Human review for safety-sensitive paths |
+
+Phase 1A is not complete until R01 and R02 pass (see master README and issue #2). That is a product milestone gate. Until those tests exist, CI does not claim they are already running.
 
 ### 2.4 Codebase Mapping
 

--- a/test/unit/test_package_import.py
+++ b/test/unit/test_package_import.py
@@ -1,0 +1,29 @@
+"""Smoke tests so CI has a real pytest entrypoint before runtime logic lands."""
+
+from __future__ import annotations
+
+import rfc8785
+
+import trajectory_ir
+
+
+def test_package_version_is_set() -> None:
+    assert trajectory_ir.__version__
+    assert isinstance(trajectory_ir.__version__, str)
+
+
+def test_subpackages_import() -> None:
+    import trajectory_ir.effects
+    import trajectory_ir.package
+    import trajectory_ir.resume
+    import trajectory_ir.runtime
+
+    assert trajectory_ir.runtime.__doc__ is not None
+    assert trajectory_ir.resume.__doc__ is not None
+    assert trajectory_ir.effects.__doc__ is not None
+    assert trajectory_ir.package.__doc__ is not None
+
+
+def test_rfc8785_key_order_stable() -> None:
+    # Phase 1A depends on real JCS, not ad hoc sort_keys dumps.
+    assert rfc8785.dumps({"b": 1, "a": 2}) == b'{"a":2,"b":1}'


### PR DESCRIPTION
## Summary

Sets up the open source process side of the repo: issue forms, PR template, GitHub Actions CI with DCO, and docs that match what CI really runs.

Closes #5

Depends on the Phase 1A scaffold branch (#4). This PR targets `chore/phase-1a-scaffold` so the diff stays limited to process work. After #4 lands on `main`, retarget this PR to `main` (or merge the stack in order: #4 then this).

## What landed

**Templates**
- Bug report, feature request, and spec question issue forms
- Config with security reporting link; blank issues still allowed
- PR template with summary, linked issue, test notes, DCO, safety, AI disclosure

**CI (`.github/workflows/ci.yml`)**
- **DCO** job on pull requests (`dco-check`, Signed-off-by required)
- **Quality** job on Python 3.11 and 3.12:
  - `pip install -e ".[dev]"`
  - Ruff lint + format check
  - Mypy on `pkg/trajectory_ir`
  - Import smoke for `trajectory_ir`, `dbos`, `rfc8785`
  - `pytest`

**Tests**
- `test/unit/test_package_import.py` so pytest is not empty in CI

**Docs**
- CONTRIBUTING describes the real gates
- infrastructure.md uses `rfc8785` (not `canonicaljson`), CI diagram matches today, R01/R02 marked planned
- `docs/maintainer-branch-protection.md` for required checks after CI is green
- CHANGELOG updated

**Labels on the repo**
- `phase-1a`
- `SPEC-QUESTION`
- `security`

## What this does not do

- No R01/R02 in CI yet (tests do not exist)
- No runtime / seal / resume code
- Branch protection on `main` is maintainer settings work after this is green

## How I tested

```text
ruff check pkg test
ruff format --check pkg test
mypy pkg/trajectory_ir
pytest -q
# 3 passed
```

Import smoke for trajectory_ir, dbos, and rfc8785 also OK locally.

## Checklist

- [x] Commits are DCO signed
- [x] Matches #5 goals
- [x] Local quality checks pass
- [x] AI tools used for boilerplate; diffs reviewed against #5 and the master README

## Safety areas

- [x] No (process and docs only)