### PR TITLE
feat: Go effect classes and fail closed MCP mapping (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintainer note for branch protection on `main`.
 - Go IR core hashing package under `go/` with shared `testdata/hash_vectors.json` parity tests against Python.
 - Go SQLite NodeLog under `go/trajir/log` matching the Python append only IR log.
+- Go effect classes and fail closed MCP mapping under `go/trajir/effects`.
+
 
 
 

--- a/go/trajir/effects/effects.go
+++ b/go/trajir/effects/effects.go
@@ -1,0 +1,43 @@
+// Package effects ports Trajectory IR tool effect classes and MCP mapping.
+// Rules match pkg/trajectory_ir/effects/classify.py (fail closed).
+package effects
+
+// EffectClass is how dangerous a tool is for resume and gate policy.
+type EffectClass string
+
+const (
+	PURE                 EffectClass = "PURE"
+	READ_ONLY            EffectClass = "READ_ONLY"
+	IDEMPOTENT_WRITE     EffectClass = "IDEMPOTENT_WRITE"
+	NON_IDEMPOTENT_WRITE EffectClass = "NON_IDEMPOTENT_WRITE"
+	AGENT_SPAWN          EffectClass = "AGENT_SPAWN"
+	SENSITIVE            EffectClass = "SENSITIVE"
+)
+
+// ClassifyFromMCP maps MCP tool annotations to an EffectClass.
+// Missing or ambiguous input becomes NON_IDEMPOTENT_WRITE.
+//
+// Python treats annotations.get("x") is True / is False strictly, so only
+// boolean true/false count. Other JSON types fall through to fail closed.
+func ClassifyFromMCP(annotations map[string]any) EffectClass {
+	if annotations == nil {
+		return NON_IDEMPOTENT_WRITE
+	}
+
+	readOnly, hasReadOnly := asBool(annotations["readOnlyHint"])
+	destructive, hasDestructive := asBool(annotations["destructiveHint"])
+	idempotent, hasIdempotent := asBool(annotations["idempotentHint"])
+
+	if hasReadOnly && readOnly && !(hasDestructive && destructive) {
+		return READ_ONLY
+	}
+	if hasReadOnly && !readOnly && hasIdempotent && idempotent && hasDestructive && !destructive {
+		return IDEMPOTENT_WRITE
+	}
+	return NON_IDEMPOTENT_WRITE
+}
+
+func asBool(v any) (value bool, ok bool) {
+	b, ok := v.(bool)
+	return b, ok
+}

--- a/go/trajir/effects/effects_test.go
+++ b/go/trajir/effects/effects_test.go
@@ -1,0 +1,78 @@
+package effects_test
+
+import (
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+)
+
+func TestMissingAnnotationsFailClosed(t *testing.T) {
+	if got := effects.ClassifyFromMCP(map[string]any{}); got != effects.NON_IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)
+	}
+	if got := effects.ClassifyFromMCP(nil); got != effects.NON_IDEMPOTENT_WRITE {
+		t.Fatalf("nil map: got %s", got)
+	}
+}
+
+func TestAmbiguousAnnotationsFailClosed(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{"readOnlyHint": false})
+	if got != effects.NON_IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)
+	}
+}
+
+func TestReadOnlyHint(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{"readOnlyHint": true})
+	if got != effects.READ_ONLY {
+		t.Fatalf("got %s, want READ_ONLY", got)
+	}
+}
+
+func TestExplicitIdempotentWrite(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{
+		"readOnlyHint":    false,
+		"idempotentHint":  true,
+		"destructiveHint": false,
+	})
+	if got != effects.IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want IDEMPOTENT_WRITE", got)
+	}
+}
+
+func TestDestructiveFailsClosedEvenIfIdempotent(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{
+		"readOnlyHint":    false,
+		"idempotentHint":  true,
+		"destructiveHint": true,
+	})
+	if got != effects.NON_IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)
+	}
+}
+
+func TestContradictoryReadOnlyAndDestructive(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{
+		"readOnlyHint":    true,
+		"destructiveHint": true,
+	})
+	if got != effects.NON_IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)
+	}
+}
+
+func TestStringValuesMatchPython(t *testing.T) {
+	want := map[effects.EffectClass]string{
+		effects.PURE:                 "PURE",
+		effects.READ_ONLY:            "READ_ONLY",
+		effects.IDEMPOTENT_WRITE:     "IDEMPOTENT_WRITE",
+		effects.NON_IDEMPOTENT_WRITE: "NON_IDEMPOTENT_WRITE",
+		effects.AGENT_SPAWN:          "AGENT_SPAWN",
+		effects.SENSITIVE:            "SENSITIVE",
+	}
+	for c, s := range want {
+		if string(c) != s {
+			t.Fatalf("%v string is %q, want %q", c, string(c), s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Ports tool effect classes and fail closed MCP annotation mapping into Go so later gate and tool wiring share the same policy as Python.

Closes #14

## Related issues

Closes #14

## How I tested

```bash
cd go
go test ./... -count=1
```

All packages passed (nodes, log, effects).

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: effect classification only (read path mapping). No resume or seal logic changed.

## AI assistance (if any)

Assisted port from pkg/trajectory_ir/effects/classify.py and test/unit/test_effects.py. Logic checked against Python strict bool checks.

## What landed

1. go/trajir/effects with six string effect classes matching Python
2. ClassifyFromMCP with the same three way rule (read only, idempotent write, else non idempotent)
3. Unit tests for empty, ambiguous, happy paths, destructive, and contradictory cases

## Out of scope

1. Seal or resume or block and gate in Go
2. Durable backend adapter
3. Client SDK