### PR TITLE
feat: Python .tir export and import thin and fat (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot for Go, pip, and Actions; CI hash golden gates and govulncheck; CONTRIBUTING Go section.
 - Go kill mid deploy demo under `go/examples/kill-mid-deploy` using trajir/client.
 - Dependabot DCO exclusion in CI; Actions and modernc.org/sqlite dependency bumps.
+- Python `.tir` thin/fat export and import with node hash verification (R05).
+
 
 
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -78,6 +78,27 @@ python agent.py
 
 Because of the **Block-and-Gate** policy, if your agent crashes inside `deploy_server`, the next time you run `python agent.py`, it will recognize the interrupted `NON_IDEMPOTENT_WRITE` and halt execution, requesting human intervention rather than blindly repeating the destructive action.
 
+## Export and import a `.tir` package
+
+Portable thin/fat packages (master README §9, R05):
+
+```python
+from trajectory_ir.package import export_tir, import_tir, ArtifactRef
+from trajectory_ir.runtime.log import NodeLog
+
+src = NodeLog("run.sqlite")
+# ... append nodes for trajectory_id="t1" ...
+
+export_tir(src, "t1", "run.tir", mode="thin")
+
+dst = NodeLog("imported.sqlite")
+pkg = import_tir("run.tir", dst)  # verifies node ids; appends idempotently
+print(pkg.manifest["node_count"], pkg.manifest["mode"])
+```
+
+Fat mode embeds artifact bytes when you pass `artifacts=` and `artifact_bytes=`.
+Import fails if any node id does not match RFC 8785 + SHA-256 identity rules.
+
 ## What's Next?
 - Read the [Infrastructure Design](infrastructure.md) to learn how to scale this to `server-s3` or `k8s-fluid`.
 - Read the [Contributing Guide](CONTRIBUTING.md) if you want to help build the project!

--- a/pkg/trajectory_ir/package/__init__.py
+++ b/pkg/trajectory_ir/package/__init__.py
@@ -1,0 +1,25 @@
+"""Portable `.tir` package export and import."""
+
+from trajectory_ir.package.tir import (
+    COMPAT,
+    PACKAGE_FORMAT_VERSION,
+    ArtifactRef,
+    TirError,
+    TirPackage,
+    TirVerificationError,
+    export_tir,
+    import_tir,
+    load_tir,
+)
+
+__all__ = [
+    "COMPAT",
+    "PACKAGE_FORMAT_VERSION",
+    "ArtifactRef",
+    "TirError",
+    "TirPackage",
+    "TirVerificationError",
+    "export_tir",
+    "import_tir",
+    "load_tir",
+]

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -143,9 +143,7 @@ def export_tir(
         for ref in artifacts:
             data = artifact_bytes.get(ref.content_hash)
             if data is None:
-                raise TirError(
-                    f"fat export missing bytes for content_hash={ref.content_hash}"
-                )
+                raise TirError(f"fat export missing bytes for content_hash={ref.content_hash}")
             if _content_hash(data) != ref.content_hash:
                 raise TirError(f"artifact bytes do not match content_hash={ref.content_hash}")
     else:
@@ -167,7 +165,9 @@ def export_tir(
             "logical_path": a.logical_path,
             "content_hash": a.content_hash,
             "uri": a.uri,
-            "size": a.size if a.size is not None else (
+            "size": a.size
+            if a.size is not None
+            else (
                 len(artifact_bytes[a.content_hash]) if a.content_hash in artifact_bytes else None
             ),
         }
@@ -250,9 +250,7 @@ def load_tir(path: str | Path, *, verify: bool = True) -> TirPackage:
             if got is None:
                 raise TirVerificationError(f"missing seal for decision node {exp['node_id']}")
             if got.get("content_hash") != exp["content_hash"]:
-                raise TirVerificationError(
-                    f"seal content_hash mismatch for {exp['node_id']}"
-                )
+                raise TirVerificationError(f"seal content_hash mismatch for {exp['node_id']}")
         mode = manifest.get("mode", "thin")
         if mode == "fat":
             for entry in artifacts_manifest:
@@ -296,9 +294,7 @@ def import_tir(
         )
         # Node regenerates id from payload; must equal package record.
         if node.id != n["id"]:
-            raise TirVerificationError(
-                f"rebuilt node id {node.id} != package id {n['id']}"
-            )
+            raise TirVerificationError(f"rebuilt node id {node.id} != package id {n['id']}")
         node_log.append(
             node.kind,
             node.step_n,

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -1,0 +1,310 @@
+"""Portable `.tir` package export and import (thin and fat modes).
+
+Layout (master README §9):
+
+    manifest.json
+    nodes.ndjson
+    seals.json
+    artifacts-manifest.json
+    artifacts/          # fat only
+    COMPAT.json
+    # SIGNATURE intentionally omitted (reserved, unimplemented)
+
+Import verifies every node id against runtime.nodes hashing (R05 spirit).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.nodes import Node, node_id, payload_hash
+
+PackageMode = Literal["thin", "fat"]
+
+PACKAGE_FORMAT_VERSION = "0.1"
+COMPAT = {
+    "package_format": PACKAGE_FORMAT_VERSION,
+    "min_runtime": "0.1.0",
+    "node_id_scheme": "sha256(tenant|trajectory|step|seq|kind|payload_hash)",
+    "payload_hash_scheme": "sha256(rfc8785(payload))",
+}
+
+
+class TirError(Exception):
+    """Base error for package operations."""
+
+
+class TirVerificationError(TirError):
+    """Raised when import finds a hash or structural mismatch."""
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """One artifact entry for thin or fat packages."""
+
+    logical_path: str
+    content_hash: str
+    uri: str | None = None  # thin: where to rehydrate from
+    size: int | None = None
+
+
+@dataclass
+class TirPackage:
+    """In-memory representation of a verified package."""
+
+    manifest: dict[str, Any]
+    nodes: list[dict[str, Any]]
+    seals: list[dict[str, Any]]
+    artifacts_manifest: list[dict[str, Any]]
+    artifact_bytes: dict[str, bytes]  # content_hash -> bytes (fat only)
+
+
+def _content_hash(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _verify_node_record(rec: dict[str, Any]) -> None:
+    """Recompute id from fields; raise if it does not match the stored id."""
+    payload = rec["payload"]
+    if not isinstance(payload, dict):
+        raise TirVerificationError(f"node {rec.get('id')}: payload must be an object")
+    try:
+        ph = payload_hash(payload)
+    except AssertionError as e:
+        raise TirVerificationError(f"node {rec.get('id')}: {e}") from e
+    expected = node_id(
+        rec["tenant_id"],
+        rec["trajectory_id"],
+        rec.get("step_n"),
+        int(rec["seq"]),
+        rec["kind"],
+        ph,
+    )
+    if rec.get("id") != expected:
+        raise TirVerificationError(
+            f"node id mismatch for kind={rec.get('kind')} seq={rec.get('seq')}: "
+            f"recorded={rec.get('id')} expected={expected}"
+        )
+    # Optional recorded payload_hash field
+    if "payload_hash" in rec and rec["payload_hash"] != ph:
+        raise TirVerificationError(
+            f"payload_hash mismatch for node {rec.get('id')}: "
+            f"recorded={rec['payload_hash']} expected={ph}"
+        )
+
+
+def _seals_from_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """DECISION rows act as decision seals in the current runtime (content-addressed append)."""
+    seals: list[dict[str, Any]] = []
+    for n in nodes:
+        if n["kind"] == "DECISION":
+            seals.append(
+                {
+                    "type": "DECISION_SEAL",
+                    "node_id": n["id"],
+                    "step_n": n.get("step_n"),
+                    "seq": n["seq"],
+                    "content_hash": payload_hash(n["payload"]),
+                }
+            )
+    return seals
+
+
+def export_tir(
+    node_log: NodeLog,
+    trajectory_id: str,
+    dest: str | Path,
+    *,
+    mode: PackageMode = "thin",
+    artifacts: list[ArtifactRef] | None = None,
+    artifact_bytes: dict[str, bytes] | None = None,
+) -> Path:
+    """Export a trajectory from ``node_log`` to a ``.tir`` zip at ``dest``."""
+    if mode not in ("thin", "fat"):
+        raise TirError(f"unsupported mode {mode!r}; use thin or fat")
+
+    nodes = node_log.list_nodes(trajectory_id)
+    if not nodes:
+        raise TirError(f"no nodes for trajectory_id={trajectory_id!r}")
+
+    tenant_id = nodes[0]["tenant_id"]
+    for n in nodes:
+        _verify_node_record(n)
+
+    artifacts = list(artifacts or [])
+    artifact_bytes = dict(artifact_bytes or {})
+    if mode == "fat":
+        for ref in artifacts:
+            data = artifact_bytes.get(ref.content_hash)
+            if data is None:
+                raise TirError(
+                    f"fat export missing bytes for content_hash={ref.content_hash}"
+                )
+            if _content_hash(data) != ref.content_hash:
+                raise TirError(f"artifact bytes do not match content_hash={ref.content_hash}")
+    else:
+        # thin: drop embedded bytes even if provided
+        artifact_bytes = {}
+
+    seals = _seals_from_nodes(nodes)
+    manifest = {
+        "package_format": PACKAGE_FORMAT_VERSION,
+        "trajectory_id": trajectory_id,
+        "tenant_id": tenant_id,
+        "mode": mode,
+        "node_count": len(nodes),
+        "seal_count": len(seals),
+        "signature": None,
+    }
+    artifacts_manifest = [
+        {
+            "logical_path": a.logical_path,
+            "content_hash": a.content_hash,
+            "uri": a.uri,
+            "size": a.size if a.size is not None else (
+                len(artifact_bytes[a.content_hash]) if a.content_hash in artifact_bytes else None
+            ),
+        }
+        for a in artifacts
+    ]
+
+    dest_path = Path(dest)
+    if dest_path.suffix != ".tir":
+        dest_path = dest_path.with_suffix(".tir")
+
+    with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        zf.writestr("COMPAT.json", json.dumps(COMPAT, indent=2, sort_keys=True) + "\n")
+        zf.writestr("seals.json", json.dumps(seals, indent=2, sort_keys=True) + "\n")
+        zf.writestr(
+            "artifacts-manifest.json",
+            json.dumps(artifacts_manifest, indent=2, sort_keys=True) + "\n",
+        )
+        ndjson = "".join(json.dumps(n, sort_keys=True) + "\n" for n in nodes)
+        zf.writestr("nodes.ndjson", ndjson)
+        if mode == "fat":
+            for h, data in artifact_bytes.items():
+                # sharded layout cas/ab/cdef... under artifacts/
+                shard = h[:2]
+                zf.writestr(f"artifacts/cas/{shard}/{h}", data)
+
+    return dest_path
+
+
+def load_tir(path: str | Path, *, verify: bool = True) -> TirPackage:
+    """Load and optionally verify a ``.tir`` zip without writing to a NodeLog."""
+    path = Path(path)
+    if not path.is_file():
+        raise TirError(f"package not found: {path}")
+
+    with zipfile.ZipFile(path, "r") as zf:
+        names = set(zf.namelist())
+        required = {
+            "manifest.json",
+            "nodes.ndjson",
+            "seals.json",
+            "artifacts-manifest.json",
+            "COMPAT.json",
+        }
+        missing = required - names
+        if missing:
+            raise TirError(f"package missing files: {sorted(missing)}")
+
+        manifest = json.loads(zf.read("manifest.json"))
+        seals = json.loads(zf.read("seals.json"))
+        artifacts_manifest = json.loads(zf.read("artifacts-manifest.json"))
+        nodes: list[dict[str, Any]] = []
+        for line in zf.read("nodes.ndjson").decode("utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            nodes.append(json.loads(line))
+
+        artifact_bytes: dict[str, bytes] = {}
+        for name in names:
+            if name.startswith("artifacts/cas/") and not name.endswith("/"):
+                data = zf.read(name)
+                h = Path(name).name
+                if _content_hash(data) != h:
+                    raise TirVerificationError(
+                        f"embedded artifact name {h} does not match content hash"
+                    )
+                artifact_bytes[h] = data
+
+    if verify:
+        if not nodes:
+            raise TirVerificationError("package has no nodes")
+        for n in nodes:
+            _verify_node_record(n)
+        expected_seals = _seals_from_nodes(nodes)
+        # Allow seals.json to be a subset or equal recomputation of DECISION seals
+        by_id = {s["node_id"]: s for s in seals}
+        for exp in expected_seals:
+            got = by_id.get(exp["node_id"])
+            if got is None:
+                raise TirVerificationError(f"missing seal for decision node {exp['node_id']}")
+            if got.get("content_hash") != exp["content_hash"]:
+                raise TirVerificationError(
+                    f"seal content_hash mismatch for {exp['node_id']}"
+                )
+        mode = manifest.get("mode", "thin")
+        if mode == "fat":
+            for entry in artifacts_manifest:
+                h = entry["content_hash"]
+                if h not in artifact_bytes:
+                    raise TirVerificationError(f"fat package missing artifact bytes {h}")
+        if mode == "thin" and artifact_bytes:
+            # thin packages should not embed bytes
+            raise TirVerificationError("thin package must not embed artifact bytes")
+
+    return TirPackage(
+        manifest=manifest,
+        nodes=nodes,
+        seals=seals,
+        artifacts_manifest=artifacts_manifest,
+        artifact_bytes=artifact_bytes,
+    )
+
+
+def import_tir(
+    path: str | Path,
+    node_log: NodeLog,
+    *,
+    verify: bool = True,
+) -> TirPackage:
+    """Verify a package and append its nodes into ``node_log`` (idempotent by id).
+
+    Does not acquire a writer lease (README §9).
+    """
+    pkg = load_tir(path, verify=verify)
+    for n in pkg.nodes:
+        # Rebuild via Node so append stores consistent fields; id must match.
+        node = Node(
+            kind=n["kind"],
+            trajectory_id=n["trajectory_id"],
+            tenant_id=n["tenant_id"],
+            step_n=n.get("step_n"),
+            seq=int(n["seq"]),
+            payload=n["payload"],
+            ts=float(n.get("ts") or 0.0),
+        )
+        # Node regenerates id from payload; must equal package record.
+        if node.id != n["id"]:
+            raise TirVerificationError(
+                f"rebuilt node id {node.id} != package id {n['id']}"
+            )
+        node_log.append(
+            node.kind,
+            node.step_n,
+            node.payload,
+            node.trajectory_id,
+            node.tenant_id,
+            node.seq,
+        )
+    return pkg

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from typing import Any
 
 from trajectory_ir.runtime.nodes import Node
 
@@ -90,6 +91,33 @@ class NodeLog:
     def count(self, node_id: str) -> int:
         cur = self._conn.execute("SELECT COUNT(*) FROM nodes WHERE id = ?", (node_id,))
         return cur.fetchone()[0]
+
+    def list_nodes(self, trajectory_id: str) -> list[dict[str, Any]]:
+        """Return all stored nodes for a trajectory ordered by step then seq."""
+        cur = self._conn.execute(
+            """
+            SELECT id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts
+            FROM nodes
+            WHERE trajectory_id = ?
+            ORDER BY COALESCE(step_n, -1), seq
+            """,
+            (trajectory_id,),
+        )
+        rows: list[dict[str, Any]] = []
+        for row in cur.fetchall():
+            rows.append(
+                {
+                    "id": row[0],
+                    "trajectory_id": row[1],
+                    "tenant_id": row[2],
+                    "step_n": row[3],
+                    "seq": row[4],
+                    "kind": row[5],
+                    "payload": json.loads(row[6]),
+                    "ts": row[7],
+                }
+            )
+        return rows
 
     def close(self):
         self._conn.close()

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -82,7 +82,11 @@ def test_export_import_round_trip_thin(sample_log: NodeLog, tmp_path: Path) -> N
         for n in pkg.nodes:
             assert payload_hash(n["payload"]) == payload_hash(
                 sample_log.list_nodes("t-export")[
-                    next(i for i, x in enumerate(sample_log.list_nodes("t-export")) if x["id"] == n["id"])
+                    next(
+                        i
+                        for i, x in enumerate(sample_log.list_nodes("t-export"))
+                        if x["id"] == n["id"]
+                    )
                 ]["payload"]
             )
         reloaded = dest.list_nodes("t-export")

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -1,0 +1,158 @@
+"""R05-style tests for .tir export / import."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from trajectory_ir.package import (
+    ArtifactRef,
+    TirVerificationError,
+    export_tir,
+    import_tir,
+    load_tir,
+)
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.nodes import payload_hash
+
+
+@pytest.fixture
+def sample_log(tmp_path: Path) -> NodeLog:
+    log = NodeLog(str(tmp_path / "src.sqlite"))
+    log.append(
+        "PROJECT_CONTEXT",
+        1,
+        {"goal": "demo"},
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=0,
+    )
+    log.append(
+        "DECISION",
+        1,
+        {"plan": {"tool_calls": [{"name": "echo", "args": {"msg": "hi"}}]}},
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=1,
+    )
+    log.append(
+        "TOOL_CALL",
+        1,
+        {"tool": "echo", "args": {"msg": "hi"}},
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=2,
+    )
+    log.append(
+        "TOOL_RESULT",
+        1,
+        {"result": "hi"},
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=3,
+    )
+    log.append(
+        "COMMIT_STEP",
+        1,
+        {},
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=4,
+    )
+    yield log
+    log.close()
+
+
+def test_export_import_round_trip_thin(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "run.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    assert out.is_file()
+
+    dest = NodeLog(str(tmp_path / "dest.sqlite"))
+    try:
+        pkg = import_tir(out, dest)
+        assert pkg.manifest["mode"] == "thin"
+        assert pkg.manifest["trajectory_id"] == "t-export"
+        assert len(pkg.nodes) == 5
+        assert dest.count(pkg.nodes[0]["id"]) == 1
+        # Round-trip preserves hashes
+        for n in pkg.nodes:
+            assert payload_hash(n["payload"]) == payload_hash(
+                sample_log.list_nodes("t-export")[
+                    next(i for i, x in enumerate(sample_log.list_nodes("t-export")) if x["id"] == n["id"])
+                ]["payload"]
+            )
+        reloaded = dest.list_nodes("t-export")
+        assert len(reloaded) == 5
+        assert [n["id"] for n in reloaded] == [n["id"] for n in sample_log.list_nodes("t-export")]
+    finally:
+        dest.close()
+
+
+def test_export_import_round_trip_fat(sample_log: NodeLog, tmp_path: Path) -> None:
+    blob = b"print('hello')\n"
+    h = __import__("hashlib").sha256(blob).hexdigest()
+    out = tmp_path / "fat.tir"
+    export_tir(
+        sample_log,
+        "t-export",
+        out,
+        mode="fat",
+        artifacts=[ArtifactRef(logical_path="src/main.py", content_hash=h)],
+        artifact_bytes={h: blob},
+    )
+    pkg = load_tir(out)
+    assert pkg.manifest["mode"] == "fat"
+    assert h in pkg.artifact_bytes
+    assert pkg.artifact_bytes[h] == blob
+
+
+def test_import_detects_tampered_node(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "good.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+
+    bad = tmp_path / "bad.tir"
+    with zipfile.ZipFile(out, "r") as zin, zipfile.ZipFile(bad, "w") as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if item.filename == "nodes.ndjson":
+                lines = data.decode().splitlines()
+                rec = json.loads(lines[1])
+                rec["payload"] = {"plan": {"tool_calls": [{"name": "evil"}]}}
+                # leave id as original so verification must fail
+                lines[1] = json.dumps(rec, sort_keys=True)
+                data = ("\n".join(lines) + "\n").encode()
+            zout.writestr(item, data)
+
+    with pytest.raises(TirVerificationError):
+        load_tir(bad)
+
+
+def test_idempotent_reimport(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "run.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    dest = NodeLog(str(tmp_path / "dest.sqlite"))
+    try:
+        import_tir(out, dest)
+        import_tir(out, dest)
+        assert len(dest.list_nodes("t-export")) == 5
+    finally:
+        dest.close()
+
+
+def test_thin_rejects_embedded_bytes(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "weird.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    # Manually inject an artifact path into a thin package
+    bad = tmp_path / "thin_with_bytes.tir"
+    with zipfile.ZipFile(out, "r") as zin, zipfile.ZipFile(bad, "w") as zout:
+        for item in zin.infolist():
+            zout.writestr(item, zin.read(item.filename))
+        h = "ab" + "0" * 62
+        zout.writestr(f"artifacts/cas/ab/{h}", b"nope")
+    # content hash of b"nope" won't match filename either — either error is fine
+    with pytest.raises(TirVerificationError):
+        load_tir(bad)


### PR DESCRIPTION
## Summary

Implements portable `.tir` packages for Python: export and import in thin and fat modes, with hard verification of node ids (and decision seal content hashes) on load. This is the R05 portability path from the master README.

Closes #35

## Related issues

Closes #35

## How I tested

```bash
pip install -e ".[dev]"
python -m pytest test/unit/test_tir_package.py test/unit -q
# 25 passed
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented signing scheme)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: package verifies decision seals and node identity; no change to live resume policy

## AI assistance (if any)

Assisted package layout against README §9. Reviewed hash verification against runtime.nodes.

## What landed

1. `trajectory_ir.package`: export_tir, load_tir, import_tir, ArtifactRef
2. Zip layout: manifest, nodes.ndjson, seals.json, artifacts-manifest, COMPAT, fat artifacts/cas/ab/hash
3. NodeLog.list_nodes for export
4. Tests: thin/fat round trip, tamper detection, idempotent reimport
5. QUICKSTART usage snippet

## Out of scope

1. Redacted mode
2. SIGNATURE crypto
3. Go .tir reader/writer