### PR TITLE
feat: Go IR node hashing with Python parity (#10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,20 @@ jobs:
 
       - name: Conformance R01/R02
         run: pytest conformance/ -q
+
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache-dependency-path: go/go.sum
+
+      - name: Test Go IR core
+        working-directory: go
+        run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phase 1A buildable core (nodes, NodeLog, effects, DBOS adapter, seal/resume gate, client SDK, kill-mid-deploy, R01/R02).
 - Issue templates, PR template, DCO CI job, Ruff/Mypy in CI alongside unit/e2e/conformance.
 - Maintainer note for branch protection on `main`.
+- Go IR core hashing package under `go/` with shared `testdata/hash_vectors.json` parity tests against Python.
+
 
 ### Changed
 - CONTRIBUTING and infrastructure docs describe the CI gates that actually run.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/Coder-s-OG-s/Trajectory-IR/go
+
+go 1.22
+
+require github.com/gowebpki/jcs v1.0.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
+github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/trajir/nodes/nodes.go
+++ b/go/trajir/nodes/nodes.go
@@ -1,0 +1,110 @@
+// Package nodes implements Trajectory IR node identity for the Go IR core.
+//
+// Hashing matches the Python reference in pkg/trajectory_ir/runtime/nodes.py:
+// RFC 8785 JCS of the payload, then SHA-256 hex for payload_hash; node_id is
+// SHA-256 hex of tenant|trajectory|step|seq|kind|payload_hash with the same
+// string rules as Python (step None formats as the four characters None).
+package nodes
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gowebpki/jcs"
+)
+
+// NODE_KINDS is the Phase 1A set used by the Python reference.
+var NODE_KINDS = map[string]struct{}{
+	"INPUT":           {},
+	"CONSTRAINT":      {},
+	"STATE_SET":       {},
+	"PROJECT_CONTEXT": {},
+	"THOUGHT":         {},
+	"DECISION":        {},
+	"TOOL_CALL":       {},
+	"TOOL_RESULT":     {},
+	"ARTIFACT_PUT":    {},
+	"ARTIFACT_REF":    {},
+	"LTM_QUERY":       {},
+	"LTM_HIT":         {},
+	"LTM_PROJECT":     {},
+	"COMMIT_STEP":     {},
+	"ABORT":           {},
+	"REDACTION":       {},
+}
+
+// PayloadHash returns SHA-256 hex of the RFC 8785 canonical form of payload.
+// The payload must not contain a "ts" key (wall clock is never hashed).
+func PayloadHash(payload map[string]any) (string, error) {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	if _, ok := payload["ts"]; ok {
+		return "", fmt.Errorf("wall-clock ts must never be hashed (spec 6.3)")
+	}
+	// encoding/json emits a legal JSON encoding; jcs.Transform applies RFC 8785.
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("json marshal: %w", err)
+	}
+	canon, err := jcs.Transform(raw)
+	if err != nil {
+		return "", fmt.Errorf("jcs: %w", err)
+	}
+	sum := sha256.Sum256(canon)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// NodeID builds the content-addressed id string used by the Python reference.
+// stepN nil is formatted as "None" so it matches Python f-string None.
+func NodeID(tenantID, trajectoryID string, stepN *int, seq int, kind, phash string) string {
+	step := "None"
+	if stepN != nil {
+		step = strconv.Itoa(*stepN)
+	}
+	raw := fmt.Sprintf("%s|%s|%s|%d|%s|%s", tenantID, trajectoryID, step, seq, kind, phash)
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// Node is a hashed IR event. Identity fields are computed on construction.
+type Node struct {
+	Kind         string
+	TrajectoryID string
+	TenantID     string
+	StepN        *int
+	Seq          int
+	Payload      map[string]any
+	TS           float64
+	PHash        string
+	ID           string
+}
+
+// NewNode validates kind and payload rules and fills PHash and ID.
+func NewNode(kind, trajectoryID, tenantID string, stepN *int, seq int, payload map[string]any) (*Node, error) {
+	if _, ok := NODE_KINDS[kind]; !ok {
+		return nil, fmt.Errorf("unknown node kind: %s", kind)
+	}
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	phash, err := PayloadHash(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &Node{
+		Kind:         kind,
+		TrajectoryID: trajectoryID,
+		TenantID:     tenantID,
+		StepN:        stepN,
+		Seq:          seq,
+		Payload:      payload,
+		TS:           float64(time.Now().UnixNano()) / 1e9,
+		PHash:        phash,
+		ID:           NodeID(tenantID, trajectoryID, stepN, seq, kind, phash),
+	}, nil
+}

--- a/go/trajir/nodes/nodes_test.go
+++ b/go/trajir/nodes/nodes_test.go
@@ -1,0 +1,125 @@
+package nodes_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/nodes"
+)
+
+type vectorFile struct {
+	Version int `json:"version"`
+	Cases   []struct {
+		Name         string         `json:"name"`
+		TenantID     string         `json:"tenant_id"`
+		TrajectoryID string         `json:"trajectory_id"`
+		StepN        *int           `json:"step_n"`
+		Seq          int            `json:"seq"`
+		Kind         string         `json:"kind"`
+		Payload      map[string]any `json:"payload"`
+		PayloadHash  string         `json:"payload_hash"`
+		NodeID       string         `json:"node_id"`
+	} `json:"cases"`
+}
+
+func loadVectors(t *testing.T) vectorFile {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// go/trajir/nodes -> repo root testdata/
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	path := filepath.Join(root, "testdata", "hash_vectors.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var vf vectorFile
+	if err := json.Unmarshal(raw, &vf); err != nil {
+		t.Fatalf("parse vectors: %v", err)
+	}
+	if len(vf.Cases) == 0 {
+		t.Fatal("no cases in hash_vectors.json")
+	}
+	return vf
+}
+
+func TestHashVectorsMatchPythonGoldens(t *testing.T) {
+	vf := loadVectors(t)
+	for _, c := range vf.Cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			ph, err := nodes.PayloadHash(c.Payload)
+			if err != nil {
+				t.Fatalf("PayloadHash: %v", err)
+			}
+			if ph != c.PayloadHash {
+				t.Fatalf("payload_hash\n got %s\nwant %s", ph, c.PayloadHash)
+			}
+			id := nodes.NodeID(c.TenantID, c.TrajectoryID, c.StepN, c.Seq, c.Kind, ph)
+			if id != c.NodeID {
+				t.Fatalf("node_id\n got %s\nwant %s", id, c.NodeID)
+			}
+			n, err := nodes.NewNode(c.Kind, c.TrajectoryID, c.TenantID, c.StepN, c.Seq, c.Payload)
+			if err != nil {
+				t.Fatalf("NewNode: %v", err)
+			}
+			if n.PHash != c.PayloadHash || n.ID != c.NodeID {
+				t.Fatalf("NewNode mismatch phash/id")
+			}
+		})
+	}
+}
+
+func TestKeyOrderIndependent(t *testing.T) {
+	a := map[string]any{"a": float64(1), "b": float64(2)}
+	b := map[string]any{"b": float64(2), "a": float64(1)}
+	ha, err := nodes.PayloadHash(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hb, err := nodes.PayloadHash(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ha != hb {
+		t.Fatalf("key order changed hash: %s vs %s", ha, hb)
+	}
+}
+
+func TestTSFieldRejected(t *testing.T) {
+	_, err := nodes.PayloadHash(map[string]any{"ts": float64(1)})
+	if err == nil {
+		t.Fatal("expected error for ts in payload")
+	}
+}
+
+func TestUnknownKindRejected(t *testing.T) {
+	step := 1
+	_, err := nodes.NewNode("NOT_A_KIND", "t1", "demo", &step, 1, map[string]any{})
+	if err == nil {
+		t.Fatal("expected unknown kind error")
+	}
+}
+
+func TestWallClockTSDoesNotAffectID(t *testing.T) {
+	step := 1
+	payload := map[string]any{"a": float64(1)}
+	n1, err := nodes.NewNode("STATE_SET", "t1", "demo", &step, 1, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	n2, err := nodes.NewNode("STATE_SET", "t1", "demo", &step, 1, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n1.ID != n2.ID {
+		t.Fatalf("id changed with wall clock: %s vs %s", n1.ID, n2.ID)
+	}
+}

--- a/test/unit/test_hash_vectors.py
+++ b/test/unit/test_hash_vectors.py
@@ -1,0 +1,50 @@
+"""Cross language golden vectors shared with the Go IR core (testdata/hash_vectors.json)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from trajectory_ir.runtime.nodes import Node, node_id, payload_hash
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTORS = ROOT / "testdata" / "hash_vectors.json"
+
+
+def _load_cases() -> list[dict]:
+    data = json.loads(VECTORS.read_text(encoding="utf-8"))
+    assert data.get("version") == 1
+    return data["cases"]
+
+
+def test_python_matches_committed_hash_vectors() -> None:
+    for case in _load_cases():
+        ph = payload_hash(case["payload"])
+        assert ph == case["payload_hash"], case["name"]
+        nid = node_id(
+            case["tenant_id"],
+            case["trajectory_id"],
+            case["step_n"],
+            case["seq"],
+            case["kind"],
+            ph,
+        )
+        assert nid == case["node_id"], case["name"]
+        node = Node(
+            kind=case["kind"],
+            trajectory_id=case["trajectory_id"],
+            tenant_id=case["tenant_id"],
+            step_n=case["step_n"],
+            seq=case["seq"],
+            payload=case["payload"],
+        )
+        assert node.phash == case["payload_hash"], case["name"]
+        assert node.id == case["node_id"], case["name"]
+
+
+def test_key_order_pair_shares_identity() -> None:
+    cases = {c["name"]: c for c in _load_cases()}
+    a = cases["key_order_independent"]
+    b = cases["key_order_reversed_same_as_above"]
+    assert a["payload_hash"] == b["payload_hash"]
+    assert a["node_id"] == b["node_id"]

--- a/testdata/hash_vectors.json
+++ b/testdata/hash_vectors.json
@@ -1,0 +1,93 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "name": "key_order_independent",
+      "tenant_id": "demo",
+      "trajectory_id": "t1",
+      "step_n": 1,
+      "seq": 1,
+      "kind": "STATE_SET",
+      "payload": {
+        "a": 1,
+        "b": 2
+      },
+      "payload_hash": "43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+      "node_id": "b7ac266b0c1068ac49c9497dd95d56fe34ab5e811f708a350c449381e9bef11b"
+    },
+    {
+      "name": "key_order_reversed_same_as_above",
+      "tenant_id": "demo",
+      "trajectory_id": "t1",
+      "step_n": 1,
+      "seq": 1,
+      "kind": "STATE_SET",
+      "payload": {
+        "b": 2,
+        "a": 1
+      },
+      "payload_hash": "43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+      "node_id": "b7ac266b0c1068ac49c9497dd95d56fe34ab5e811f708a350c449381e9bef11b"
+    },
+    {
+      "name": "simple_a1",
+      "tenant_id": "demo",
+      "trajectory_id": "t1",
+      "step_n": 1,
+      "seq": 1,
+      "kind": "STATE_SET",
+      "payload": {
+        "a": 1
+      },
+      "payload_hash": "015abd7f5cc57a2dd94b7590f04ad8084273905ee33ec5cebeae62276a97f862",
+      "node_id": "4becda0479e3e1729739d866f75e99c4c3dcb27b7c5426453447bd7b5386f746"
+    },
+    {
+      "name": "null_step",
+      "tenant_id": "demo",
+      "trajectory_id": "t1",
+      "step_n": null,
+      "seq": 0,
+      "kind": "INPUT",
+      "payload": {
+        "msg": "hello"
+      },
+      "payload_hash": "faf0237414bb4de6d09919f02006843e237179c7a3a866d6cc77e967688d6e02",
+      "node_id": "cad6334b5cd72f3b66cc2baf6b586868b407a4554936133ed06e02602f83fa90"
+    },
+    {
+      "name": "nested_decision_like",
+      "tenant_id": "acme",
+      "trajectory_id": "run-9",
+      "step_n": 2,
+      "seq": 3,
+      "kind": "DECISION",
+      "payload": {
+        "plan": {
+          "tool_calls": [
+            {
+              "name": "pure.echo",
+              "args": {
+                "x": true,
+                "n": 3
+              }
+            }
+          ]
+        }
+      },
+      "payload_hash": "c9af6e9490de1e1ffbba43a56fcd1517ec888bcb7b5067dbc870676800d6dbfe",
+      "node_id": "a917ff215987efb2f9247eb60efafc1469da4cbd40b803e45344c500fbca272f"
+    },
+    {
+      "name": "empty_payload",
+      "tenant_id": "demo",
+      "trajectory_id": "t2",
+      "step_n": 1,
+      "seq": 7,
+      "kind": "COMMIT_STEP",
+      "payload": {},
+      "payload_hash": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+      "node_id": "61c104870a222bdaf8e73f88cba233c68ac78be1f49b4a88dde3a46d205696d9"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the first Go IR core package: content addressed node identity using the same rules as the Python reference. Shared golden vectors under testdata prove Go and Python produce the same payload_hash and node_id.

Closes #10

## Related issues

Closes #10

## How I tested

```bash
cd go && go test ./... -count=1
pip install -e ".[dev]"
pytest test/unit/test_hash_vectors.py test/unit/test_node_identity.py -q
```

All of the above passed locally (Go vectors case by case; Python goldens green).

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes (call it out here)

## AI assistance (if any)

Assisted scaffolding and review against issue #10 and pkg/trajectory_ir/runtime/nodes.py. I verified goldens against the live Python library.

## What landed

1. `go/` module with `trajir/nodes` (kinds, PayloadHash, NodeID, NewNode)
2. JCS via `github.com/gowebpki/jcs` (RFC 8785 Transform on marshaled JSON)
3. Shared `testdata/hash_vectors.json` produced from the Python reference
4. Go tests load those goldens; Python `test_hash_vectors.py` does the same
5. CI job `Go` runs `go test ./...` under `go/`

## Out of scope (as planned)

1. Go NodeLog, effects, seal/resume, client SDK
2. Durable backend for Go (Temporal/Restate later)
3. Full Phase 1A rewrite in Go