### PR TITLE
feat: Go block and gate for non idempotent tools (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go SQLite NodeLog under `go/trajir/log` matching the Python append only IR log.
 - Go effect classes and fail closed MCP mapping under `go/trajir/effects`.
 - Go durable backend package (`trajir/durable`): local SQLite and memory step memoization; Temporal named as production target.
+- Go block and gate under `go/trajir/resume` for non idempotent tool re-entry.
 
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -10,6 +10,7 @@ Second language implementation of Trajectory IR primitives. Python remains the P
 | `trajir/log` | SQLite append only NodeLog |
 | `trajir/effects` | Effect classes and fail closed MCP mapping |
 | `trajir/durable` | Pluggable step memoization backend |
+| `trajir/resume` | Block and gate for NON_IDEMPOTENT_WRITE tools |
 
 ## Durable backend decision (issue #16)
 

--- a/go/trajir/resume/gate.go
+++ b/go/trajir/resume/gate.go
@@ -1,0 +1,95 @@
+// Package resume holds Go resume policy helpers. Block and gate lives here;
+// full run_step orchestration is a follow up.
+package resume
+
+import (
+	"fmt"
+
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+)
+
+// BlockedNeedsGate is raised when a NON_IDEMPOTENT_WRITE tool was already
+// attempted for this step/seq and must not be silently re-run.
+type BlockedNeedsGate struct {
+	StepN    int
+	ToolName string
+}
+
+func (e *BlockedNeedsGate) Error() string {
+	return fmt.Sprintf(
+		"step %d: '%s' BLOCKED_NEEDS_GATE (crashed mid-execution, not retried)",
+		e.StepN,
+		e.ToolName,
+	)
+}
+
+// ToolFunc is a tool body that receives a free-form args map.
+type ToolFunc func(args map[string]any) (any, error)
+
+// MakeGatedToolCall wraps toolFn so re-entry after TOOL_CALL was logged blocks.
+//
+// Seq layout matches Python: TOOL_CALL at seq, TOOL_RESULT or ABORT at seq+1.
+// Callers should space tools as seq = 2 + 2*i for tool index i inside a step.
+//
+// The gate keys only on TOOL_CALL at this exact seq. It does not require a
+// missing TOOL_RESULT (that pattern fails open after a partial crash window).
+func MakeGatedToolCall(
+	log *nodelog.NodeLog,
+	trajectoryID, tenantID string,
+	stepN, seq int,
+	toolName string,
+	toolFn ToolFunc,
+) ToolFunc {
+	return func(args map[string]any) (any, error) {
+		if args == nil {
+			args = map[string]any{}
+		}
+		step := stepN
+
+		ok, err := log.Has(trajectoryID, stepN, "TOOL_CALL", &seq)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			if _, err := log.Append(
+				"ABORT",
+				&step,
+				map[string]any{"reason": "BLOCKED_NEEDS_GATE", "tool": toolName},
+				trajectoryID,
+				tenantID,
+				seq+1,
+			); err != nil {
+				return nil, err
+			}
+			return nil, &BlockedNeedsGate{StepN: stepN, ToolName: toolName}
+		}
+
+		if _, err := log.Append(
+			"TOOL_CALL",
+			&step,
+			map[string]any{"tool": toolName, "args": args},
+			trajectoryID,
+			tenantID,
+			seq,
+		); err != nil {
+			return nil, err
+		}
+
+		result, err := toolFn(args)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := log.Append(
+			"TOOL_RESULT",
+			&step,
+			map[string]any{"result": result},
+			trajectoryID,
+			tenantID,
+			seq+1,
+		); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+}

--- a/go/trajir/resume/gate_test.go
+++ b/go/trajir/resume/gate_test.go
@@ -1,0 +1,113 @@
+package resume_test
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+func openLog(t *testing.T) *nodelog.NodeLog {
+	t.Helper()
+	nl, err := nodelog.Open(filepath.Join(t.TempDir(), "nodes.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = nl.Close() })
+	return nl
+}
+
+func TestGatedToolRunsOnceThenBlocks(t *testing.T) {
+	nl := openLog(t)
+	sideEffects := 0
+	tool := func(args map[string]any) (any, error) {
+		sideEffects++
+		return map[string]any{"ok": true, "n": args["n"]}, nil
+	}
+
+	gated := resume.MakeGatedToolCall(nl, "t1", "demo", 1, 2, "deploy_server", tool)
+
+	out, err := gated(map[string]any{"n": float64(1)})
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if sideEffects != 1 {
+		t.Fatalf("sideEffects=%d after first call", sideEffects)
+	}
+	m := out.(map[string]any)
+	if m["ok"] != true {
+		t.Fatalf("unexpected result: %#v", out)
+	}
+
+	_, err = gated(map[string]any{"n": float64(1)})
+	var blocked *resume.BlockedNeedsGate
+	if !errors.As(err, &blocked) {
+		t.Fatalf("second call err=%v, want BlockedNeedsGate", err)
+	}
+	if blocked.StepN != 1 || blocked.ToolName != "deploy_server" {
+		t.Fatalf("blocked fields: %+v", blocked)
+	}
+	if sideEffects != 1 {
+		t.Fatalf("sideEffects=%d after block, want 1", sideEffects)
+	}
+
+	ok, err := nl.Has("t1", 1, "TOOL_CALL", intPtr(2))
+	if err != nil || !ok {
+		t.Fatalf("TOOL_CALL present=%v err=%v", ok, err)
+	}
+	ok, err = nl.Has("t1", 1, "ABORT", intPtr(3))
+	if err != nil || !ok {
+		t.Fatalf("ABORT present=%v err=%v", ok, err)
+	}
+}
+
+func TestGateKeysOnSeqNotSiblingTool(t *testing.T) {
+	nl := openLog(t)
+	callsA, callsB := 0, 0
+
+	a := resume.MakeGatedToolCall(nl, "t1", "demo", 1, 2, "tool_a", func(map[string]any) (any, error) {
+		callsA++
+		return "a", nil
+	})
+	b := resume.MakeGatedToolCall(nl, "t1", "demo", 1, 4, "tool_b", func(map[string]any) (any, error) {
+		callsB++
+		return "b", nil
+	})
+
+	if _, err := a(nil); err != nil {
+		t.Fatal(err)
+	}
+	// Completing A must not block first entry of B at a different seq.
+	if _, err := b(nil); err != nil {
+		t.Fatal(err)
+	}
+	if callsA != 1 || callsB != 1 {
+		t.Fatalf("calls A=%d B=%d", callsA, callsB)
+	}
+
+	// Re-entry of A still blocks.
+	_, err := a(nil)
+	var blocked *resume.BlockedNeedsGate
+	if !errors.As(err, &blocked) {
+		t.Fatalf("want block on A re-entry, got %v", err)
+	}
+	if callsA != 1 {
+		t.Fatalf("A re-ran: callsA=%d", callsA)
+	}
+}
+
+func TestErrorTextIncludesStepAndTool(t *testing.T) {
+	e := &resume.BlockedNeedsGate{StepN: 3, ToolName: "deploy_server"}
+	msg := e.Error()
+	if msg == "" {
+		t.Fatal("empty error text")
+	}
+	if !strings.Contains(msg, "3") || !strings.Contains(msg, "deploy_server") || !strings.Contains(msg, "BLOCKED_NEEDS_GATE") {
+		t.Fatalf("unexpected message: %s", msg)
+	}
+}
+
+func intPtr(v int) *int { return &v }


### PR DESCRIPTION
## Summary

Ports the Python block and gate into Go. A NON_IDEMPOTENT_WRITE tool that already has a TOOL_CALL at the same step and seq will not run again; the gate appends ABORT and returns BlockedNeedsGate.

Closes #18

## Related issues

Closes #18

## How I tested

```bash
cd go
go test ./trajir/resume ./trajir/log ./trajir/nodes ./trajir/durable -count=1
```

All four packages passed.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: block and gate only (NodeLog TOOL_CALL at seq). No seal orchestration yet.

## AI assistance (if any)

Assisted port from pkg/trajectory_ir/resume/gate.py. Reviewed against the fail open TOOL_RESULT pitfall noted in Python.

## What landed

1. go/trajir/resume: BlockedNeedsGate, MakeGatedToolCall
2. Gate condition: TOOL_CALL at exact seq (not missing TOOL_RESULT)
3. Tests: first run succeeds, re-entry blocks without second side effect, multi tool seq isolation

## Out of scope

1. run_step / DECISION seal path
2. Temporal adapter
3. Full R01/R02 process kill suite