### PR TITLE
feat: Go RunStep seal path for one agent step (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go effect classes and fail closed MCP mapping under `go/trajir/effects`.
 - Go durable backend package (`trajir/durable`): local SQLite and memory step memoization; Temporal named as production target.
 - Go block and gate under `go/trajir/resume` for non idempotent tool re-entry.
+- Go RunStep seal path (project, durable infer, DECISION, tools, COMMIT_STEP).
+
 
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -10,7 +10,7 @@ Second language implementation of Trajectory IR primitives. Python remains the P
 | `trajir/log` | SQLite append only NodeLog |
 | `trajir/effects` | Effect classes and fail closed MCP mapping |
 | `trajir/durable` | Pluggable step memoization backend |
-| `trajir/resume` | Block and gate for NON_IDEMPOTENT_WRITE tools |
+| `trajir/resume` | Block and gate, and RunStep seal path for one agent step |
 
 ## Durable backend decision (issue #16)
 

--- a/go/trajir/resume/gate.go
+++ b/go/trajir/resume/gate.go
@@ -1,5 +1,4 @@
-// Package resume holds Go resume policy helpers. Block and gate lives here;
-// full run_step orchestration is a follow up.
+// Package resume holds Go seal and resume helpers: block and gate, and RunStep.
 package resume
 
 import (

--- a/go/trajir/resume/step.go
+++ b/go/trajir/resume/step.go
@@ -1,0 +1,220 @@
+package resume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+)
+
+// Tool is a named tool with an effect class and implementation.
+type Tool struct {
+	Name   string
+	Effect effects.EffectClass
+	Fn     ToolFunc
+}
+
+// ModelFunc produces a plan map for a step. Plan must include "tool_calls":
+// a list of maps with "name" and optional "args".
+type ModelFunc func(ctx context.Context, context map[string]any) (map[string]any, error)
+
+// RunStepConfig wires IR log, durable memo backend, and tools for one trajectory.
+type RunStepConfig struct {
+	Log              *nodelog.NodeLog
+	Backend          durable.Backend
+	TenantID         string
+	TrajectoryID     string
+	WorkflowID       string // durable memo scope; often same as TrajectoryID
+	Tools            map[string]Tool
+	OnDecisionSealed func() // optional test hook after DECISION is appended
+}
+
+// RunStep executes one agent step: project context, durable infer, DECISION seal,
+// tools (gated when NON_IDEMPOTENT_WRITE), then COMMIT_STEP.
+//
+// Seq layout matches Python make_run_step:
+//
+//	0 PROJECT_CONTEXT, 1 DECISION, tools at 2+2*i / 3+2*i, COMMIT at 2+2*n.
+func RunStep(
+	ctx context.Context,
+	cfg RunStepConfig,
+	stepN int,
+	model ModelFunc,
+	stepContext map[string]any,
+) ([]any, error) {
+	if cfg.Log == nil || cfg.Backend == nil {
+		return nil, fmt.Errorf("resume: Log and Backend are required")
+	}
+	if cfg.WorkflowID == "" {
+		cfg.WorkflowID = cfg.TrajectoryID
+	}
+	if stepContext == nil {
+		stepContext = map[string]any{}
+	}
+	step := stepN
+
+	if _, err := cfg.Log.Append(
+		"PROJECT_CONTEXT",
+		&step,
+		stepContext,
+		cfg.TrajectoryID,
+		cfg.TenantID,
+		0,
+	); err != nil {
+		return nil, err
+	}
+
+	planAny, err := durable.Infer(ctx, cfg.Backend, cfg.WorkflowID, fmt.Sprintf("step%d", stepN), func(context.Context) (any, error) {
+		return model(ctx, stepContext)
+	})
+	if err != nil {
+		return nil, err
+	}
+	plan, err := asStringMap(planAny)
+	if err != nil {
+		return nil, fmt.Errorf("resume: plan: %w", err)
+	}
+
+	if _, err := cfg.Log.Append(
+		"DECISION",
+		&step,
+		map[string]any{"plan": plan},
+		cfg.TrajectoryID,
+		cfg.TenantID,
+		1,
+	); err != nil {
+		return nil, err
+	}
+	if cfg.OnDecisionSealed != nil {
+		cfg.OnDecisionSealed()
+	}
+
+	calls, err := toolCallsFromPlan(plan)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]any, 0, len(calls))
+	for i, call := range calls {
+		tool, ok := cfg.Tools[call.Name]
+		if !ok {
+			return nil, fmt.Errorf("resume: unknown tool %q", call.Name)
+		}
+		seq := 2 + 2*i
+		args := call.Args
+		if args == nil {
+			args = map[string]any{}
+		}
+
+		var result any
+		stepKey := fmt.Sprintf("%s@%d", call.Name, seq)
+		if tool.Effect == effects.NON_IDEMPOTENT_WRITE {
+			gated := MakeGatedToolCall(
+				cfg.Log,
+				cfg.TrajectoryID,
+				cfg.TenantID,
+				stepN,
+				seq,
+				call.Name,
+				tool.Fn,
+			)
+			result, err = durable.Tool(ctx, cfg.Backend, cfg.WorkflowID, stepKey, func(context.Context) (any, error) {
+				return gated(args)
+			})
+		} else {
+			fn := tool.Fn
+			result, err = durable.Tool(ctx, cfg.Backend, cfg.WorkflowID, stepKey, func(context.Context) (any, error) {
+				return fn(args)
+			})
+			if err == nil {
+				// Plain tools still need IR history for audit; gate path already logs.
+				if _, err := cfg.Log.Append(
+					"TOOL_CALL",
+					&step,
+					map[string]any{"tool": call.Name, "args": args},
+					cfg.TrajectoryID,
+					cfg.TenantID,
+					seq,
+				); err != nil {
+					return nil, err
+				}
+				if _, err := cfg.Log.Append(
+					"TOOL_RESULT",
+					&step,
+					map[string]any{"result": result},
+					cfg.TrajectoryID,
+					cfg.TenantID,
+					seq+1,
+				); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+
+	commitSeq := 2 + 2*len(calls)
+	if _, err := cfg.Log.Append(
+		"COMMIT_STEP",
+		&step,
+		map[string]any{},
+		cfg.TrajectoryID,
+		cfg.TenantID,
+		commitSeq,
+	); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+type toolCall struct {
+	Name string
+	Args map[string]any
+}
+
+func toolCallsFromPlan(plan map[string]any) ([]toolCall, error) {
+	raw, ok := plan["tool_calls"]
+	if !ok {
+		return nil, fmt.Errorf("resume: plan missing tool_calls")
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		// JSON may decode as []map under some paths; accept []any only after Infer.
+		return nil, fmt.Errorf("resume: tool_calls must be a list")
+	}
+	out := make([]toolCall, 0, len(list))
+	for i, item := range list {
+		m, err := asStringMap(item)
+		if err != nil {
+			return nil, fmt.Errorf("resume: tool_calls[%d]: %w", i, err)
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			return nil, fmt.Errorf("resume: tool_calls[%d] missing name", i)
+		}
+		var args map[string]any
+		if a, ok := m["args"]; ok && a != nil {
+			args, err = asStringMap(a)
+			if err != nil {
+				return nil, fmt.Errorf("resume: tool_calls[%d].args: %w", i, err)
+			}
+		}
+		out = append(out, toolCall{Name: name, Args: args})
+	}
+	return out, nil
+}
+
+func asStringMap(v any) (map[string]any, error) {
+	if v == nil {
+		return map[string]any{}, nil
+	}
+	if m, ok := v.(map[string]any); ok {
+		return m, nil
+	}
+	return nil, fmt.Errorf("want object, got %T", v)
+}

--- a/go/trajir/resume/step_test.go
+++ b/go/trajir/resume/step_test.go
@@ -1,0 +1,210 @@
+package resume_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+func testEnv(t *testing.T) (*nodelog.NodeLog, *durable.Memory) {
+	t.Helper()
+	nl, err := nodelog.Open(filepath.Join(t.TempDir(), "nodes.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = nl.Close() })
+	mem := durable.NewMemory()
+	t.Cleanup(func() { _ = mem.Close() })
+	return nl, mem
+}
+
+func TestRunStepHappyPathIdempotentTool(t *testing.T) {
+	ctx := context.Background()
+	nl, backend := testEnv(t)
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf1",
+		Tools: map[string]resume.Tool{
+			"echo": {
+				Name:   "echo",
+				Effect: effects.PURE,
+				Fn: func(args map[string]any) (any, error) {
+					return args["msg"], nil
+				},
+			},
+		},
+	}
+
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{
+					"name": "echo",
+					"args": map[string]any{"msg": "hello"},
+				},
+			},
+		}, nil
+	}
+
+	results, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{"k": "v"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0] != "hello" {
+		t.Fatalf("results=%#v", results)
+	}
+
+	ok, _ := nl.Has("t1", 1, "DECISION", nil)
+	if !ok {
+		t.Fatal("missing DECISION")
+	}
+	ok, _ = nl.Has("t1", 1, "COMMIT_STEP", nil)
+	if !ok {
+		t.Fatal("missing COMMIT_STEP")
+	}
+}
+
+func TestRunStepModelNotReinvokedOnReplay(t *testing.T) {
+	ctx := context.Background()
+	nl, backend := testEnv(t)
+	var modelCalls atomic.Int32
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf-replay",
+		Tools: map[string]resume.Tool{
+			"echo": {
+				Name:   "echo",
+				Effect: effects.PURE,
+				Fn:     func(args map[string]any) (any, error) { return "ok", nil },
+			},
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		modelCalls.Add(1)
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "echo", "args": map[string]any{}},
+			},
+		}, nil
+	}
+
+	if _, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if modelCalls.Load() != 1 {
+		t.Fatalf("model calls=%d, want 1", modelCalls.Load())
+	}
+}
+
+func TestRunStepNonIdempotentGateOnReentry(t *testing.T) {
+	ctx := context.Background()
+	nl, backend := testEnv(t)
+	var deploys atomic.Int32
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf-gate",
+		Tools: map[string]resume.Tool{
+			"deploy_server": {
+				Name:   "deploy_server",
+				Effect: effects.NON_IDEMPOTENT_WRITE,
+				Fn: func(map[string]any) (any, error) {
+					deploys.Add(1)
+					return "deployed", nil
+				},
+			},
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "deploy_server", "args": map[string]any{"x": "1"}},
+			},
+		}, nil
+	}
+
+	if _, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if deploys.Load() != 1 {
+		t.Fatalf("deploys=%d after first run", deploys.Load())
+	}
+
+	// Same workflow id: durable.Tool returns memoized result without calling the
+	// gated body again. Side effect must stay 1. Gate would also block if the
+	// durable layer re-entered the body after TOOL_CALL was logged.
+	if _, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if deploys.Load() != 1 {
+		t.Fatalf("deploys=%d after second run, want 1", deploys.Load())
+	}
+}
+
+func TestRunStepGateWhenToolCallAlreadyLogged(t *testing.T) {
+	ctx := context.Background()
+	nl, backend := testEnv(t)
+	var deploys atomic.Int32
+
+	// Simulate crash after TOOL_CALL was written but before durable memo finished.
+	step := 1
+	seq := 2
+	if _, err := nl.Append("TOOL_CALL", &step, map[string]any{"tool": "deploy_server", "args": map[string]any{}}, "t1", "demo", seq); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf-partial",
+		Tools: map[string]resume.Tool{
+			"deploy_server": {
+				Name:   "deploy_server",
+				Effect: effects.NON_IDEMPOTENT_WRITE,
+				Fn: func(map[string]any) (any, error) {
+					deploys.Add(1)
+					return "deployed", nil
+				},
+			},
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "deploy_server", "args": map[string]any{}},
+			},
+		}, nil
+	}
+
+	_, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{})
+	var blocked *resume.BlockedNeedsGate
+	if !errors.As(err, &blocked) {
+		t.Fatalf("want BlockedNeedsGate, got %v", err)
+	}
+	if deploys.Load() != 0 {
+		t.Fatalf("deploy ran %d times, want 0", deploys.Load())
+	}
+}


### PR DESCRIPTION
## Summary

Adds RunStep for Go: one agent step from project context through durable model inference, DECISION seal, tools (block and gate for non idempotent), and COMMIT_STEP. Mirrors Python make_run_step seq layout.

Closes #20

## Related issues

Closes #20

## How I tested

```bash
cd go
go test ./trajir/resume -count=1 -v
```

All resume tests passed (gate + RunStep).

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: seal path and tool execution with gate for NON_IDEMPOTENT_WRITE

## AI assistance (if any)

Assisted orchestration against pkg/trajectory_ir/resume/step.py and existing Go packages. Reviewed seq spacing and durable Infer memo for R01 style behaviour.

## What landed

1. resume.RunStep + RunStepConfig, Tool, ModelFunc
2. Seq layout: 0 context, 1 decision, 2+2*i tools, commit after
3. Tests: happy path, model not re-invoked on replay, deploy not doubled, gate when TOOL_CALL already logged

## Out of scope

1. Multi step agent loop / client SDK
2. Temporal adapter
3. Full process kill R01/R02 suite