### PR TITLE
feat: Go crash resume tests R01 and R02 style (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,10 @@ Thumbs.db
 test_model_call_count.txt
 test_deploy_side_effect_count.txt
 *.marker
+
+# Go local caches (never commit; use the user GOCACHE, not the repo)
+go/.gocache/
+go/.tmp/
+go/.bin/
+*.test
+*.test.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go durable backend package (`trajir/durable`): local SQLite and memory step memoization; Temporal named as production target.
 - Go block and gate under `go/trajir/resume` for non idempotent tool re-entry.
 - Go RunStep seal path (project, durable infer, DECISION, tools, COMMIT_STEP).
+- Go crash resume conformance tests (R01/R02 style) via cmd/crashagent.
+
 
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -28,3 +28,14 @@ Model inference and tools must go through `durable.Step` / `Infer` / `Tool`. Blo
 cd go
 go test ./...
 ```
+
+Crash resume conformance (R01/R02 style) lives under `conformance/`.
+
+1. In-process tests always run (panic after seal, TOOL_CALL pre-seed for gate).
+2. Subprocess tests build `cmd/crashagent`, hard-kill at markers, then resume.
+   They skip if the host blocks running the binary (some Windows policies).
+
+```bash
+cd go
+go test ./conformance -count=1 -v
+```

--- a/go/cmd/crashagent/main.go
+++ b/go/cmd/crashagent/main.go
@@ -1,0 +1,137 @@
+// Command crashagent is a fixture for R01/R02 style crash resume tests.
+//
+//	crashagent -workdir DIR -crash-after=decision_sealed
+//	crashagent -workdir DIR -resume
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+const (
+	tenantID     = "demo"
+	trajectoryID = "go-crash-demo"
+	workflowID   = "go-crash-demo-wf"
+	crashWindow  = 30 * time.Second
+)
+
+func main() {
+	workdir := flag.String("workdir", ".", "directory for sqlite files, counters, markers")
+	crashAfter := flag.String("crash-after", "", "decision_sealed")
+	crashDuring := flag.String("crash-during", "", "tool_call")
+	resumeMode := flag.Bool("resume", false, "reopen same workdir and continue")
+	flag.Parse()
+
+	if err := os.Chdir(*workdir); err != nil {
+		fail(err)
+	}
+
+	logPath := "nodes.sqlite"
+	memoPath := "memo.sqlite"
+
+	nl, err := nodelog.Open(logPath)
+	if err != nil {
+		fail(err)
+	}
+	defer nl.Close()
+
+	backend, err := durable.OpenLocal(memoPath)
+	if err != nil {
+		fail(err)
+	}
+	defer backend.Close()
+
+	crashDuringTool := strings.EqualFold(*crashDuring, "tool_call")
+	crashAfterSeal := strings.EqualFold(*crashAfter, "decision_sealed")
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     tenantID,
+		TrajectoryID: trajectoryID,
+		WorkflowID:   workflowID,
+		Tools: map[string]resume.Tool{
+			"deploy_server": {
+				Name:   "deploy_server",
+				Effect: effects.NON_IDEMPOTENT_WRITE,
+				Fn: func(args map[string]any) (any, error) {
+					if err := writeFile("tool_started.marker", "started"); err != nil {
+						return nil, err
+					}
+					fmt.Println("TOOL_CALL: deploy_server started")
+					if crashDuringTool && !*resumeMode {
+						time.Sleep(crashWindow)
+					}
+					if _, err := bumpCounter("test_deploy_side_effect_count.txt"); err != nil {
+						return nil, err
+					}
+					return map[string]any{"deployed": args["version"]}, nil
+				},
+			},
+		},
+		OnDecisionSealed: func() {
+			_ = writeFile("decision_sealed.marker", "sealed")
+			fmt.Println("DECISION sealed")
+			if crashAfterSeal && !*resumeMode {
+				time.Sleep(crashWindow)
+			}
+		},
+	}
+
+	model := func(ctx context.Context, _ map[string]any) (map[string]any, error) {
+		if _, err := bumpCounter("test_model_call_count.txt"); err != nil {
+			return nil, err
+		}
+		fmt.Println("INFERENCE: model_call invoked")
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{
+					"name": "deploy_server",
+					"args": map[string]any{"version": "1.0.0"},
+				},
+			},
+		}, nil
+	}
+
+	ctx := context.Background()
+	_, err = resume.RunStep(ctx, cfg, 1, model, map[string]any{"run": "crashagent"})
+	if err != nil {
+		var blocked *resume.BlockedNeedsGate
+		if errors.As(err, &blocked) {
+			fmt.Printf("BLOCKED_NEEDS_GATE: %s\n", blocked.Error())
+			os.Exit(0)
+		}
+		fail(err)
+	}
+	fmt.Println("step committed")
+}
+
+func bumpCounter(path string) (int, error) {
+	n := 0
+	if b, err := os.ReadFile(path); err == nil {
+		n, _ = strconv.Atoi(strings.TrimSpace(string(b)))
+	}
+	n++
+	return n, writeFile(path, strconv.Itoa(n))
+}
+
+func writeFile(path, body string) error {
+	return os.WriteFile(path, []byte(body), 0o644)
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/go/conformance/crash_resume_test.go
+++ b/go/conformance/crash_resume_test.go
@@ -1,0 +1,306 @@
+package conformance_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+}
+
+func buildCrashAgent(t *testing.T) (string, bool) {
+	t.Helper()
+	root := moduleRoot(t)
+	binDir := filepath.Join(root, ".bin")
+	_ = os.MkdirAll(binDir, 0o755)
+	out := filepath.Join(binDir, "crashagent")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", out, "./cmd/crashagent")
+	cmd.Dir = root
+	cmd.Env = os.Environ()
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build crashagent: %v\n%s", err, outBytes)
+	}
+	// Probe whether this host allows running the binary (Windows Application Control may block).
+	probe := exec.Command(out, "-h")
+	if err := probe.Run(); err != nil {
+		// -h is not defined; any start failure is the signal we care about.
+		if _, ok := err.(*exec.ExitError); ok {
+			return out, true
+		}
+		if strings.Contains(err.Error(), "Application Control") || strings.Contains(err.Error(), "blocked") {
+			return out, false
+		}
+		// Try a real short start: if fork/exec fails, skip subprocess tests.
+		return out, false
+	}
+	return out, true
+}
+
+func canExecAgent(t *testing.T, bin string) bool {
+	t.Helper()
+	cmd := exec.Command(bin, "-workdir", t.TempDir())
+	// Will fail quickly if flag path missing files mid-run is fine; we only care about fork/exec.
+	err := cmd.Start()
+	if err != nil {
+		if strings.Contains(err.Error(), "Application Control") || strings.Contains(err.Error(), "blocked") || strings.Contains(err.Error(), "fork/exec") {
+			return false
+		}
+		return false
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+	return true
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func readCounter(path string) int {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return n
+}
+
+func TestR01NoReinferAfterDecisionSeal_Subprocess(t *testing.T) {
+	bin, _ := buildCrashAgent(t)
+	if !canExecAgent(t, bin) {
+		t.Skip("subprocess crashagent blocked on this host (e.g. Windows Application Control); see in-process tests")
+	}
+	workdir := t.TempDir()
+	marker := filepath.Join(workdir, "decision_sealed.marker")
+
+	crash := exec.Command(bin, "-workdir", workdir, "-crash-after=decision_sealed")
+	if err := crash.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitForFile(t, marker, 15*time.Second)
+	if err := crash.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	_, _ = crash.Process.Wait()
+
+	resumeCmd := exec.Command(bin, "-workdir", workdir, "-resume")
+	out, err := resumeCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resume: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "step committed") {
+		t.Fatalf("resume output missing commit:\n%s", out)
+	}
+	if n := readCounter(filepath.Join(workdir, "test_model_call_count.txt")); n != 1 {
+		t.Fatalf("model calls=%d, want 1", n)
+	}
+	if n := readCounter(filepath.Join(workdir, "test_deploy_side_effect_count.txt")); n != 1 {
+		t.Fatalf("deploy count=%d, want 1", n)
+	}
+}
+
+func TestR02BlockWhenToolCallInterrupted_Subprocess(t *testing.T) {
+	bin, _ := buildCrashAgent(t)
+	if !canExecAgent(t, bin) {
+		t.Skip("subprocess crashagent blocked on this host; see in-process tests")
+	}
+	workdir := t.TempDir()
+	marker := filepath.Join(workdir, "tool_started.marker")
+
+	crash := exec.Command(bin, "-workdir", workdir, "-crash-during=tool_call")
+	if err := crash.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitForFile(t, marker, 15*time.Second)
+	if err := crash.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	_, _ = crash.Process.Wait()
+
+	if n := readCounter(filepath.Join(workdir, "test_deploy_side_effect_count.txt")); n != 0 {
+		t.Fatalf("deploy count after kill=%d, want 0", n)
+	}
+
+	resumeCmd := exec.Command(bin, "-workdir", workdir, "-resume")
+	out, err := resumeCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resume: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "BLOCKED_NEEDS_GATE") {
+		t.Fatalf("resume missing block:\n%s", out)
+	}
+	if n := readCounter(filepath.Join(workdir, "test_deploy_side_effect_count.txt")); n != 0 {
+		t.Fatalf("deploy count after resume=%d, want 0", n)
+	}
+	if n := readCounter(filepath.Join(workdir, "test_model_call_count.txt")); n != 1 {
+		t.Fatalf("model calls=%d, want 1", n)
+	}
+}
+
+// In-process R01: crash inject via panic after DECISION, then resume same DBs.
+func TestR01NoReinferAfterDecisionSeal_InProcess(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "nodes.sqlite")
+	memoPath := filepath.Join(dir, "memo.sqlite")
+
+	var modelCalls atomic.Int32
+	var deploys atomic.Int32
+
+	runOnce := func(crashAfterSeal bool) error {
+		nl, err := nodelog.Open(logPath)
+		if err != nil {
+			return err
+		}
+		defer nl.Close()
+		backend, err := durable.OpenLocal(memoPath)
+		if err != nil {
+			return err
+		}
+		defer backend.Close()
+
+		cfg := resume.RunStepConfig{
+			Log:          nl,
+			Backend:      backend,
+			TenantID:     "demo",
+			TrajectoryID: "t1",
+			WorkflowID:   "wf-r01",
+			Tools: map[string]resume.Tool{
+				"deploy_server": {
+					Name:   "deploy_server",
+					Effect: effects.NON_IDEMPOTENT_WRITE,
+					Fn: func(map[string]any) (any, error) {
+						deploys.Add(1)
+						return "ok", nil
+					},
+				},
+			},
+			OnDecisionSealed: func() {
+				if crashAfterSeal {
+					panic("inject crash after decision seal")
+				}
+			},
+		}
+		model := func(context.Context, map[string]any) (map[string]any, error) {
+			modelCalls.Add(1)
+			return map[string]any{
+				"tool_calls": []any{
+					map[string]any{"name": "deploy_server", "args": map[string]any{}},
+				},
+			}, nil
+		}
+		_, err = resume.RunStep(ctx, cfg, 1, model, map[string]any{})
+		return err
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic after seal")
+			}
+		}()
+		_ = runOnce(true)
+	}()
+
+	if err := runOnce(false); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if modelCalls.Load() != 1 {
+		t.Fatalf("model calls=%d, want 1", modelCalls.Load())
+	}
+	if deploys.Load() != 1 {
+		t.Fatalf("deploys=%d, want 1", deploys.Load())
+	}
+}
+
+// In-process R02: TOOL_CALL already logged (crash after call start), resume blocks.
+func TestR02BlockWhenToolCallInterrupted_InProcess(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	nl, err := nodelog.Open(filepath.Join(dir, "nodes.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nl.Close()
+	backend, err := durable.OpenLocal(filepath.Join(dir, "memo.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+
+	step, seq := 1, 2
+	if _, err := nl.Append("TOOL_CALL", &step, map[string]any{"tool": "deploy_server", "args": map[string]any{}}, "t1", "demo", seq); err != nil {
+		t.Fatal(err)
+	}
+
+	var deploys atomic.Int32
+	var modelCalls atomic.Int32
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf-r02",
+		Tools: map[string]resume.Tool{
+			"deploy_server": {
+				Name:   "deploy_server",
+				Effect: effects.NON_IDEMPOTENT_WRITE,
+				Fn: func(map[string]any) (any, error) {
+					deploys.Add(1)
+					return "ok", nil
+				},
+			},
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		modelCalls.Add(1)
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "deploy_server", "args": map[string]any{}},
+			},
+		}, nil
+	}
+
+	_, err = resume.RunStep(ctx, cfg, 1, model, map[string]any{})
+	var blocked *resume.BlockedNeedsGate
+	if !errors.As(err, &blocked) {
+		t.Fatalf("want BlockedNeedsGate, got %v", err)
+	}
+	if deploys.Load() != 0 {
+		t.Fatalf("deploys=%d, want 0", deploys.Load())
+	}
+	if modelCalls.Load() != 1 {
+		t.Fatalf("model calls=%d, want 1", modelCalls.Load())
+	}
+}


### PR DESCRIPTION
## Summary

Adds Go crash resume conformance for RunStep: R01 style (no second model call after decision seal) and R02 style (block non idempotent re-entry after TOOL_CALL). Includes a crashagent fixture for hard kill tests and in-process proofs that always run.

Closes #22

## Related issues

Closes #22

## How I tested

```bash
cd go
go test ./trajir/... ./conformance -count=1 -timeout 120s
```

In-process R01/R02 passed. Subprocess tests skipped on this Windows host when Application Control blocks the built binary; Linux CI is expected to run them.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: tests only for seal resume and gate behaviour (no production policy change)

## AI assistance (if any)

Assisted fixture and harness layout. Reviewed against Python conformance intent and Go RunStep/gate APIs.

## What landed

1. go/cmd/crashagent fixture (markers, counters, LocalSQLite + NodeLog)
2. go/conformance subprocess R01/R02 (hard kill, skip if exec blocked)
3. go/conformance in-process R01 (panic after seal) and R02 (pre-seeded TOOL_CALL)
4. go/README note; gitignore go/.bin/

## Out of scope

1. Temporal adapter
2. Multi step client SDK
3. Changing Python conformance