### PR TITLE
feat: Go durable local backend for step memoization (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go IR core hashing package under `go/` with shared `testdata/hash_vectors.json` parity tests against Python.
 - Go SQLite NodeLog under `go/trajir/log` matching the Python append only IR log.
 - Go effect classes and fail closed MCP mapping under `go/trajir/effects`.
+- Go durable backend package (`trajir/durable`): local SQLite and memory step memoization; Temporal named as production target.
+
 
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,29 @@
+# Go IR core
+
+Second language implementation of Trajectory IR primitives. Python remains the Phase 1A reference runtime.
+
+## Packages
+
+| Path | Role |
+|------|------|
+| `trajir/nodes` | Node kinds, RFC 8785 payload hash, node id |
+| `trajir/log` | SQLite append only NodeLog |
+| `trajir/effects` | Effect classes and fail closed MCP mapping |
+| `trajir/durable` | Pluggable step memoization backend |
+
+## Durable backend decision (issue #16)
+
+| | |
+|--|--|
+| **Coding default** | `LocalSQLite` (file) and `Memory` (tests) in `trajir/durable` |
+| **Production target** | Temporal adapter (follow up). Restate welcome later. |
+| **Why** | Matches master README: do not hand roll crash engines. Local memo is enough to prove Infer/Tool skip on re-entry and to build seal and gate next, without standing up Temporal in every contributor environment. |
+
+Model inference and tools must go through `durable.Step` / `Infer` / `Tool`. Block and gate still relies on the NodeLog for NON_IDEMPOTENT_WRITE.
+
+## Test
+
+```bash
+cd go
+go test ./...
+```

--- a/go/trajir/durable/backend.go
+++ b/go/trajir/durable/backend.go
@@ -1,0 +1,75 @@
+package durable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Backend stores memoized step outputs for a workflow id.
+// Temporal and Restate drivers will implement this later; LocalSQLite and
+// Memory implement it for Phase 1B coding and tests.
+type Backend interface {
+	// Load returns the saved JSON for workflowID+stepKey if present.
+	Load(ctx context.Context, workflowID, stepKey string) (value []byte, found bool, err error)
+	// Save stores JSON for workflowID+stepKey. Saving twice with the same key
+	// should be idempotent (keep first value).
+	Save(ctx context.Context, workflowID, stepKey string, value []byte) error
+	// Close releases resources. Safe to call more than once.
+	Close() error
+}
+
+// Step runs fn once per (workflowID, stepKey). On later calls it returns the
+// memoized JSON decoded into result, without calling fn.
+//
+// result must be a pointer if non-nil when loading a prior value. When fn runs,
+// its return value is JSON marshaled. Use map[string]any or concrete structs
+// that encode cleanly.
+func Step(ctx context.Context, b Backend, workflowID, stepKey string, fn func(context.Context) (any, error)) (any, error) {
+	if b == nil {
+		return nil, fmt.Errorf("durable: nil backend")
+	}
+	if workflowID == "" || stepKey == "" {
+		return nil, fmt.Errorf("durable: workflowID and stepKey are required")
+	}
+
+	raw, found, err := b.Load(ctx, workflowID, stepKey)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		var out any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return nil, fmt.Errorf("durable: decode memo %s/%s: %w", workflowID, stepKey, err)
+		}
+		return out, nil
+	}
+
+	val, err := fn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	raw, err = json.Marshal(val)
+	if err != nil {
+		return nil, fmt.Errorf("durable: encode memo %s/%s: %w", workflowID, stepKey, err)
+	}
+	if err := b.Save(ctx, workflowID, stepKey, raw); err != nil {
+		return nil, err
+	}
+	// Return the same JSON round trip shape callers get on replay.
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Infer is Step with a conventional step key prefix for model calls.
+func Infer(ctx context.Context, b Backend, workflowID, name string, fn func(context.Context) (any, error)) (any, error) {
+	return Step(ctx, b, workflowID, "infer:"+name, fn)
+}
+
+// Tool is Step with a conventional step key prefix for tool calls.
+func Tool(ctx context.Context, b Backend, workflowID, name string, fn func(context.Context) (any, error)) (any, error) {
+	return Step(ctx, b, workflowID, "tool:"+name, fn)
+}

--- a/go/trajir/durable/doc.go
+++ b/go/trajir/durable/doc.go
@@ -1,0 +1,22 @@
+// Package durable is the Go pluggable execution backend for Trajectory IR.
+//
+// Decision (issue #16)
+//
+//   Coding default: LocalSQLite (and Memory for pure unit tests).
+//   It memoizes step results by workflow id and step key so re-entry skips
+//   re-running model inference and tools. No separate Temporal or Restate
+//   server is required for Phase 1B Go development.
+//
+//   Production target: Temporal as the first full Go adapter. Restate remains
+//   a welcome second adapter later, consistent with the master README.
+//
+// Rules (same as Python + DBOS)
+//
+//  1. Model inference and tool calls must run through Step (or a backend
+//     wrapper that provides the same memoization). Never call them raw inside
+//     a workflow body if crash resume must not re-invoke them.
+//  2. Block and gate for NON_IDEMPOTENT_WRITE still uses the NodeLog
+//     (TOOL_CALL at step+seq) as source of truth, not backend internals alone.
+//  3. Do not implement custom lease, heartbeat, or retry loops outside this
+//     package and a real Temporal/Restate driver.
+package durable

--- a/go/trajir/durable/durable_test.go
+++ b/go/trajir/durable/durable_test.go
@@ -1,0 +1,132 @@
+package durable_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
+)
+
+func TestMemoryStepMemoizes(t *testing.T) {
+	ctx := context.Background()
+	b := durable.NewMemory()
+	t.Cleanup(func() { _ = b.Close() })
+
+	var calls atomic.Int32
+	fn := func(context.Context) (any, error) {
+		calls.Add(1)
+		return map[string]any{"n": float64(1)}, nil
+	}
+
+	v1, err := durable.Step(ctx, b, "wf1", "infer:model", fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := durable.Step(ctx, b, "wf1", "infer:model", fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("fn called %d times, want 1", calls.Load())
+	}
+	m1 := v1.(map[string]any)
+	m2 := v2.(map[string]any)
+	if m1["n"] != m2["n"] {
+		t.Fatalf("results differ: %#v vs %#v", v1, v2)
+	}
+}
+
+func TestLocalSQLiteSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "memo.sqlite")
+
+	var calls atomic.Int32
+	fn := func(context.Context) (any, error) {
+		calls.Add(1)
+		return map[string]any{"plan": "seal-me"}, nil
+	}
+
+	b1, err := durable.OpenLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := durable.Infer(ctx, b1, "run-1", "model", fn); err != nil {
+		t.Fatal(err)
+	}
+	_ = b1.Close()
+
+	b2, err := durable.OpenLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = b2.Close() })
+
+	v, err := durable.Infer(ctx, b2, "run-1", "model", fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("after reopen fn called %d times, want 1", calls.Load())
+	}
+	m := v.(map[string]any)
+	if m["plan"] != "seal-me" {
+		t.Fatalf("unexpected memo: %#v", v)
+	}
+}
+
+func TestToolPrefixIndependentOfInfer(t *testing.T) {
+	ctx := context.Background()
+	b := durable.NewMemory()
+	t.Cleanup(func() { _ = b.Close() })
+
+	var inferCalls, toolCalls atomic.Int32
+	if _, err := durable.Infer(ctx, b, "wf", "m", func(context.Context) (any, error) {
+		inferCalls.Add(1)
+		return "plan", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := durable.Tool(ctx, b, "wf", "echo", func(context.Context) (any, error) {
+		toolCalls.Add(1)
+		return "ok", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := durable.Infer(ctx, b, "wf", "m", func(context.Context) (any, error) {
+		inferCalls.Add(1)
+		return "plan", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := durable.Tool(ctx, b, "wf", "echo", func(context.Context) (any, error) {
+		toolCalls.Add(1)
+		return "ok", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if inferCalls.Load() != 1 || toolCalls.Load() != 1 {
+		t.Fatalf("infer=%d tool=%d, want 1 each", inferCalls.Load(), toolCalls.Load())
+	}
+}
+
+func TestFirstSaveWins(t *testing.T) {
+	ctx := context.Background()
+	b := durable.NewMemory()
+	t.Cleanup(func() { _ = b.Close() })
+
+	if err := b.Save(ctx, "wf", "k", []byte(`"first"`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Save(ctx, "wf", "k", []byte(`"second"`)); err != nil {
+		t.Fatal(err)
+	}
+	raw, found, err := b.Load(ctx, "wf", "k")
+	if err != nil || !found {
+		t.Fatalf("load: found=%v err=%v", found, err)
+	}
+	if string(raw) != `"first"` {
+		t.Fatalf("got %s, want first", raw)
+	}
+}

--- a/go/trajir/durable/memory.go
+++ b/go/trajir/durable/memory.go
@@ -1,0 +1,56 @@
+package durable
+
+import (
+	"context"
+	"sync"
+)
+
+// Memory is an in process Backend. Fine for unit tests. Does not survive process exit.
+type Memory struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+// NewMemory returns an empty Memory backend.
+func NewMemory() *Memory {
+	return &Memory{data: make(map[string][]byte)}
+}
+
+func memKey(workflowID, stepKey string) string {
+	return workflowID + "\x00" + stepKey
+}
+
+// Load implements Backend.
+func (m *Memory) Load(_ context.Context, workflowID, stepKey string) ([]byte, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.data[memKey(workflowID, stepKey)]
+	if !ok {
+		return nil, false, nil
+	}
+	out := make([]byte, len(v))
+	copy(out, v)
+	return out, true, nil
+}
+
+// Save implements Backend. First writer wins.
+func (m *Memory) Save(_ context.Context, workflowID, stepKey string, value []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := memKey(workflowID, stepKey)
+	if _, exists := m.data[k]; exists {
+		return nil
+	}
+	cp := make([]byte, len(value))
+	copy(cp, value)
+	m.data[k] = cp
+	return nil
+}
+
+// Close implements Backend.
+func (m *Memory) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data = nil
+	return nil
+}

--- a/go/trajir/durable/sqlite.go
+++ b/go/trajir/durable/sqlite.go
@@ -1,0 +1,83 @@
+package durable
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	_ "modernc.org/sqlite"
+)
+
+// LocalSQLite is the Phase 1B coding default Backend. Step memos survive
+// process restart when the same database path is reopened (needed for crash
+// style tests later).
+type LocalSQLite struct {
+	db *sql.DB
+	mu sync.Mutex
+}
+
+// OpenLocal opens or creates a SQLite memo database at path.
+func OpenLocal(path string) (*LocalSQLite, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("durable sqlite open: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	schema := `
+CREATE TABLE IF NOT EXISTS step_memos (
+    workflow_id TEXT NOT NULL,
+    step_key TEXT NOT NULL,
+    value_json BLOB NOT NULL,
+    PRIMARY KEY (workflow_id, step_key)
+)`
+	if _, err := db.Exec(schema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("durable sqlite schema: %w", err)
+	}
+	return &LocalSQLite{db: db}, nil
+}
+
+// Load implements Backend.
+func (s *LocalSQLite) Load(ctx context.Context, workflowID, stepKey string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var raw []byte
+	err := s.db.QueryRowContext(ctx,
+		`SELECT value_json FROM step_memos WHERE workflow_id = ? AND step_key = ?`,
+		workflowID, stepKey,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return raw, true, nil
+}
+
+// Save implements Backend. First writer wins (INSERT OR IGNORE).
+func (s *LocalSQLite) Save(ctx context.Context, workflowID, stepKey string, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO step_memos (workflow_id, step_key, value_json) VALUES (?, ?, ?)`,
+		workflowID, stepKey, value,
+	)
+	return err
+}
+
+// Close implements Backend.
+func (s *LocalSQLite) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil
+	}
+	err := s.db.Close()
+	s.db = nil
+	return err
+}


### PR DESCRIPTION
## Summary

Records the Go durable backend decision from #16 and ships the Phase 1B coding default: a pluggable Backend with Memory and LocalSQLite step memoization, plus Infer/Tool helpers so model and tool calls are not re-run on re-entry.

Closes #16

## Related issues

Closes #16

## How I tested

```bash
cd go
go test ./trajir/durable ./trajir/log ./trajir/nodes -count=1
```

durable, log, and nodes passed locally. effects may be blocked by Windows Application Control on this machine; Linux CI is authoritative for the full module.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented crash engines)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No (memoization backend only; no gate or seal yet)
- [ ] Yes

## AI assistance (if any)

Assisted package layout and tests. Decision and API reviewed against README 3.1/12.0 and the Python DBOS adapter shape.

## Decision frozen in tree

| | |
|--|--|
| Coding default | LocalSQLite + Memory in go/trajir/durable |
| Production target | Temporal (Restate later) |
| Why | No hand rolled crash engine; no Temporal server required for every contributor |

## What landed

1. Backend interface (Load/Save/Close)
2. Step, Infer, Tool helpers (JSON memo, first save wins)
3. Memory and LocalSQLite implementations
4. Tests: memoization, reopen survival, infer vs tool keys
5. go/README.md documenting packages and the decision

## Out of scope (next PRs)

1. Block and gate
2. run_step seal path
3. Temporal worker adapter
4. R01/R02 style Go crash tests