### PR TITLE
chore: open source process (templates, DCO, CI) (#5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something is broken or behaves differently than the spec or docs say.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. Please skip secrets, tokens, and private trajectory data.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened
+      description: Short description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps. Commands are welcome.
+      placeholder: |
+        1. pip install -e ".[dev]"
+        2. pytest conformance/ -v
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Environment
+      description: OS, Python version, install method.
+      placeholder: Windows 11, Python 3.12, pip install -e ".[dev]"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant output. Redact secrets.
+      render: text
+
+  - type: input
+    id: spec
+    attributes:
+      label: Related spec section (optional)
+      placeholder: README §8 / conformance R01

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Coder-s-OG-s/Trajectory-IR/security/advisories/new
+    about: Do not file public issues for security reports. Use private vulnerability reporting.
+  - name: Master specification
+    url: https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/README.md
+    about: Read the root README before opening a SPEC-QUESTION or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature or enhancement
+description: Propose new behavior that fits the project scope.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Trajectory IR follows the master README. Features that reimplement durable
+        execution (custom crash engines, retry loops) or pull Fluid/CAMI into
+        Phase 1A are usually out of scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is hard or missing today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should change? Keep it concrete.
+    validations:
+      required: true
+
+  - type: input
+    id: spec
+    attributes:
+      label: Spec reference
+      description: README section or file under docs/. Use "none yet" if unsure.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Explicitly not part of this idea
+      placeholder: Not asking for a Restate adapter yet.

--- a/.github/ISSUE_TEMPLATE/spec_question.yml
+++ b/.github/ISSUE_TEMPLATE/spec_question.yml
@@ -1,0 +1,36 @@
+name: Spec question
+description: The master README or design docs are unclear. Do not invent behavior.
+title: "spec: "
+labels: ["SPEC-QUESTION"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the spec is ambiguous. Wait for a resolution before coding around the gap.
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: File and section (README §…, design doc, issue number).
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What is unclear
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Options you see (optional)
+      description: If you already have two readings, list them. Do not implement either yet.
+
+  - type: textarea
+    id: blocked
+    attributes:
+      label: What this blocks
+      description: Which PR or task is stuck until this is answered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- What changed and why. A few sentences is enough. -->
+
+## Related issues
+
+<!-- Example: Closes #123 -->
+
+## How I tested
+
+```bash
+pip install -e ".[dev]"
+pytest test/unit -q
+pytest test/e2e -q
+pytest conformance/ -q
+ruff check pkg drivers client test conformance examples
+```
+
+## Checklist
+
+- [ ] Commits are DCO signed (`git commit -s`)
+- [ ] Change matches the master README (no invented APIs)
+- [ ] Relevant CI checks pass locally
+- [ ] AI assistance disclosed below if a tool wrote a meaningful share of the change
+
+## Safety areas
+
+Does this touch effect classes, resume / block-and-gate, seals, or secret handling?
+
+- [ ] No
+- [ ] Yes (call it out here)
+
+## AI assistance (if any)
+
+<!-- Example: Assisted with Cursor for boilerplate; I reviewed all diffs. Or: None. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,81 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
-  test:
+  dco:
+    name: DCO
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          python-version: "3.11"
-      - run: pip install -e ".[dev]"
-      - run: pytest test/unit -v
-      - run: pytest test/e2e -v
-      - run: pytest conformance/ -v
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dco-check
+        run: pip install --upgrade pip dco-check
+
+      - name: Verify Signed-off-by on PR commits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dco-check --verbose
+
+  quality:
+    name: Quality (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and dev tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff lint
+        run: ruff check pkg drivers client test conformance examples
+
+      - name: Ruff format check
+        run: ruff format --check pkg drivers client test conformance examples
+
+      - name: Mypy
+        run: mypy pkg/trajectory_ir
+
+      - name: Unit tests
+        run: pytest test/unit -q
+
+      - name: E2E crash/resume tests
+        run: pytest test/e2e -q
+
+      - name: Conformance R01/R02
+        run: pytest conformance/ -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Boilerplate directory structure initialization for Phase 1A python components (`pkg/`, `client/`, `drivers/`, `conformance/`, `spec/`).
-- GitHub workflow CI/CD documentation and DCO requirements.
+- Phase 1A buildable core (nodes, NodeLog, effects, DBOS adapter, seal/resume gate, client SDK, kill-mid-deploy, R01/R02).
+- Issue templates, PR template, DCO CI job, Ruff/Mypy in CI alongside unit/e2e/conformance.
+- Maintainer note for branch protection on `main`.
+
+### Changed
+- CONTRIBUTING and infrastructure docs describe the CI gates that actually run.
+- Lint cleanups for Ruff/Mypy on the core package and test harness.
 
 ## [v0.1.0-draft] - 2026-07-27
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,67 +1,84 @@
 # Contributing to Trajectory IR
 
-First off, thank you for considering contributing to Trajectory IR! 
+Thanks for helping. Trajectory IR is a portable semantic layer for agent runs
+(seals, effect classes, `.tir`, honest resume). The root `README.md` is the
+master specification.
 
-This document outlines the workflow and strict requirements for getting your code merged. Because Trajectory IR functions as an authoritative, portable master specification, we enforce high standards for code changes and documentation.
+## 1. Spec before code
 
-## 1. The Golden Rule: Spec Before Code
+1. Read the root `README.md`.
+2. Do not implement behavior that is not defined there.
+3. Do not reimplement durable execution (retry, lease, custom crash engines).
+   That belongs under `drivers/durable_backend/` (DBOS in Phase 1A).
+4. If something is ambiguous, open a **Spec question** issue and wait.
 
-The `README.md` (and the technical specifications inside `spec/`) acts as the single source of truth. 
-* **Do not** implement behavior that isn't defined in the spec.
-* **Do not** derive undefined behavior from general familiarity with high-level AI orchestration or state frameworks (e.g., LangGraph, CrewAI). *Note: The one deliberate exception is our pluggable durable execution backend (§3.1, such as DBOS or Restate), whose documented transactional replay, retry, and checkpoint behavior should be relied upon directly without redundant wrapper logic.*
-* If a design point is ambiguous, open an issue tagged `SPEC-QUESTION` and wait for a resolution. **Do not guess**.
+## 2. Developer Certificate of Origin (DCO)
 
-## 2. Developer Certificate of Origin (DCO) Sign-off
-
-**This is a hard requirement.** We enforce the DCO for all commits to ensure that contributors have the right to submit the code under the Apache-2.0 license.
-
-Every single commit must contain the following trailer at the end of the commit message:
-
-```text
-Signed-off-by: Jane Doe <jane.doe@example.com>
-```
-
-You can add this automatically to your commits by using the `-s` or `--signoff` flag with git:
+Required on every commit:
 
 ```bash
-git commit -s -m "feat: add basic DBOS adapter framework"
+git commit -s -m "feat: short description"
 ```
 
-**Pull Requests with unsigned commits will be automatically rejected by CI.**
+Pull requests with unsigned commits fail the **DCO** job in CI.
 
-## 3. Pull Request Process & Quality Gates
+## 3. Pull requests
 
-We enforce a layered governance model combining automated continuous integration checks with rigorous human and AI developer procedural review policies.
+1. Prefer a linked issue (`Closes #N`).
+2. Keep the change focused.
+3. Fill in the PR template.
+4. Wait for CI to go green.
 
-### A. AI Agent Working Agreements (ECC Integration)
-If you are an AI coding agent (like Claude Code or Antigravity) or a developer leveraging AI assistants, you are strictly bound by the rules in `README.md` Section 15. Specifically, our codebase integrates the **Everything Claude Code (ECC)** subagent suite and mandates three specialized gate roles:
-- Use the **Planner Agent** to conduct architectural research and create an `implementation_plan.md` before writing core logic.
-- Use the **TDD-Guide Agent** to build test-first modules in `pkg/` and `drivers/`, enforcing >80% test coverage.
-- Use the **Security-Review Agent** as a mandatory procedural code review step before submitting any modifications to `pkg/effects/` or `pkg/resume/`.
+### Automated CI (what runs today)
 
-### B. Automated vs Procedural Gates
-- **Automated Hard CI Gates**: No PR will be merged if it violates automated continuous integration checks. Commits lacking DCO sign-offs or failing static analysis (Ruff/Mypy) will be blocked. Crucially, the conformance tests defined in `conformance/`—specifically **R01 (Safe Resume)** and **R02 (Block-and-Gate)**—are automated hard blockers for Phase 1A.
-- **Procedural Governance Gates**: Peer review by a human maintainer and Security-Review Agent verification are mandatory policy rules for any PR modifying safety boundaries or block-and-gate resumption.
+Defined in `.github/workflows/ci.yml`:
 
-### C. Formatting and Linting
-We use modern Python tooling:
-- Run `ruff check .` to lint.
-- Run `ruff format .` to format your code.
-- Run `mypy .` to ensure strict type safety.
+| Check | What it does |
+|-------|----------------|
+| **DCO** | Every commit on the PR has `Signed-off-by` |
+| **Quality** | install, Ruff, Mypy on `pkg/trajectory_ir`, unit tests, e2e crash tests, R01/R02 |
 
-## 4. Setting up your environment
+Quality runs on Python **3.11** and **3.12**.
 
-1. Clone the repository.
-2. We recommend using **Hatch** (`pip install hatch`) to manage the Python environment.
-3. Run `hatch shell` to enter the virtual environment.
-4. Run `pytest` to run the existing test suite.
+### Procedural review
 
-We look forward to reviewing your pull requests!
+Changes to effect classification or resume / block-and-gate need careful human
+review (`pkg/trajectory_ir/effects/`, `pkg/trajectory_ir/resume/`).
 
-## 5. AI Contribution Disclosure
+If you use AI tools for a meaningful share of a change, say so in the PR. You
+are still responsible for correctness against the spec.
 
-Trajectory IR is heavily developed in collaboration with AI tools (like the Antigravity IDE, Claude Code, and the Everything Claude Code [ECC] agent suite). We strongly embrace AI-assisted development! However, to maintain code quality, accountability, and clarity of origin, **human contributors must adhere to the following:**
+## 4. Local setup
 
-1. **Disclosure**: If you used an AI coding assistant (Copilot, Cursor, Claude, Antigravity, ChatGPT, etc.) to generate a significant portion of the logic in your PR, please mention it in the Pull Request description (e.g., "This PR was generated with the help of Antigravity IDE").
-2. **Accountability**: You, the human contributor, are 100% responsible for the code you submit. You must review the AI-generated code to ensure it adheres to the `README.md` spec, passes all conformance tests, and does not introduce security or performance regressions. 
-3. **No Hallucinations**: Do not let an AI agent invent APIs, node kinds, or durable execution mechanics that are not explicitly documented in the Trajectory IR master spec.
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR
+python -m venv .venv
+# Windows: .\.venv\Scripts\activate
+# Unix:    source .venv/bin/activate
+pip install -U pip
+pip install -e ".[dev]"
+```
+
+Useful commands:
+
+```bash
+ruff check pkg drivers client test conformance examples
+ruff format pkg drivers client test conformance examples
+mypy pkg/trajectory_ir
+pytest test/unit -q
+pytest test/e2e -q
+pytest conformance/ -q
+```
+
+## 5. Issues
+
+Use the issue forms when you can: bug report, feature, or spec question.
+
+Security issues go through private vulnerability reporting (`SECURITY.md`),
+not public issues.
+
+## 6. Maintainer note
+
+After CI is green on `main`, turn on branch protection as described in
+`docs/maintainer-branch-protection.md`.

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -33,21 +33,33 @@ class ToolResult:
     result: Any
 
 
-def open_trajectory(tenant_id: str, trajectory_id: str, db_path: str = "trajectory.sqlite") -> Trajectory:
+def open_trajectory(
+    tenant_id: str, trajectory_id: str, db_path: str = "trajectory.sqlite"
+) -> Trajectory:
     init_backend(app_name=trajectory_id)
     return Trajectory(trajectory_id=trajectory_id, tenant_id=tenant_id, db_path=db_path)
 
 
 def project(trajectory: Trajectory, step_n: int, context: dict) -> ProjectContext:
     NodeLog(trajectory.db_path).append(
-        "PROJECT_CONTEXT", step_n, context, trajectory.trajectory_id, trajectory.tenant_id, seq=0
+        "PROJECT_CONTEXT",
+        step_n,
+        context,
+        trajectory.trajectory_id,
+        trajectory.tenant_id,
+        seq=0,
     )
     return ProjectContext(step_n=step_n, context=context)
 
 
 def seal_decision(trajectory: Trajectory, step_n: int, plan: dict) -> Decision:
     NodeLog(trajectory.db_path).append(
-        "DECISION", step_n, {"plan": plan}, trajectory.trajectory_id, trajectory.tenant_id, seq=1
+        "DECISION",
+        step_n,
+        {"plan": plan},
+        trajectory.trajectory_id,
+        trajectory.tenant_id,
+        seq=1,
     )
     return Decision(step_n=step_n, plan=plan)
 
@@ -69,8 +81,13 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool, seq: 
     log = NodeLog(trajectory.db_path)
     if tool.effect_class == EffectClass.NON_IDEMPOTENT_WRITE:
         fn = make_gated_tool_call(
-            log, trajectory.trajectory_id, trajectory.tenant_id, step_n, seq=seq,
-            tool_name=tool.name, tool_fn=tool.fn,
+            log,
+            trajectory.trajectory_id,
+            trajectory.tenant_id,
+            step_n,
+            seq=seq,
+            tool_name=tool.name,
+            tool_fn=tool.fn,
         )
     else:
         fn = tool.fn
@@ -87,10 +104,17 @@ def commit_step(trajectory: Trajectory, step_n: int, seq: int) -> None:
         seq: Sequence number for commit (should be 2 + 2*num_tool_calls to follow after all tool calls)
     """
     NodeLog(trajectory.db_path).append(
-        "COMMIT_STEP", step_n, {}, trajectory.trajectory_id, trajectory.tenant_id, seq=seq
+        "COMMIT_STEP",
+        step_n,
+        {},
+        trajectory.trajectory_id,
+        trajectory.tenant_id,
+        seq=seq,
     )
 
 
-def resume(trajectory_id: str, tenant_id: str = "demo", db_path: str = "trajectory.sqlite") -> Trajectory:
+def resume(
+    trajectory_id: str, tenant_id: str = "demo", db_path: str = "trajectory.sqlite"
+) -> Trajectory:
     init_backend(app_name=trajectory_id)
     return Trajectory(trajectory_id=trajectory_id, tenant_id=tenant_id, db_path=db_path)

--- a/conformance/r01_seal_resume_test.py
+++ b/conformance/r01_seal_resume_test.py
@@ -1,13 +1,24 @@
 """Conformance test for R01: model inference not reinvoked after decision seal."""
+
 import os
 
-from test.e2e._util import hard_kill, read_counter, run_agent, start_agent, wait_for_marker
+from test.e2e._util import (
+    hard_kill,
+    read_counter,
+    run_agent,
+    start_agent,
+    wait_for_marker,
+)
 
 
 def _report(workdir, result):
     """Diagnostic helper for resume run failures."""
     crash_log = os.path.join(workdir, "crash_run.log")
-    crash_output = open(crash_log).read() if os.path.exists(crash_log) else "<none>"
+    if os.path.exists(crash_log):
+        with open(crash_log, encoding="utf-8") as f:
+            crash_output = f.read()
+    else:
+        crash_output = "<none>"
     return (
         f"\n--- crashed run output ---\n{crash_output}"
         f"\n--- resume run stdout ---\n{result.stdout}"
@@ -37,9 +48,7 @@ def test_r01_no_reinfer_after_seal(tmp_path):
     result = run_agent("--resume", cwd=workdir)
 
     # Assert resume completed successfully
-    assert result.returncode == 0, (
-        "resume failed" + _report(workdir, result)
-    )
+    assert result.returncode == 0, "resume failed" + _report(workdir, result)
 
     # Assert model was invoked exactly once across both runs
     model_count = read_counter(os.path.join(workdir, "test_model_call_count.txt"))
@@ -49,6 +58,6 @@ def test_r01_no_reinfer_after_seal(tmp_path):
 
     # Assert tool side effect executed exactly once
     deploy_count = read_counter(os.path.join(workdir, "test_deploy_side_effect_count.txt"))
-    assert deploy_count == 1, (
-        f"tool side effect ran {deploy_count} times, expected 1" + _report(workdir, result)
+    assert deploy_count == 1, f"tool side effect ran {deploy_count} times, expected 1" + _report(
+        workdir, result
     )

--- a/conformance/r02_non_idempotent_test.py
+++ b/conformance/r02_non_idempotent_test.py
@@ -1,13 +1,24 @@
 """Conformance test for R02: non-idempotent tool crash blocks, not retries."""
+
 import os
 
-from test.e2e._util import hard_kill, read_counter, run_agent, start_agent, wait_for_marker
+from test.e2e._util import (
+    hard_kill,
+    read_counter,
+    run_agent,
+    start_agent,
+    wait_for_marker,
+)
 
 
 def _report(workdir, result):
     """Diagnostic helper for resume run failures."""
     crash_log = os.path.join(workdir, "crash_run.log")
-    crash_output = open(crash_log).read() if os.path.exists(crash_log) else "<none>"
+    if os.path.exists(crash_log):
+        with open(crash_log, encoding="utf-8") as f:
+            crash_output = f.read()
+    else:
+        crash_output = "<none>"
     return (
         f"\n--- crashed run output ---\n{crash_output}"
         f"\n--- resume run stdout ---\n{result.stdout}"
@@ -40,8 +51,8 @@ def test_r02_crash_mid_tool_blocks_not_retries(tmp_path):
     # Assert resume completed successfully (exit 0) and the exception was caught
     # by the agent's except BlockedNeedsGate block (the only path that exits 0
     # and prints the exact block message with the correct prefix).
-    assert result.returncode == 0, (
-        "resume failed or exception not caught" + _report(workdir, result)
+    assert result.returncode == 0, "resume failed or exception not caught" + _report(
+        workdir, result
     )
     assert "BLOCKED_NEEDS_GATE: step 1: 'deploy_server'" in result.stdout + result.stderr, (
         "resume did not report BLOCKED_NEEDS_GATE with correct prefix" + _report(workdir, result)

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -1,0 +1,27 @@
+# Maintainer note: branch protection on main
+
+Do this after the CI workflow has run green at least once on main or on a PR.
+
+## Recommended settings
+
+GitHub → Settings → Branches → Branch protection rule for `main`:
+
+1. Require a pull request before merging
+2. Require approvals (at least 1 when more than one maintainer is active)
+3. Require status checks to pass before merging
+4. Optionally require branches to be up to date before merging
+
+## Status checks to require
+
+Match the names shown in the Actions UI after CI runs. Expect at least:
+
+1. `DCO`
+2. `Quality (Python 3.11)`
+3. `Quality (Python 3.12)`
+
+## Order
+
+1. Merge the PR that defines `.github/workflows/ci.yml`
+2. Confirm a green run so check names exist
+3. Enable the protection rule and select those checks
+4. Confirm a test PR cannot merge with a failing DCO or quality job

--- a/examples/kill-mid-deploy/agent.py
+++ b/examples/kill-mid-deploy/agent.py
@@ -19,6 +19,7 @@ All artifacts (node log, DBOS system database, counters, markers) are written
 relative to the current working directory, so callers isolate runs by cd'ing
 into a scratch directory.
 """
+
 import argparse
 import os
 import sys
@@ -34,11 +35,11 @@ for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
 from dbos import SetWorkflowID
 
 from drivers.durable_backend.dbos.adapter import init_backend
-from trajectory_ir.runtime.log import NodeLog
-from trajectory_ir.runtime.tool import Tool
 from trajectory_ir.effects import EffectClass
 from trajectory_ir.resume.gate import BlockedNeedsGate
 from trajectory_ir.resume.step import make_run_step
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.tool import Tool
 
 TRAJECTORY_ID = "kill-mid-deploy-demo"
 TENANT_ID = "demo"
@@ -61,9 +62,13 @@ _CRASH_DURING_INFERENCE = False
 
 
 def _bump_counter(path: str) -> int:
-    n = int(open(path).read().strip() or "0") if os.path.exists(path) else 0
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            n = int(f.read().strip() or "0")
+    else:
+        n = 0
     n += 1
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(str(n))
     return n
 
@@ -102,7 +107,11 @@ def main():
     _CRASH_DURING_INFERENCE = args.crash_during == "inference"
 
     if not args.resume:
-        for marker in (DECISION_SEALED_MARKER, TOOL_STARTED_MARKER, INFERENCE_STARTED_MARKER):
+        for marker in (
+            DECISION_SEALED_MARKER,
+            TOOL_STARTED_MARKER,
+            INFERENCE_STARTED_MARKER,
+        ):
             if os.path.exists(marker):
                 os.remove(marker)
 
@@ -112,7 +121,11 @@ def main():
         return deploy_server(version, crash_during=(args.crash_during == "tool_call"))
 
     tool_registry = {
-        "deploy_server": Tool(name="deploy_server", fn=deploy_wrapper, effect_class=EffectClass.NON_IDEMPOTENT_WRITE),
+        "deploy_server": Tool(
+            name="deploy_server",
+            fn=deploy_wrapper,
+            effect_class=EffectClass.NON_IDEMPOTENT_WRITE,
+        ),
     }
 
     def seal_marker_hook():
@@ -126,7 +139,13 @@ def main():
     # DBOS looks up pending workflows for recovery at launch time and resolves
     # them by registered name, and it derives the application version (which
     # pending-workflow lookup is keyed on) from the registered workflows.
-    run_step = make_run_step(node_log, TENANT_ID, TRAJECTORY_ID, tool_registry, on_decision_sealed=seal_marker_hook)
+    run_step = make_run_step(
+        node_log,
+        TENANT_ID,
+        TRAJECTORY_ID,
+        tool_registry,
+        on_decision_sealed=seal_marker_hook,
+    )
 
     init_backend(app_name="kill-mid-deploy")
 

--- a/examples/kill-mid-deploy/run_demo.py
+++ b/examples/kill-mid-deploy/run_demo.py
@@ -8,6 +8,7 @@ Usage:
     python examples/kill-mid-deploy/run_demo.py --resume
     # expected output: "Resumed. deploy_server executed exactly once."
 """
+
 import subprocess
 import sys
 

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -69,9 +69,9 @@ To ensure high quality, deterministic builds, and rapid iteration, we enforce st
    - Type Checking: **Mypy** (Strict mode enabled for all core IR packages).
 
 2. **Core Dependencies**:
-   - `canonicaljson`: For RFC 8785 strict canonical hashing.
-   - `dbos`: For the embedded durable execution Phase 1A backend.
-   - `pytest` & `pytest-cov`: For the conformance suite.
+   - `rfc8785`: RFC 8785 JCS for stable payload hashing (do not use `canonicaljson`).
+   - `dbos`: Embedded durable execution backend for Phase 1A.
+   - `pytest` & `pytest-cov`: Unit, e2e, and conformance (R01/R02).
 
 ### 2.2 AI Agent Workflow (ECC Integration)
 
@@ -83,42 +83,35 @@ This repository is maintained by human owners collaborating with AI agents (spec
 
 ### 2.3 CI/CD Pipeline (GitHub Actions)
 
-Every pull request runs through a strict automated CI pipeline. All four validation stages function as hard blocking gates upon failure:
+Workflow: `.github/workflows/ci.yml`.
 
 ```mermaid
 sequenceDiagram
     participant PR as Pull Request
-    participant DCO as DCO Verifier
-    participant Lint as Ruff & Mypy
-    participant Unit as Pytest (Unit)
-    participant Conf as Conformance (R01/R02)
+    participant DCO as DCO job
+    participant Q as Quality job
 
-    PR->>DCO: Check "Signed-off-by" trailer
-    alt DCO Check Fails
-        DCO-->>PR: Block Merge (Missing Sign-off)
-    else DCO Check Passes
-        PR->>Lint: Static Analysis & Type Checking
-        alt Lint / Mypy Fails
-            Lint-->>PR: Block Merge (Static Analysis Error)
-        else Static Analysis Passes
-            PR->>Unit: Execute Fast Localized Unit Tests
-            alt Unit Tests Fail
-                Unit-->>PR: Block Merge (Unit Test Failure)
-            else Unit Tests Pass
-                PR->>Conf: Execute Durable Conformance Gates (R01/R02)
-                alt Conformance Suite Fails
-                    Conf-->>PR: Block Merge (Durable Gate Failure)
-                else All Stages Pass Cleanly
-                    Conf-->>PR: Allow Merge
-                end
-            end
+    PR->>DCO: Signed-off-by on each commit
+    alt DCO fails
+        DCO-->>PR: Block
+    else DCO passes
+        PR->>Q: Ruff, Mypy, unit, e2e, R01/R02
+        alt Quality fails
+            Q-->>PR: Block
+        else Quality passes
+            Q-->>PR: Allow merge from CI side
         end
     end
 ```
 
-- **DCO Sign-off (Automated Hard Gate)**: Every commit must carry a Developer Certificate of Origin (`Signed-off-by: Name <email>`). Commits without this are hard-blocked by CI.
-- **Conformance Gates (Automated Hard Gate)**: Features are not complete unless tests `R01` (Safe Resume) and `R02` (Block-and-Gate) pass cleanly in automated CI.
-- **Security & Architectural Sign-off (Procedural Review Policy)**: Changes modifying tool effect classification or block-and-gate resumption require explicit procedural peer review and human maintainer approval before PR merge.
+| Gate | Status |
+|------|--------|
+| DCO | Hard gate on pull requests |
+| Ruff + Mypy + unit + e2e + R01/R02 | Hard gate (Python 3.11 and 3.12) |
+| Branch protection on `main` | Maintainer settings; see `docs/maintainer-branch-protection.md` |
+| Effects / resume review | Procedural human review |
+
+Milestone product gate for Phase 1A was R01/R02 green with a real kill/resume path (delivered in #8).
 
 ### 2.4 Codebase Mapping
 

--- a/pkg/trajectory_ir/resume/gate.py
+++ b/pkg/trajectory_ir/resume/gate.py
@@ -53,19 +53,31 @@ def make_gated_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_n
         # missing one, and the same silent re-run follows.
         if node_log.has(trajectory_id, step_n, "TOOL_CALL", seq=seq):
             node_log.append(
-                "ABORT", step_n, {"reason": "BLOCKED_NEEDS_GATE", "tool": tool_name},
-                trajectory_id, tenant_id, seq + 1,
+                "ABORT",
+                step_n,
+                {"reason": "BLOCKED_NEEDS_GATE", "tool": tool_name},
+                trajectory_id,
+                tenant_id,
+                seq + 1,
             )
             raise BlockedNeedsGate(step_n, tool_name)
 
         node_log.append(
-            "TOOL_CALL", step_n, {"tool": tool_name, "args": kwargs},
-            trajectory_id, tenant_id, seq,
+            "TOOL_CALL",
+            step_n,
+            {"tool": tool_name, "args": kwargs},
+            trajectory_id,
+            tenant_id,
+            seq,
         )
         result = tool_fn(**kwargs)
         node_log.append(
-            "TOOL_RESULT", step_n, {"result": result},
-            trajectory_id, tenant_id, seq + 1,
+            "TOOL_RESULT",
+            step_n,
+            {"result": result},
+            trajectory_id,
+            tenant_id,
+            seq + 1,
         )
         return result
 

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -1,6 +1,10 @@
+from drivers.durable_backend.dbos.adapter import (
+    durable_infer,
+    durable_tool,
+    durable_workflow,
+)
 from trajectory_ir.effects import EffectClass
 from trajectory_ir.resume.gate import make_gated_tool_call
-from drivers.durable_backend.dbos.adapter import durable_infer, durable_tool, durable_workflow
 
 
 def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision_sealed=None):
@@ -33,7 +37,13 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
             seq = 2 + 2 * i
             if tool.effect_class == EffectClass.NON_IDEMPOTENT_WRITE:
                 gated = make_gated_tool_call(
-                    node_log, trajectory_id, tenant_id, step_n, seq, call["name"], tool.fn
+                    node_log,
+                    trajectory_id,
+                    tenant_id,
+                    step_n,
+                    seq,
+                    call["name"],
+                    tool.fn,
                 )
                 result = durable_tool(gated)(**call["args"])
             else:
@@ -41,7 +51,11 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
             results.append(result)
 
         node_log.append(
-            "COMMIT_STEP", step_n, {}, trajectory_id, tenant_id,
+            "COMMIT_STEP",
+            step_n,
+            {},
+            trajectory_id,
+            tenant_id,
             seq=2 + 2 * len(plan["tool_calls"]),
         )
         return results

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -1,6 +1,5 @@
 import json
 import sqlite3
-from typing import Optional
 
 from trajectory_ir.runtime.nodes import Node
 
@@ -37,20 +36,41 @@ class NodeLog:
         )
         self._conn.commit()
 
-    def append(self, kind: str, step_n: Optional[int], payload: dict, trajectory_id: str, tenant_id: str, seq: int) -> Node:
+    def append(
+        self,
+        kind: str,
+        step_n: int | None,
+        payload: dict,
+        trajectory_id: str,
+        tenant_id: str,
+        seq: int,
+    ) -> Node:
         node = Node(
-            kind=kind, trajectory_id=trajectory_id, tenant_id=tenant_id,
-            step_n=step_n, seq=seq, payload=payload,
+            kind=kind,
+            trajectory_id=trajectory_id,
+            tenant_id=tenant_id,
+            step_n=step_n,
+            seq=seq,
+            payload=payload,
         )
         self._conn.execute(
             "INSERT OR IGNORE INTO nodes (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (node.id, node.trajectory_id, node.tenant_id, node.step_n, node.seq, node.kind, json.dumps(node.payload), node.ts),
+            (
+                node.id,
+                node.trajectory_id,
+                node.tenant_id,
+                node.step_n,
+                node.seq,
+                node.kind,
+                json.dumps(node.payload),
+                node.ts,
+            ),
         )
         self._conn.commit()
         return node
 
-    def has(self, trajectory_id: str, step_n: int, kind: str, seq: Optional[int] = None) -> bool:
+    def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
         """Does a node of `kind` exist for this trajectory/step?
 
         `seq` narrows the question to one exact node slot. Without it, a step
@@ -60,10 +80,10 @@ class NodeLog:
         step-level kinds (DECISION, COMMIT_STEP) that occur at most once.
         """
         sql = "SELECT 1 FROM nodes WHERE trajectory_id = ? AND step_n = ? AND kind = ?"
-        params = (trajectory_id, step_n, kind)
+        params: list[object] = [trajectory_id, step_n, kind]
         if seq is not None:
             sql += " AND seq = ?"
-            params += (seq,)
+            params.append(seq)
         cur = self._conn.execute(sql + " LIMIT 1", params)
         return cur.fetchone() is not None
 

--- a/pkg/trajectory_ir/runtime/nodes.py
+++ b/pkg/trajectory_ir/runtime/nodes.py
@@ -1,15 +1,29 @@
 import hashlib
 import time
 from dataclasses import dataclass, field
-from typing import Optional
 
 import rfc8785
 
-NODE_KINDS = frozenset({
-    "INPUT", "CONSTRAINT", "STATE_SET", "PROJECT_CONTEXT", "THOUGHT",
-    "DECISION", "TOOL_CALL", "TOOL_RESULT", "ARTIFACT_PUT", "ARTIFACT_REF",
-    "LTM_QUERY", "LTM_HIT", "LTM_PROJECT", "COMMIT_STEP", "ABORT", "REDACTION",
-})
+NODE_KINDS = frozenset(
+    {
+        "INPUT",
+        "CONSTRAINT",
+        "STATE_SET",
+        "PROJECT_CONTEXT",
+        "THOUGHT",
+        "DECISION",
+        "TOOL_CALL",
+        "TOOL_RESULT",
+        "ARTIFACT_PUT",
+        "ARTIFACT_REF",
+        "LTM_QUERY",
+        "LTM_HIT",
+        "LTM_PROJECT",
+        "COMMIT_STEP",
+        "ABORT",
+        "REDACTION",
+    }
+)
 
 
 def payload_hash(payload: dict) -> str:
@@ -19,7 +33,14 @@ def payload_hash(payload: dict) -> str:
     return hashlib.sha256(canon).hexdigest()
 
 
-def node_id(tenant_id: str, trajectory_id: str, step_n: Optional[int], seq: int, kind: str, phash: str) -> str:
+def node_id(
+    tenant_id: str,
+    trajectory_id: str,
+    step_n: int | None,
+    seq: int,
+    kind: str,
+    phash: str,
+) -> str:
     raw = f"{tenant_id}|{trajectory_id}|{step_n}|{seq}|{kind}|{phash}".encode()
     return hashlib.sha256(raw).hexdigest()
 
@@ -29,7 +50,7 @@ class Node:
     kind: str
     trajectory_id: str
     tenant_id: str
-    step_n: Optional[int]
+    step_n: int | None
     seq: int
     payload: dict
     ts: float = field(default_factory=time.time)
@@ -38,5 +59,10 @@ class Node:
         assert self.kind in NODE_KINDS, f"unknown node kind: {self.kind}"
         self.phash = payload_hash(self.payload)
         self.id = node_id(
-            self.tenant_id, self.trajectory_id, self.step_n, self.seq, self.kind, self.phash
+            self.tenant_id,
+            self.trajectory_id,
+            self.step_n,
+            self.seq,
+            self.kind,
+            self.phash,
         )

--- a/pkg/trajectory_ir/runtime/tool.py
+++ b/pkg/trajectory_ir/runtime/tool.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from trajectory_ir.effects import EffectClass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,38 @@ packages = ["pkg/trajectory_ir", "drivers", "client"]
 
 [tool.pytest.ini_options]
 testpaths = ["test", "conformance"]
+addopts = [
+    "-ra",
+    "--strict-markers",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+src = ["pkg", "drivers", "client", "test", "conformance", "examples"]
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "I",
+    "UP",
+    "B",
+]
+ignore = [
+    "E501",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Fixture agent adjusts sys.path before local imports on purpose.
+"examples/kill-mid-deploy/agent.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["trajectory_ir", "drivers", "client", "test"]
+
+[tool.mypy]
+python_version = "3.11"
+mypy_path = "pkg"
+packages = ["trajectory_ir"]
+warn_unused_configs = true
+show_error_codes = true

--- a/test/e2e/_util.py
+++ b/test/e2e/_util.py
@@ -11,9 +11,13 @@ AGENT_SCRIPT = os.path.join(REPO_ROOT, "examples", "kill-mid-deploy", "agent.py"
 # the crashed run's databases, so scenarios isolate themselves by working
 # directory rather than by deleting these between the crash and the resume.
 ARTIFACTS = (
-    "test_model_call_count.txt", "test_deploy_side_effect_count.txt",
-    "decision_sealed.marker", "tool_started.marker", "inference_started.marker",
-    "kill_mid_deploy.sqlite", "kill-mid-deploy.sqlite",
+    "test_model_call_count.txt",
+    "test_deploy_side_effect_count.txt",
+    "decision_sealed.marker",
+    "tool_started.marker",
+    "inference_started.marker",
+    "kill_mid_deploy.sqlite",
+    "kill-mid-deploy.sqlite",
 )
 
 
@@ -29,7 +33,8 @@ def start_agent(*args: str, cwd: str, log_path: str) -> subprocess.Popen:
     Output goes to a file rather than a pipe: a hard-killed process's piped
     output is lost, and these runs are killed by design.
     """
-    log = open(log_path, "w")
+    # Handle must stay open for the life of the child; closed in hard_kill.
+    log = open(log_path, "w", encoding="utf-8")  # noqa: SIM115
     proc = subprocess.Popen(agent_cmd(*args), cwd=cwd, stdout=log, stderr=subprocess.STDOUT)
     proc._log_file = log  # keep the handle alive until the process is reaped
     return proc
@@ -38,7 +43,12 @@ def start_agent(*args: str, cwd: str, log_path: str) -> subprocess.Popen:
 def run_agent(*args: str, cwd: str, timeout: float = 120.0) -> subprocess.CompletedProcess:
     """Run the agent to completion, capturing its output."""
     return subprocess.run(
-        agent_cmd(*args), cwd=cwd, capture_output=True, text=True, timeout=timeout
+        agent_cmd(*args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
     )
 
 
@@ -65,7 +75,8 @@ def wait_for_marker(path: str, timeout: float = 60.0) -> None:
 def read_counter(path: str) -> int:
     if not os.path.exists(path):
         return 0
-    return int(open(path).read().strip() or "0")
+    with open(path, encoding="utf-8") as f:
+        return int(f.read().strip() or "0")
 
 
 def cleanup(*paths: str) -> None:

--- a/test/e2e/test_seal_resume_crash.py
+++ b/test/e2e/test_seal_resume_crash.py
@@ -5,10 +5,17 @@ the same durable workflow id.
 Each scenario gets its own working directory so the node log and the durable
 backend's system database survive the crash but never leak between scenarios.
 """
+
 import os
 import sqlite3
 
-from test.e2e._util import hard_kill, read_counter, run_agent, start_agent, wait_for_marker
+from test.e2e._util import (
+    hard_kill,
+    read_counter,
+    run_agent,
+    start_agent,
+    wait_for_marker,
+)
 
 MODEL_COUNT = "test_model_call_count.txt"
 DEPLOY_COUNT = "test_deploy_side_effect_count.txt"
@@ -29,7 +36,11 @@ def _logged_kinds(workdir):
 
 def _report(workdir, result):
     crash_log = os.path.join(workdir, "crash_run.log")
-    crash_output = open(crash_log).read() if os.path.exists(crash_log) else "<none>"
+    if os.path.exists(crash_log):
+        with open(crash_log, encoding="utf-8") as f:
+            crash_output = f.read()
+    else:
+        crash_output = "<none>"
     return (
         f"\n--- crashed run output ---\n{crash_output}"
         f"\n--- resume run stdout ---\n{result.stdout}"
@@ -137,8 +148,8 @@ def test_crash_mid_nonidempotent_tool_blocks_not_retries(tmp_path):
     # This asserts the typed exception was reconstructed and caught by the
     # agent, which is the only path that both prints this line and exits 0.
     assert result.returncode == 0, _report(workdir, result)
-    assert "BLOCKED_NEEDS_GATE: step 1: 'deploy_server'" in result.stdout + result.stderr, (
-        _report(workdir, result)
+    assert "BLOCKED_NEEDS_GATE: step 1: 'deploy_server'" in result.stdout + result.stderr, _report(
+        workdir, result
     )
     assert read_counter(os.path.join(workdir, DEPLOY_COUNT)) <= 1, (
         "deploy_server side effect ran more than once" + _report(workdir, result)

--- a/test/unit/test_client_sdk.py
+++ b/test/unit/test_client_sdk.py
@@ -1,14 +1,15 @@
-import os
-import tempfile
-
 import pytest
 
 from client.python.trajectory_client import (
-    open_trajectory, project, seal_decision, exec_tool, commit_step,
+    commit_step,
+    exec_tool,
+    open_trajectory,
+    project,
+    seal_decision,
 )
-from trajectory_ir.runtime.tool import Tool
 from trajectory_ir.effects import EffectClass
 from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.tool import Tool
 
 
 @pytest.fixture

--- a/test/unit/test_dbos_adapter.py
+++ b/test/unit/test_dbos_adapter.py
@@ -1,4 +1,8 @@
-from drivers.durable_backend.dbos.adapter import durable_infer, durable_tool, durable_workflow, init_backend
+from drivers.durable_backend.dbos.adapter import (
+    durable_infer,
+    durable_workflow,
+    init_backend,
+)
 
 
 def test_wrapped_workflow_runs_and_returns_result(tmp_path, monkeypatch):

--- a/test/unit/test_effects.py
+++ b/test/unit/test_effects.py
@@ -14,12 +14,20 @@ def test_read_only_hint_classified_read_only():
 
 
 def test_explicit_idempotent_write_classified_correctly():
-    annotations = {"readOnlyHint": False, "idempotentHint": True, "destructiveHint": False}
+    annotations = {
+        "readOnlyHint": False,
+        "idempotentHint": True,
+        "destructiveHint": False,
+    }
     assert classify_from_mcp(annotations) == EffectClass.IDEMPOTENT_WRITE
 
 
 def test_destructive_hint_true_fails_closed_even_if_idempotent():
-    annotations = {"readOnlyHint": False, "idempotentHint": True, "destructiveHint": True}
+    annotations = {
+        "readOnlyHint": False,
+        "idempotentHint": True,
+        "destructiveHint": True,
+    }
     assert classify_from_mcp(annotations) == EffectClass.NON_IDEMPOTENT_WRITE
 
 

--- a/test/unit/test_node_identity.py
+++ b/test/unit/test_node_identity.py
@@ -6,23 +6,65 @@ from trajectory_ir.runtime.nodes import Node
 
 
 def test_identical_payload_different_key_order_same_hash():
-    n1 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1, "b": 2})
-    n2 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"b": 2, "a": 1})
+    n1 = Node(
+        kind="STATE_SET",
+        trajectory_id="t1",
+        tenant_id="demo",
+        step_n=1,
+        seq=1,
+        payload={"a": 1, "b": 2},
+    )
+    n2 = Node(
+        kind="STATE_SET",
+        trajectory_id="t1",
+        tenant_id="demo",
+        step_n=1,
+        seq=1,
+        payload={"b": 2, "a": 1},
+    )
     assert n1.id == n2.id  # whole point of JCS
 
 
 def test_ts_never_affects_hash():
-    n1 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1})
+    n1 = Node(
+        kind="STATE_SET",
+        trajectory_id="t1",
+        tenant_id="demo",
+        step_n=1,
+        seq=1,
+        payload={"a": 1},
+    )
     time.sleep(1.1)
-    n2 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1})
+    n2 = Node(
+        kind="STATE_SET",
+        trajectory_id="t1",
+        tenant_id="demo",
+        step_n=1,
+        seq=1,
+        payload={"a": 1},
+    )
     assert n1.id == n2.id  # ts differs, id must not
 
 
 def test_unknown_kind_rejected():
     with pytest.raises(AssertionError):
-        Node(kind="NOT_A_KIND", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={})
+        Node(
+            kind="NOT_A_KIND",
+            trajectory_id="t1",
+            tenant_id="demo",
+            step_n=1,
+            seq=1,
+            payload={},
+        )
 
 
 def test_ts_key_in_payload_rejected():
     with pytest.raises(AssertionError):
-        Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"ts": 123})
+        Node(
+            kind="STATE_SET",
+            trajectory_id="t1",
+            tenant_id="demo",
+            step_n=1,
+            seq=1,
+            payload={"ts": 123},
+        )

--- a/test/unit/test_node_log.py
+++ b/test/unit/test_node_log.py
@@ -17,13 +17,34 @@ def log():
 
 
 def test_append_then_has(log):
-    log.append("DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1)
+    log.append(
+        "DECISION",
+        step_n=1,
+        payload={"plan": "x"},
+        trajectory_id="t1",
+        tenant_id="demo",
+        seq=1,
+    )
     assert log.has("t1", 1, "DECISION")
     assert not log.has("t1", 1, "TOOL_RESULT")
 
 
 def test_append_is_idempotent_by_content(log):
-    n1 = log.append("DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1)
-    n2 = log.append("DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1)
+    n1 = log.append(
+        "DECISION",
+        step_n=1,
+        payload={"plan": "x"},
+        trajectory_id="t1",
+        tenant_id="demo",
+        seq=1,
+    )
+    n2 = log.append(
+        "DECISION",
+        step_n=1,
+        payload={"plan": "x"},
+        trajectory_id="t1",
+        tenant_id="demo",
+        seq=1,
+    )
     assert n1.id == n2.id
     assert log.count(n1.id) == 1


### PR DESCRIPTION
## Summary

Process layer for the repo after the Phase 1A core landed in #8. Templates for contributors, real DCO enforcement, and a CI job that keeps R01/R02 while adding lint and type checks.

Closes #5

## What landed

**Templates**
- Bug, feature, and spec-question issue forms
- Security contact link; blank issues still allowed
- PR template (summary, tests, DCO, safety, AI note)

**CI**
- **DCO** job on pull requests
- **Quality** on Python 3.11 and 3.12: install, Ruff, Mypy (`pkg/trajectory_ir`), unit, e2e, conformance R01/R02

**Docs**
- CONTRIBUTING matches the real gates
- infrastructure.md: `rfc8785`, accurate CI diagram
- Maintainer branch-protection note

**Code hygiene**
- Ruff/Mypy cleanups so the new quality job is green
- No behavior change intended in runtime logic

## How I tested

```text
ruff check pkg drivers client test conformance examples
ruff format --check pkg drivers client test conformance examples
mypy pkg/trajectory_ir
pytest test/unit test/e2e conformance/ -q
# 23 passed
```

## Checklist

- [x] DCO signed
- [x] Matches #5
- [x] Local quality green
- [x] AI assistance used for boilerplate; reviewed against #5 and current main

## Safety areas

- [x] No (process + lint only; no gate/resume logic changes intended)