### PR TITLE
feat: Go kill mid deploy demo using trajir client (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go Temporal durable backend adapter under `go/trajir/durable/temporal` (optional cluster).
 - Go client SDK under `go/trajir/client` (open, project, seal, exec, commit, resume, RunStep).
 - Dependabot for Go, pip, and Actions; CI hash golden gates and govulncheck; CONTRIBUTING Go section.
+- Go kill mid deploy demo under `go/examples/kill-mid-deploy` using trajir/client.
+
 
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -53,6 +53,19 @@ results, err := tr.RunStep(ctx, 1, model, tools, map[string]any{"k": "v"})
 tr2, err := client.Resume("demo", "t1", client.Options{WorkDir: dir})
 ```
 
+## Demo: kill mid deploy
+
+Human runnable story (seal, kill, resume):
+
+```bash
+cd go
+go run ./examples/kill-mid-deploy -workdir ./kill-mid-deploy-data -crash-during=tool_call
+# kill when deploy starts, then:
+go run ./examples/kill-mid-deploy -workdir ./kill-mid-deploy-data -resume
+```
+
+See [examples/kill-mid-deploy/README.md](examples/kill-mid-deploy/README.md).
+
 | Go | Python |
 |----|--------|
 | `OpenTrajectory` | `open_trajectory` |

--- a/go/examples/kill-mid-deploy/README.md
+++ b/go/examples/kill-mid-deploy/README.md
@@ -1,0 +1,72 @@
+# Go demo: kill mid deploy
+
+Shows honest seal and resume for Trajectory IR in Go (same story as the Python demo under `examples/kill-mid-deploy/`).
+
+Uses `trajir/client` with LocalSQLite for the IR log and durable step memos.
+
+## What you should see
+
+1. Model seals a deploy plan (DECISION).
+2. `deploy_server` starts (NON_IDEMPOTENT_WRITE).
+3. You kill the process mid flight.
+4. On `-resume`, the model is not asked again after seal, and a mid tool crash does not silently re-run deploy (block and gate).
+
+## Setup
+
+From the repo root:
+
+```bash
+cd go
+```
+
+## Crash during deploy (R02 style)
+
+Terminal 1:
+
+```bash
+go run ./examples/kill-mid-deploy -workdir ./kill-mid-deploy-data -crash-during=tool_call
+```
+
+When you see `TOOL_CALL: deploy_server started`, kill the process:
+
+```bash
+# Unix / Git Bash
+kill -9 <pid>
+
+# Windows PowerShell (another window)
+# find PID from the go run process tree, then:
+Stop-Process -Id <pid> -Force
+```
+
+Terminal 1 again (or a new one):
+
+```bash
+go run ./examples/kill-mid-deploy -workdir ./kill-mid-deploy-data -resume
+```
+
+Expect a `BLOCKED_NEEDS_GATE` line and `deploy_count=0` (effect never completed; gate refuses a blind retry).
+
+## Crash after decision seal (R01 style)
+
+```bash
+go run ./examples/kill-mid-deploy -workdir ./kill-mid-deploy-data2 -crash-after=decision_sealed
+# kill when you see DECISION sealed
+go run ./examples/kill-mid-deploy -workdir ./kill-mid-deploy-data2 -resume
+```
+
+Expect `model_count=1` across both runs and a completed deploy on resume (`deploy_count=1`).
+
+## Clean workdir
+
+```bash
+# Unix
+rm -rf ./kill-mid-deploy-data
+
+# PowerShell
+Remove-Item -Recurse -Force .\kill-mid-deploy-data
+```
+
+## Related
+
+- CI style tests: `go test ./conformance`
+- Fixture binary also used by tests: `go/cmd/crashagent`

--- a/go/examples/kill-mid-deploy/main.go
+++ b/go/examples/kill-mid-deploy/main.go
@@ -1,0 +1,170 @@
+// Command kill-mid-deploy is the human runnable Go demo for honest seal resume.
+//
+//	go run ./examples/kill-mid-deploy -workdir ./demo-run -crash-during=tool_call
+//	# kill the process when you see the tool started line
+//	go run ./examples/kill-mid-deploy -workdir ./demo-run -resume
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/client"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+const (
+	tenantID     = "demo"
+	trajectoryID = "go-kill-mid-deploy"
+	workflowID   = "go-kill-mid-deploy-wf"
+	crashWindow  = 45 * time.Second
+)
+
+func main() {
+	workdir := flag.String("workdir", "./kill-mid-deploy-data", "directory for sqlite files and counters")
+	crashAfter := flag.String("crash-after", "", "decision_sealed: idle after DECISION so you can kill")
+	crashDuring := flag.String("crash-during", "", "tool_call: idle inside deploy so you can kill")
+	resumeMode := flag.Bool("resume", false, "reopen the same workdir and continue")
+	flag.Parse()
+
+	if err := os.MkdirAll(*workdir, 0o755); err != nil {
+		fail(err)
+	}
+
+	fmt.Println("Trajectory IR Go demo: kill mid deploy")
+	fmt.Printf("workdir: %s\n", *workdir)
+	if *resumeMode {
+		fmt.Println("mode: resume")
+	} else {
+		fmt.Println("mode: first run")
+	}
+
+	tr, err := openHandle(*workdir, *resumeMode)
+	if err != nil {
+		fail(err)
+	}
+	defer tr.Close()
+
+	crashDuringTool := strings.EqualFold(*crashDuring, "tool_call")
+	crashAfterSeal := strings.EqualFold(*crashAfter, "decision_sealed")
+
+	tools := map[string]resume.Tool{
+		"deploy_server": {
+			Name:   "deploy_server",
+			Effect: effects.NON_IDEMPOTENT_WRITE,
+			Fn: func(args map[string]any) (any, error) {
+				path := counterPath(*workdir, "tool_started.marker")
+				if err := os.WriteFile(path, []byte("started"), 0o644); err != nil {
+					return nil, err
+				}
+				fmt.Println("TOOL_CALL: deploy_server started")
+				fmt.Println(">>> Kill this process now (Ctrl+C or kill -9 / taskkill), then re-run with -resume")
+				if crashDuringTool && !*resumeMode {
+					time.Sleep(crashWindow)
+				}
+				if _, err := bumpCounter(counterPath(*workdir, "deploy_count.txt")); err != nil {
+					return nil, err
+				}
+				fmt.Println("TOOL_RESULT: deploy finished")
+				return map[string]any{"deployed": args["version"]}, nil
+			},
+		},
+	}
+
+	model := func(ctx context.Context, _ map[string]any) (map[string]any, error) {
+		if _, err := bumpCounter(counterPath(*workdir, "model_count.txt")); err != nil {
+			return nil, err
+		}
+		fmt.Println("INFERENCE: model produced a deploy plan")
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{
+					"name": "deploy_server",
+					"args": map[string]any{"version": "1.0.0"},
+				},
+			},
+		}, nil
+	}
+
+	ctx := context.Background()
+	_, err = tr.RunStep(ctx, 1, model, tools, map[string]any{"demo": "kill-mid-deploy"}, client.RunStepOpts{
+		OnDecisionSealed: func() {
+			path := counterPath(*workdir, "decision_sealed.marker")
+			_ = os.WriteFile(path, []byte("sealed"), 0o644)
+			fmt.Println("DECISION sealed (plan frozen; resume must not re-ask the model for this step)")
+			if crashAfterSeal && !*resumeMode {
+				fmt.Println(">>> Kill this process now, then re-run with -resume")
+				time.Sleep(crashWindow)
+			}
+		},
+	})
+	if err != nil {
+		var blocked *resume.BlockedNeedsGate
+		if errors.As(err, &blocked) {
+			fmt.Printf("BLOCKED_NEEDS_GATE: %s\n", blocked.Error())
+			fmt.Println("Honest resume: non idempotent deploy was not silently re-run.")
+			printCounters(*workdir)
+			os.Exit(0)
+		}
+		fail(err)
+	}
+
+	if *resumeMode {
+		fmt.Println("Resumed. Step committed.")
+	} else {
+		fmt.Println("Step committed (no kill).")
+	}
+	printCounters(*workdir)
+}
+
+func openHandle(workdir string, resumeMode bool) (*client.Trajectory, error) {
+	opts := client.Options{
+		WorkDir:    workdir,
+		WorkflowID: workflowID,
+	}
+	if resumeMode {
+		return client.Resume(tenantID, trajectoryID, opts)
+	}
+	return client.OpenTrajectory(tenantID, trajectoryID, opts)
+}
+
+func counterPath(workdir, name string) string {
+	return workdir + string(os.PathSeparator) + name
+}
+
+func bumpCounter(path string) (int, error) {
+	n := 0
+	if b, err := os.ReadFile(path); err == nil {
+		n, _ = strconv.Atoi(strings.TrimSpace(string(b)))
+	}
+	n++
+	return n, os.WriteFile(path, []byte(strconv.Itoa(n)), 0o644)
+}
+
+func printCounters(workdir string) {
+	fmt.Printf("model_count=%d deploy_count=%d\n",
+		readCounter(counterPath(workdir, "model_count.txt")),
+		readCounter(counterPath(workdir, "deploy_count.txt")),
+	)
+}
+
+func readCounter(path string) int {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return n
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "error:", err)
+	os.Exit(1)
+}

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -205,6 +205,11 @@ func (t *Trajectory) CommitStep(stepN, seq int) error {
 	return err
 }
 
+// RunStepOpts are optional hooks for RunStep (demo and tests).
+type RunStepOpts struct {
+	OnDecisionSealed func()
+}
+
 // RunStep runs a full sealed step via resume.RunStep (project, infer, decision, tools, commit).
 func (t *Trajectory) RunStep(
 	ctx context.Context,
@@ -212,6 +217,7 @@ func (t *Trajectory) RunStep(
 	model resume.ModelFunc,
 	tools map[string]resume.Tool,
 	stepContext map[string]any,
+	opts ...RunStepOpts,
 ) ([]any, error) {
 	cfg := resume.RunStepConfig{
 		Log:          t.log,
@@ -220,6 +226,9 @@ func (t *Trajectory) RunStep(
 		TrajectoryID: t.TrajectoryID,
 		WorkflowID:   t.WorkflowID,
 		Tools:        tools,
+	}
+	if len(opts) > 0 {
+		cfg.OnDecisionSealed = opts[0].OnDecisionSealed
 	}
 	return resume.RunStep(ctx, cfg, stepN, model, stepContext)
 }


### PR DESCRIPTION
## Summary

Adds a human runnable Go kill mid deploy demo on trajir/client: seal a non idempotent deploy, kill mid flight, resume honestly. Includes README for Windows and Unix and a small client hook for the decision sealed crash point.

Closes #33

## Related issues

Closes #33

## How I tested

```bash
cd go
go test ./trajir/client -count=1
go build -o .bin/kill-mid-deploy-demo ./examples/kill-mid-deploy
```

Build and client tests passed.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: demo of seal and gate only (no new gate rules)

## AI assistance (if any)

Assisted demo wiring from crashagent patterns and client API. Reviewed crash point behaviour against R01/R02 intent.

## What landed

1. go/examples/kill-mid-deploy main + README
2. client.RunStepOpts.OnDecisionSealed for the seal crash window
3. go/README Demo section

## Out of scope

1. Temporal required for the demo
2. Changing Python demo
3. New CI hard kill job (conformance already covers automated paths)