### PR TITLE
feat: Go client SDK open project seal exec resume (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go RunStep seal path (project, durable infer, DECISION, tools, COMMIT_STEP).
 - Go crash resume conformance tests (R01/R02 style) via cmd/crashagent.
 - Go Temporal durable backend adapter under `go/trajir/durable/temporal` (optional cluster).
+- Go client SDK under `go/trajir/client` (open, project, seal, exec, commit, resume, RunStep).
+
 
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -12,6 +12,7 @@ Second language implementation of Trajectory IR primitives. Python remains the P
 | `trajir/durable` | Pluggable step memoization backend |
 | `trajir/durable/temporal` | Temporal Backend + worker registration |
 | `trajir/resume` | Block and gate, and RunStep seal path for one agent step |
+| `trajir/client` | Thin SDK: open, project, seal, exec, commit, resume, RunStep |
 
 ## Durable backend decision (issues #16 and #24)
 
@@ -41,6 +42,26 @@ Default `go test ./...` does **not** need Temporal. Optional live check:
 # with Temporal listening on localhost:7233 and a worker on trajectory-ir
 go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v
 ```
+
+## Client usage
+
+```go
+tr, err := client.OpenTrajectory("demo", "t1", client.Options{WorkDir: dir})
+// ...
+results, err := tr.RunStep(ctx, 1, model, tools, map[string]any{"k": "v"})
+// reopen same workdir
+tr2, err := client.Resume("demo", "t1", client.Options{WorkDir: dir})
+```
+
+| Go | Python |
+|----|--------|
+| `OpenTrajectory` | `open_trajectory` |
+| `Resume` | `resume` |
+| `Project` | `project` |
+| `SealDecision` | `seal_decision` |
+| `ExecTool` | `exec_tool` |
+| `CommitStep` | `commit_step` |
+| `RunStep` | full step via runtime (convenience) |
 
 ## Test
 

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -1,0 +1,252 @@
+// Package client is a thin Go surface over Trajectory IR primitives.
+//
+// Python mapping (client/python/trajectory_client.py):
+//
+//	OpenTrajectory  ~ open_trajectory
+//	Resume          ~ resume
+//	Project         ~ project
+//	SealDecision    ~ seal_decision
+//	ExecTool        ~ exec_tool
+//	CommitStep      ~ commit_step
+//	RunStep         ~ full sealed step (resume.RunStep convenience)
+package client
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+// Options configure workdir paths and optional durable backend injection.
+type Options struct {
+	// WorkDir holds default relative paths for sqlite files when set.
+	WorkDir string
+	// NodesPath is the NodeLog sqlite path. Default: WorkDir/nodes.sqlite or nodes.sqlite.
+	NodesPath string
+	// MemoPath is the LocalSQLite durable memo path. Default: WorkDir/memo.sqlite or memo.sqlite.
+	MemoPath string
+	// WorkflowID scopes durable memo keys. Default: TrajectoryID.
+	WorkflowID string
+	// Backend overrides LocalSQLite when non nil. Caller owns Close unless Open created it.
+	Backend durable.Backend
+}
+
+// Trajectory is an open IR run handle.
+type Trajectory struct {
+	TrajectoryID string
+	TenantID     string
+	WorkflowID   string
+
+	log         *nodelog.NodeLog
+	backend     durable.Backend
+	ownsBackend bool
+	ownsLog     bool
+}
+
+// ProjectContext is returned by Project.
+type ProjectContext struct {
+	StepN   int
+	Context map[string]any
+}
+
+// Decision is returned by SealDecision.
+type Decision struct {
+	StepN int
+	Plan  map[string]any
+}
+
+// ToolResult is returned by ExecTool.
+type ToolResult struct {
+	StepN  int
+	Result any
+}
+
+// OpenTrajectory opens or creates log and durable memo stores for a trajectory.
+func OpenTrajectory(tenantID, trajectoryID string, opts Options) (*Trajectory, error) {
+	if tenantID == "" || trajectoryID == "" {
+		return nil, fmt.Errorf("client: tenantID and trajectoryID are required")
+	}
+	nodesPath, memoPath := resolvePaths(opts)
+	wf := opts.WorkflowID
+	if wf == "" {
+		wf = trajectoryID
+	}
+
+	nl, err := nodelog.Open(nodesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var backend durable.Backend
+	ownsBackend := false
+	if opts.Backend != nil {
+		backend = opts.Backend
+	} else {
+		backend, err = durable.OpenLocal(memoPath)
+		if err != nil {
+			_ = nl.Close()
+			return nil, err
+		}
+		ownsBackend = true
+	}
+
+	return &Trajectory{
+		TrajectoryID: trajectoryID,
+		TenantID:     tenantID,
+		WorkflowID:   wf,
+		log:          nl,
+		backend:      backend,
+		ownsBackend:  ownsBackend,
+		ownsLog:      true,
+	}, nil
+}
+
+// Resume reopens the same stores as OpenTrajectory (same options and ids).
+func Resume(tenantID, trajectoryID string, opts Options) (*Trajectory, error) {
+	return OpenTrajectory(tenantID, trajectoryID, opts)
+}
+
+// Close releases owned resources.
+func (t *Trajectory) Close() error {
+	var first error
+	if t.ownsLog && t.log != nil {
+		if err := t.log.Close(); err != nil && first == nil {
+			first = err
+		}
+		t.log = nil
+	}
+	if t.ownsBackend && t.backend != nil {
+		if err := t.backend.Close(); err != nil && first == nil {
+			first = err
+		}
+		t.backend = nil
+	}
+	return first
+}
+
+// Project appends PROJECT_CONTEXT at seq 0 for the step.
+func (t *Trajectory) Project(stepN int, context map[string]any) (*ProjectContext, error) {
+	if context == nil {
+		context = map[string]any{}
+	}
+	step := stepN
+	if _, err := t.log.Append(
+		"PROJECT_CONTEXT",
+		&step,
+		context,
+		t.TrajectoryID,
+		t.TenantID,
+		0,
+	); err != nil {
+		return nil, err
+	}
+	return &ProjectContext{StepN: stepN, Context: context}, nil
+}
+
+// SealDecision appends DECISION at seq 1 for the step.
+func (t *Trajectory) SealDecision(stepN int, plan map[string]any) (*Decision, error) {
+	if plan == nil {
+		plan = map[string]any{}
+	}
+	step := stepN
+	if _, err := t.log.Append(
+		"DECISION",
+		&step,
+		map[string]any{"plan": plan},
+		t.TrajectoryID,
+		t.TenantID,
+		1,
+	); err != nil {
+		return nil, err
+	}
+	return &Decision{StepN: stepN, Plan: plan}, nil
+}
+
+// ExecTool runs one tool at the given seq (caller supplies unique seq; 2+2*i is typical).
+func (t *Trajectory) ExecTool(stepN, seq int, tool resume.Tool, args map[string]any) (*ToolResult, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	fn := tool.Fn
+	if tool.Effect == effects.NON_IDEMPOTENT_WRITE {
+		fn = resume.MakeGatedToolCall(
+			t.log,
+			t.TrajectoryID,
+			t.TenantID,
+			stepN,
+			seq,
+			tool.Name,
+			tool.Fn,
+		)
+	}
+	result, err := fn(args)
+	if err != nil {
+		return nil, err
+	}
+	return &ToolResult{StepN: stepN, Result: result}, nil
+}
+
+// CommitStep appends COMMIT_STEP at seq (typically 2+2*numTools).
+func (t *Trajectory) CommitStep(stepN, seq int) error {
+	step := stepN
+	_, err := t.log.Append(
+		"COMMIT_STEP",
+		&step,
+		map[string]any{},
+		t.TrajectoryID,
+		t.TenantID,
+		seq,
+	)
+	return err
+}
+
+// RunStep runs a full sealed step via resume.RunStep (project, infer, decision, tools, commit).
+func (t *Trajectory) RunStep(
+	ctx context.Context,
+	stepN int,
+	model resume.ModelFunc,
+	tools map[string]resume.Tool,
+	stepContext map[string]any,
+) ([]any, error) {
+	cfg := resume.RunStepConfig{
+		Log:          t.log,
+		Backend:      t.backend,
+		TenantID:     t.TenantID,
+		TrajectoryID: t.TrajectoryID,
+		WorkflowID:   t.WorkflowID,
+		Tools:        tools,
+	}
+	return resume.RunStep(ctx, cfg, stepN, model, stepContext)
+}
+
+// Log exposes the underlying NodeLog for advanced tests.
+func (t *Trajectory) Log() *nodelog.NodeLog { return t.log }
+
+// Backend exposes the durable backend for advanced tests.
+func (t *Trajectory) Backend() durable.Backend { return t.backend }
+
+func resolvePaths(opts Options) (nodesPath, memoPath string) {
+	base := opts.WorkDir
+	nodesPath = opts.NodesPath
+	memoPath = opts.MemoPath
+	if nodesPath == "" {
+		if base != "" {
+			nodesPath = filepath.Join(base, "nodes.sqlite")
+		} else {
+			nodesPath = "nodes.sqlite"
+		}
+	}
+	if memoPath == "" {
+		if base != "" {
+			memoPath = filepath.Join(base, "memo.sqlite")
+		} else {
+			memoPath = "memo.sqlite"
+		}
+	}
+	return nodesPath, memoPath
+}

--- a/go/trajir/client/client_test.go
+++ b/go/trajir/client/client_test.go
@@ -1,0 +1,118 @@
+package client_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/client"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+func TestOpenProjectSealCommit(t *testing.T) {
+	dir := t.TempDir()
+	tr, err := client.OpenTrajectory("demo", "t1", client.Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Close()
+
+	if _, err := tr.Project(1, map[string]any{"k": "v"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tr.SealDecision(1, map[string]any{
+		"tool_calls": []any{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.CommitStep(1, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := tr.Log().Has("t1", 1, "DECISION", nil)
+	if err != nil || !ok {
+		t.Fatalf("DECISION present=%v err=%v", ok, err)
+	}
+	ok, err = tr.Log().Has("t1", 1, "COMMIT_STEP", nil)
+	if err != nil || !ok {
+		t.Fatalf("COMMIT_STEP present=%v err=%v", ok, err)
+	}
+}
+
+func TestRunStepAndResumeNoSecondModelCall(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	opts := client.Options{WorkDir: dir, WorkflowID: "wf-client"}
+
+	var modelCalls atomic.Int32
+	tools := map[string]resume.Tool{
+		"echo": {
+			Name:   "echo",
+			Effect: effects.PURE,
+			Fn:     func(args map[string]any) (any, error) { return args["msg"], nil },
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		modelCalls.Add(1)
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "echo", "args": map[string]any{"msg": "hi"}},
+			},
+		}, nil
+	}
+
+	tr, err := client.OpenTrajectory("demo", "t1", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results, err := tr.RunStep(ctx, 1, model, tools, map[string]any{"a": 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0] != "hi" {
+		t.Fatalf("results=%#v", results)
+	}
+	_ = tr.Close()
+
+	tr2, err := client.Resume("demo", "t1", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr2.Close()
+	if _, err := tr2.RunStep(ctx, 1, model, tools, map[string]any{"a": 1}); err != nil {
+		t.Fatal(err)
+	}
+	if modelCalls.Load() != 1 {
+		t.Fatalf("model calls=%d, want 1", modelCalls.Load())
+	}
+}
+
+func TestExecToolGated(t *testing.T) {
+	dir := t.TempDir()
+	tr, err := client.OpenTrajectory("demo", "t1", client.Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Close()
+
+	var n atomic.Int32
+	tool := resume.Tool{
+		Name:   "deploy_server",
+		Effect: effects.NON_IDEMPOTENT_WRITE,
+		Fn: func(map[string]any) (any, error) {
+			n.Add(1)
+			return "ok", nil
+		},
+	}
+	if _, err := tr.ExecTool(1, 2, tool, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = tr.ExecTool(1, 2, tool, map[string]any{})
+	if err == nil {
+		t.Fatal("expected block on second exec")
+	}
+	if n.Load() != 1 {
+		t.Fatalf("side effects=%d", n.Load())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a thin Go client SDK so callers can open a trajectory, run a sealed step, and resume without wiring packages by hand. Maps to the Python six call surface plus a RunStep convenience.

Closes #26

## Related issues

Closes #26

## How I tested

```bash
cd go
go test ./trajir/client ./trajir/resume ./trajir/log ./trajir/durable -count=1 -v
```

All listed packages passed.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: client wraps seal path and gated ExecTool (no new gate rules)

## AI assistance (if any)

Assisted package layout against client/python/trajectory_client.py and existing Go primitives. Reviewed API mapping table in go/README.md.

## What landed

1. go/trajir/client: OpenTrajectory, Resume, Project, SealDecision, ExecTool, CommitStep, RunStep
2. Default LocalSQLite memo + NodeLog under WorkDir
3. Optional Backend injection for Temporal later
4. Tests: open/project/seal/commit, RunStep resume without second model call, gated ExecTool
5. go/README usage snippet and Python name mapping

## Out of scope

1. Restate adapter
2. HTTP API server
3. Changing Python client