### PR TITLE
fix: security hardening for package load, gate races, identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go kill mid deploy demo under `go/examples/kill-mid-deploy` using trajir/client.
 - Dependabot DCO exclusion in CI; Actions and modernc.org/sqlite dependency bumps.
 - Python `.tir` thin/fat export and import with node hash verification (R05).
-
-
-
+- Security hardening: `.tir` zip size/path limits, atomic TOOL_CALL claim (Python + Go),
+  identity delimiter validation, tenant-scoped list/export, redacted export mode,
+  Temporal TLS/API key config, safer import verification API.
 
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,28 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 - **Cache Poisoning (`k8s-fluid` profile)**: Exploits where a stale or poisoned Fluid Dataset FUSE mount can trick the runtime into bypassing the direct S3/MinIO CAS hash-verification fallback.
 
 ### C. Data & Export Plane (`.tir` Packages)
-- **Sensitive Data Leakage**: Flaws where nodes marked with the `SENSITIVE` effect class fail to be stripped or hashed properly during a `redacted` `.tir` package export.
+- **Sensitive Data Leakage**: Flaws where secret-like fields or thoughts leak during a `redacted` `.tir` package export.
+- **Package resource exhaustion**: Zip bombs / oversized members must be rejected by load limits (`TirLimitError`).
+- **Unverified import**: `import_tir` always verifies; `load_tir(verify=False)` is disabled. Inspection without verification requires explicit `load_tir_unverified()` and must never write to a durable NodeLog.
+- **Integrity vs provenance**: Node hash verification proves content integrity, not publisher authenticity. Package signatures remain reserved / unimplemented until a cryptography-focused design lands.
+
+### D. Execution concurrency
+- **Block-and-gate races**: Claiming a `TOOL_CALL` slot must be atomic so concurrent workers cannot double-run a `NON_IDEMPOTENT_WRITE` tool (R02).
+
+### E. Implemented vs planned (be honest)
+| Control | Status |
+| ------- | ------ |
+| Fail-closed MCP effect mapping | Implemented |
+| Atomic TOOL_CALL claim (gate) | Implemented |
+| `.tir` size / path safety limits | Implemented |
+| Redacted export (secret-like keys + thoughts) | Implemented (basic) |
+| Package digital signatures | Not implemented (reserved) |
+| Full multi-tenant SaaS isolation | Not a product surface yet; tenant_id filter on list/export exists |
+| Fluid / k8s cache poisoning controls | Design only (future profile) |
+
+### F. Continuous dependency scanning
+- **Go**: `govulncheck ./...` runs in CI.
+- **Python**: maintainers should run `pip install pip-audit && pip-audit --skip-editable` in a clean venv after `pip install -e ".[dev]"` before release. Adding a permanent CI job requires a token with the GitHub `workflow` scope when editing `.github/workflows/ci.yml`.
 
 ## 4. Security Accountability for Contributors
 

--- a/go/trajir/durable/temporal/backend.go
+++ b/go/trajir/durable/temporal/backend.go
@@ -34,10 +34,7 @@ func Dial(ctx context.Context, cfg Config) (*Backend, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	c, err := client.Dial(client.Options{
-		HostPort:  cfg.HostPort,
-		Namespace: cfg.Namespace,
-	})
+	c, err := client.Dial(cfg.ClientOptions())
 	if err != nil {
 		return nil, fmt.Errorf("temporal dial: %w", err)
 	}

--- a/go/trajir/durable/temporal/config.go
+++ b/go/trajir/durable/temporal/config.go
@@ -1,20 +1,29 @@
 package temporal
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strings"
+
+	"go.temporal.io/sdk/client"
 )
 
 // Config holds Temporal client and worker settings.
-// Env defaults match a local Temporal dev server.
+// Env defaults match a local Temporal dev server (plaintext).
+// For production, set TEMPORAL_TLS=true and optionally TEMPORAL_API_KEY.
 type Config struct {
 	HostPort  string // e.g. localhost:7233
 	Namespace string // e.g. default
 	TaskQueue string // e.g. trajectory-ir
+	// TLS enables TLS on the Temporal frontend connection.
+	TLS bool
+	// APIKey is an optional Temporal Cloud API key (requires TLS).
+	APIKey string
 }
 
-// ConfigFromEnv reads TEMPORAL_HOSTPORT, TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE.
+// ConfigFromEnv reads TEMPORAL_HOSTPORT, TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE,
+// TEMPORAL_TLS, and TEMPORAL_API_KEY.
 func ConfigFromEnv() Config {
 	c := Config{
 		HostPort:  "localhost:7233",
@@ -30,10 +39,18 @@ func ConfigFromEnv() Config {
 	if v := strings.TrimSpace(os.Getenv("TEMPORAL_TASK_QUEUE")); v != "" {
 		c.TaskQueue = v
 	}
+	if v := strings.TrimSpace(os.Getenv("TEMPORAL_TLS")); v != "" {
+		c.TLS = strings.EqualFold(v, "1") || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+	}
+	if v := strings.TrimSpace(os.Getenv("TEMPORAL_API_KEY")); v != "" {
+		c.APIKey = v
+		// API keys imply TLS for Temporal Cloud.
+		c.TLS = true
+	}
 	return c
 }
 
-// Validate checks required fields.
+// Validate checks required fields and TLS/API key consistency.
 func (c Config) Validate() error {
 	if c.HostPort == "" {
 		return fmt.Errorf("temporal: HostPort is required")
@@ -44,7 +61,30 @@ func (c Config) Validate() error {
 	if c.TaskQueue == "" {
 		return fmt.Errorf("temporal: TaskQueue is required")
 	}
+	if c.APIKey != "" && !c.TLS {
+		return fmt.Errorf("temporal: APIKey requires TLS")
+	}
 	return nil
+}
+
+// ClientOptions builds SDK client options from this config.
+// Local defaults remain plaintext; production should enable TLS.
+func (c Config) ClientOptions() client.Options {
+	opts := client.Options{
+		HostPort:  c.HostPort,
+		Namespace: c.Namespace,
+	}
+	if c.TLS {
+		opts.ConnectionOptions = client.ConnectionOptions{
+			TLS: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+		}
+	}
+	if c.APIKey != "" {
+		opts.Credentials = client.NewAPIKeyStaticCredentials(c.APIKey)
+	}
+	return opts
 }
 
 // MemoWorkflowID builds a stable Temporal workflow id for one durable step memo.

--- a/go/trajir/durable/temporal/config_test.go
+++ b/go/trajir/durable/temporal/config_test.go
@@ -55,3 +55,35 @@ func TestValidateRejectsEmpty(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestConfigTLSAndAPIKeyFromEnv(t *testing.T) {
+	t.Setenv("TEMPORAL_TLS", "true")
+	t.Setenv("TEMPORAL_API_KEY", "test-key")
+	c := temporal.ConfigFromEnv()
+	if !c.TLS {
+		t.Fatal("expected TLS true")
+	}
+	if c.APIKey != "test-key" {
+		t.Fatalf("APIKey=%q", c.APIKey)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	opts := c.ClientOptions()
+	if opts.ConnectionOptions.TLS == nil {
+		t.Fatal("expected TLS config on client options")
+	}
+}
+
+func TestValidateAPIKeyRequiresTLS(t *testing.T) {
+	err := temporal.Config{
+		HostPort:  "x:7233",
+		Namespace: "default",
+		TaskQueue: "q",
+		APIKey:    "k",
+		TLS:       false,
+	}.Validate()
+	if err == nil {
+		t.Fatal("expected APIKey requires TLS")
+	}
+}

--- a/go/trajir/log/log.go
+++ b/go/trajir/log/log.go
@@ -43,7 +43,12 @@ CREATE TABLE IF NOT EXISTS nodes (
     kind TEXT NOT NULL,
     payload_json TEXT NOT NULL,
     ts REAL NOT NULL
-)`
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_slot
+ON nodes (tenant_id, trajectory_id, IFNULL(step_n, -1), seq, kind);
+CREATE INDEX IF NOT EXISTS idx_nodes_traj_tenant
+ON nodes (trajectory_id, tenant_id);
+`
 	if _, err := db.Exec(schema); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create schema: %w", err)
@@ -97,6 +102,77 @@ func (l *NodeLog) Append(
 	return n, nil
 }
 
+// ClaimToolCall atomically inserts a TOOL_CALL at (trajectory, step, seq).
+// Returns claimed=true if this caller owns the slot and may run the tool.
+// Returns claimed=false if the slot was already taken (block-and-gate).
+func (l *NodeLog) ClaimToolCall(
+	stepN int,
+	payload map[string]any,
+	trajectoryID, tenantID string,
+	seq int,
+) (claimed bool, err error) {
+	n, err := nodes.NewNode("TOOL_CALL", trajectoryID, tenantID, &stepN, seq, payload)
+	if err != nil {
+		return false, err
+	}
+	payloadJSON, err := json.Marshal(n.Payload)
+	if err != nil {
+		return false, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	tx, err := l.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var one int
+	qerr := tx.QueryRow(
+		`SELECT 1 FROM nodes WHERE tenant_id = ? AND trajectory_id = ? AND step_n = ? AND kind = ? AND seq = ? LIMIT 1`,
+		tenantID, trajectoryID, stepN, "TOOL_CALL", seq,
+	).Scan(&one)
+	if qerr == nil {
+		if err = tx.Commit(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if qerr != sql.ErrNoRows {
+		err = qerr
+		return false, err
+	}
+
+	_, err = tx.Exec(
+		`INSERT INTO nodes
+		 (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		n.ID,
+		n.TrajectoryID,
+		n.TenantID,
+		stepN,
+		n.Seq,
+		n.Kind,
+		string(payloadJSON),
+		n.TS,
+	)
+	if err != nil {
+		// Unique slot conflict under race: treat as not claimed.
+		_ = tx.Rollback()
+		return false, nil
+	}
+	if err = tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Has reports whether a node of kind exists for trajectory and step.
 // When seq is non nil, the match is limited to that sequence slot.
 func (l *NodeLog) Has(trajectoryID string, stepN int, kind string, seq *int) (bool, error) {
@@ -130,6 +206,60 @@ func (l *NodeLog) Count(nodeID string) (int, error) {
 	var n int
 	err := l.db.QueryRow(`SELECT COUNT(*) FROM nodes WHERE id = ?`, nodeID).Scan(&n)
 	return n, err
+}
+
+// ListNodes returns nodes for a trajectory, optionally scoped to tenantID.
+func (l *NodeLog) ListNodes(trajectoryID string, tenantID *string) ([]map[string]any, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	q := `SELECT id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts
+	      FROM nodes WHERE trajectory_id = ?`
+	args := []any{trajectoryID}
+	if tenantID != nil {
+		q += ` AND tenant_id = ?`
+		args = append(args, *tenantID)
+	}
+	q += ` ORDER BY COALESCE(step_n, -1), seq`
+
+	rows, err := l.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]map[string]any, 0)
+	for rows.Next() {
+		var (
+			id, traj, tenant, kind, payloadJSON string
+			stepN                               sql.NullInt64
+			seq                                 int
+			ts                                  float64
+		)
+		if err := rows.Scan(&id, &traj, &tenant, &stepN, &seq, &kind, &payloadJSON, &ts); err != nil {
+			return nil, err
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			return nil, err
+		}
+		rec := map[string]any{
+			"id":            id,
+			"trajectory_id": traj,
+			"tenant_id":     tenant,
+			"seq":           seq,
+			"kind":          kind,
+			"payload":       payload,
+			"ts":            ts,
+		}
+		if stepN.Valid {
+			rec["step_n"] = int(stepN.Int64)
+		} else {
+			rec["step_n"] = nil
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
 }
 
 // Close releases the database handle.

--- a/go/trajir/log/log_test.go
+++ b/go/trajir/log/log_test.go
@@ -154,3 +154,54 @@ func TestUnknownKindRejected(t *testing.T) {
 		t.Fatal("expected unknown kind error")
 	}
 }
+
+func TestClaimToolCallSingleWinner(t *testing.T) {
+	nl := openTemp(t)
+	claimed1, err := nl.ClaimToolCall(1, map[string]any{"tool": "a", "args": map[string]any{}}, "t1", "demo", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !claimed1 {
+		t.Fatal("first claim should win")
+	}
+	claimed2, err := nl.ClaimToolCall(1, map[string]any{"tool": "a", "args": map[string]any{}}, "t1", "demo", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed2 {
+		t.Fatal("second claim should lose")
+	}
+	seq := 2
+	ok, err := nl.Has("t1", 1, "TOOL_CALL", &seq)
+	if err != nil || !ok {
+		t.Fatalf("TOOL_CALL present=%v err=%v", ok, err)
+	}
+}
+
+func TestListNodesTenantFilter(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "a"}, "t1", "tenant-a", 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "b"}, "t1", "tenant-b", 2); err != nil {
+		t.Fatal(err)
+	}
+	tenant := "tenant-a"
+	rows, err := nl.ListNodes("t1", &tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0]["tenant_id"] != "tenant-a" {
+		t.Fatalf("rows=%v", rows)
+	}
+}
+
+func TestPipeInTenantRejected(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	_, err := nl.Append("DECISION", &step, map[string]any{"plan": "x"}, "t1", "a|b", 1)
+	if err == nil {
+		t.Fatal("expected delimiter rejection")
+	}
+}

--- a/go/trajir/nodes/nodes.go
+++ b/go/trajir/nodes/nodes.go
@@ -12,7 +12,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gowebpki/jcs"
 )
@@ -35,6 +37,24 @@ var NODE_KINDS = map[string]struct{}{
 	"COMMIT_STEP":     {},
 	"ABORT":           {},
 	"REDACTION":       {},
+}
+
+// ValidateIDComponent rejects empty values and characters that break the
+// '|' joined node_id preimage (delimiter / control injection).
+func ValidateIDComponent(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s must be a non-empty string", name)
+	}
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", name)
+	}
+	if strings.ContainsAny(value, "|\n\r\x00") {
+		return fmt.Errorf("%s must not contain '|' or control characters (identity delimiter safety)", name)
+	}
+	if len(value) > 512 {
+		return fmt.Errorf("%s exceeds maximum length 512", name)
+	}
+	return nil
 }
 
 // PayloadHash returns SHA-256 hex of the RFC 8785 canonical form of payload.
@@ -61,14 +81,20 @@ func PayloadHash(payload map[string]any) (string, error) {
 
 // NodeID builds the content-addressed id string used by the Python reference.
 // stepN nil is formatted as "None" so it matches Python f-string None.
-func NodeID(tenantID, trajectoryID string, stepN *int, seq int, kind, phash string) string {
+func NodeID(tenantID, trajectoryID string, stepN *int, seq int, kind, phash string) (string, error) {
+	if err := ValidateIDComponent("tenant_id", tenantID); err != nil {
+		return "", err
+	}
+	if err := ValidateIDComponent("trajectory_id", trajectoryID); err != nil {
+		return "", err
+	}
 	step := "None"
 	if stepN != nil {
 		step = strconv.Itoa(*stepN)
 	}
 	raw := fmt.Sprintf("%s|%s|%s|%d|%s|%s", tenantID, trajectoryID, step, seq, kind, phash)
 	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // Node is a hashed IR event. Identity fields are computed on construction.
@@ -89,10 +115,20 @@ func NewNode(kind, trajectoryID, tenantID string, stepN *int, seq int, payload m
 	if _, ok := NODE_KINDS[kind]; !ok {
 		return nil, fmt.Errorf("unknown node kind: %s", kind)
 	}
+	if err := ValidateIDComponent("tenant_id", tenantID); err != nil {
+		return nil, err
+	}
+	if err := ValidateIDComponent("trajectory_id", trajectoryID); err != nil {
+		return nil, err
+	}
 	if payload == nil {
 		payload = map[string]any{}
 	}
 	phash, err := PayloadHash(payload)
+	if err != nil {
+		return nil, err
+	}
+	id, err := NodeID(tenantID, trajectoryID, stepN, seq, kind, phash)
 	if err != nil {
 		return nil, err
 	}
@@ -105,6 +141,6 @@ func NewNode(kind, trajectoryID, tenantID string, stepN *int, seq int, payload m
 		Payload:      payload,
 		TS:           float64(time.Now().UnixNano()) / 1e9,
 		PHash:        phash,
-		ID:           NodeID(tenantID, trajectoryID, stepN, seq, kind, phash),
+		ID:           id,
 	}, nil
 }

--- a/go/trajir/nodes/nodes_test.go
+++ b/go/trajir/nodes/nodes_test.go
@@ -61,7 +61,10 @@ func TestHashVectorsMatchPythonGoldens(t *testing.T) {
 			if ph != c.PayloadHash {
 				t.Fatalf("payload_hash\n got %s\nwant %s", ph, c.PayloadHash)
 			}
-			id := nodes.NodeID(c.TenantID, c.TrajectoryID, c.StepN, c.Seq, c.Kind, ph)
+			id, err := nodes.NodeID(c.TenantID, c.TrajectoryID, c.StepN, c.Seq, c.Kind, ph)
+			if err != nil {
+				t.Fatalf("NodeID: %v", err)
+			}
 			if id != c.NodeID {
 				t.Fatalf("node_id\n got %s\nwant %s", id, c.NodeID)
 			}

--- a/go/trajir/resume/gate.go
+++ b/go/trajir/resume/gate.go
@@ -25,13 +25,13 @@ func (e *BlockedNeedsGate) Error() string {
 // ToolFunc is a tool body that receives a free-form args map.
 type ToolFunc func(args map[string]any) (any, error)
 
-// MakeGatedToolCall wraps toolFn so re-entry after TOOL_CALL was logged blocks.
+// MakeGatedToolCall wraps toolFn so re-entry after TOOL_CALL was claimed blocks.
 //
 // Seq layout matches Python: TOOL_CALL at seq, TOOL_RESULT or ABORT at seq+1.
 // Callers should space tools as seq = 2 + 2*i for tool index i inside a step.
 //
-// The gate keys only on TOOL_CALL at this exact seq. It does not require a
-// missing TOOL_RESULT (that pattern fails open after a partial crash window).
+// The claim is atomic (transactional insert). Concurrent workers cannot both
+// win the same (trajectory, step, seq) TOOL_CALL slot.
 func MakeGatedToolCall(
 	log *nodelog.NodeLog,
 	trajectoryID, tenantID string,
@@ -45,11 +45,17 @@ func MakeGatedToolCall(
 		}
 		step := stepN
 
-		ok, err := log.Has(trajectoryID, stepN, "TOOL_CALL", &seq)
+		claimed, err := log.ClaimToolCall(
+			stepN,
+			map[string]any{"tool": toolName, "args": args},
+			trajectoryID,
+			tenantID,
+			seq,
+		)
 		if err != nil {
 			return nil, err
 		}
-		if ok {
+		if !claimed {
 			if _, err := log.Append(
 				"ABORT",
 				&step,
@@ -61,17 +67,6 @@ func MakeGatedToolCall(
 				return nil, err
 			}
 			return nil, &BlockedNeedsGate{StepN: stepN, ToolName: toolName}
-		}
-
-		if _, err := log.Append(
-			"TOOL_CALL",
-			&step,
-			map[string]any{"tool": toolName, "args": args},
-			trajectoryID,
-			tenantID,
-			seq,
-		); err != nil {
-			return nil, err
 		}
 
 		result, err := toolFn(args)

--- a/pkg/trajectory_ir/effects/classify.py
+++ b/pkg/trajectory_ir/effects/classify.py
@@ -13,14 +13,27 @@ class EffectClass(Enum):
 def classify_from_mcp(annotations: dict) -> EffectClass:
     """Fail-closed per spec §7.2. Any missing or ambiguous annotation -> NON_IDEMPOTENT_WRITE.
 
-    Contradictory annotations (e.g., readOnlyHint=True AND destructiveHint=True) fail-close to NON_IDEMPOTENT_WRITE.
+    Contradictory annotations (e.g., readOnlyHint=True AND destructiveHint=True)
+    fail-close to NON_IDEMPOTENT_WRITE.
+
+    ``openWorldHint`` alone is never treated as safe: open-world tools without
+    an explicit non-destructive read/idempotent write profile fail closed.
+    Trust boundary: callers must assign ``Tool.effect_class`` from this mapper
+    (or an equivalent operator policy); the runtime does not re-classify
+    arbitrary caller labels.
     """
+    if not isinstance(annotations, dict):
+        return EffectClass.NON_IDEMPOTENT_WRITE
+
+    # openWorldHint=True without a clear safe profile stays fail-closed below.
     if annotations.get("readOnlyHint") is True and annotations.get("destructiveHint") is not True:
         return EffectClass.READ_ONLY
     if (
         annotations.get("readOnlyHint") is False
         and annotations.get("idempotentHint") is True
         and annotations.get("destructiveHint") is False
+        and annotations.get("openWorldHint") is not True
     ):
+        # openWorld + write is treated as non-idempotent unless operator overrides.
         return EffectClass.IDEMPOTENT_WRITE
     return EffectClass.NON_IDEMPOTENT_WRITE  # fail closed, always

--- a/pkg/trajectory_ir/package/__init__.py
+++ b/pkg/trajectory_ir/package/__init__.py
@@ -5,11 +5,13 @@ from trajectory_ir.package.tir import (
     PACKAGE_FORMAT_VERSION,
     ArtifactRef,
     TirError,
+    TirLimitError,
     TirPackage,
     TirVerificationError,
     export_tir,
     import_tir,
     load_tir,
+    load_tir_unverified,
 )
 
 __all__ = [
@@ -17,9 +19,11 @@ __all__ = [
     "PACKAGE_FORMAT_VERSION",
     "ArtifactRef",
     "TirError",
+    "TirLimitError",
     "TirPackage",
     "TirVerificationError",
     "export_tir",
     "import_tir",
     "load_tir",
+    "load_tir_unverified",
 ]

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -11,19 +11,23 @@ Layout (master README §9):
     # SIGNATURE intentionally omitted (reserved, unimplemented)
 
 Import verifies every node id against runtime.nodes hashing (R05 spirit).
+
+Security: load enforces zip path safety and size/count limits so untrusted
+packages cannot zip-bomb or path-traverse the reader.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import re
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
 from trajectory_ir.runtime.log import NodeLog
-from trajectory_ir.runtime.nodes import Node, node_id, payload_hash
+from trajectory_ir.runtime.nodes import Node, NodeValidationError, node_id, payload_hash
 
 PackageMode = Literal["thin", "fat"]
 
@@ -35,6 +39,29 @@ COMPAT = {
     "payload_hash_scheme": "sha256(rfc8785(payload))",
 }
 
+# Hard limits for untrusted package load (DoS / zip-bomb resistance).
+MAX_ZIP_ENTRIES = 10_000
+MAX_UNCOMPRESSED_ENTRY_BYTES = 32 * 1024 * 1024  # 32 MiB per member
+MAX_TOTAL_UNCOMPRESSED_BYTES = 128 * 1024 * 1024  # 128 MiB total
+MAX_NODES = 100_000
+MAX_ARTIFACTS = 10_000
+
+_REQUIRED_MEMBERS = frozenset(
+    {
+        "manifest.json",
+        "nodes.ndjson",
+        "seals.json",
+        "artifacts-manifest.json",
+        "COMPAT.json",
+    }
+)
+
+# Keys whose values are redacted in redacted export mode (case-insensitive).
+_SECRET_KEY_RE = re.compile(
+    r"(password|passwd|secret|token|api[_-]?key|authorization|auth|credential|private[_-]?key)",
+    re.IGNORECASE,
+)
+
 
 class TirError(Exception):
     """Base error for package operations."""
@@ -42,6 +69,10 @@ class TirError(Exception):
 
 class TirVerificationError(TirError):
     """Raised when import finds a hash or structural mismatch."""
+
+
+class TirLimitError(TirError):
+    """Raised when a package exceeds safe size or count limits."""
 
 
 @dataclass(frozen=True)
@@ -69,6 +100,44 @@ def _content_hash(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _safe_zip_name(name: str) -> None:
+    """Reject path traversal and absolute paths inside the zip."""
+    if not name or name.startswith("/") or name.startswith("\\"):
+        raise TirVerificationError(f"unsafe zip member path: {name!r}")
+    # Normalize separators and reject .. segments
+    parts = name.replace("\\", "/").split("/")
+    if ".." in parts or parts[0] == "":
+        raise TirVerificationError(f"unsafe zip member path: {name!r}")
+    if name.startswith("artifacts/") and not (
+        name == "artifacts/" or name.startswith("artifacts/cas/")
+    ):
+        raise TirVerificationError(f"unexpected artifact path: {name!r}")
+
+
+def _read_zip_member(zf: zipfile.ZipFile, name: str, *, budget: list[int]) -> bytes:
+    """Read one member with per-entry and total uncompressed budgets.
+
+    ``budget`` is a single-element list holding remaining total bytes.
+    """
+    _safe_zip_name(name)
+    info = zf.getinfo(name)
+    # Zip bombs often report huge file_size; reject before allocating.
+    if info.file_size > MAX_UNCOMPRESSED_ENTRY_BYTES:
+        raise TirLimitError(
+            f"zip member {name!r} uncompressed size {info.file_size} "
+            f"exceeds limit {MAX_UNCOMPRESSED_ENTRY_BYTES}"
+        )
+    if info.file_size > budget[0]:
+        raise TirLimitError(
+            f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
+        )
+    data = zf.read(name)
+    if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
+        raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
+    budget[0] -= len(data)
+    return data
+
+
 def _verify_node_record(rec: dict[str, Any]) -> None:
     """Recompute id from fields; raise if it does not match the stored id."""
     payload = rec["payload"]
@@ -76,22 +145,21 @@ def _verify_node_record(rec: dict[str, Any]) -> None:
         raise TirVerificationError(f"node {rec.get('id')}: payload must be an object")
     try:
         ph = payload_hash(payload)
-    except AssertionError as e:
+        expected = node_id(
+            rec["tenant_id"],
+            rec["trajectory_id"],
+            rec.get("step_n"),
+            int(rec["seq"]),
+            rec["kind"],
+            ph,
+        )
+    except (NodeValidationError, KeyError, TypeError, ValueError) as e:
         raise TirVerificationError(f"node {rec.get('id')}: {e}") from e
-    expected = node_id(
-        rec["tenant_id"],
-        rec["trajectory_id"],
-        rec.get("step_n"),
-        int(rec["seq"]),
-        rec["kind"],
-        ph,
-    )
     if rec.get("id") != expected:
         raise TirVerificationError(
             f"node id mismatch for kind={rec.get('kind')} seq={rec.get('seq')}: "
             f"recorded={rec.get('id')} expected={expected}"
         )
-    # Optional recorded payload_hash field
     if "payload_hash" in rec and rec["payload_hash"] != ph:
         raise TirVerificationError(
             f"payload_hash mismatch for node {rec.get('id')}: "
@@ -116,6 +184,50 @@ def _seals_from_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return seals
 
 
+def _redact_value(key: str, value: Any) -> Any:
+    if _SECRET_KEY_RE.search(key):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {k: _redact_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(key, item) for item in value]
+    return value
+
+
+def _redact_node(rec: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a node record with thoughts/secrets stripped for sharing."""
+    kind = rec["kind"]
+    payload = rec["payload"]
+    if kind == "THOUGHT":
+        new_payload: dict[str, Any] = {"redacted": True}
+    elif isinstance(payload, dict):
+        new_payload = {k: _redact_value(str(k), v) for k, v in payload.items()}
+    else:
+        new_payload = {"redacted": True}
+
+    # Rebuild via Node so id matches redacted payload (export is a new package).
+    node = Node(
+        kind=kind,
+        trajectory_id=rec["trajectory_id"],
+        tenant_id=rec["tenant_id"],
+        step_n=rec.get("step_n"),
+        seq=int(rec["seq"]),
+        payload=new_payload,
+        ts=float(rec.get("ts") or 0.0),
+    )
+    return {
+        "id": node.id,
+        "trajectory_id": node.trajectory_id,
+        "tenant_id": node.tenant_id,
+        "step_n": node.step_n,
+        "seq": node.seq,
+        "kind": node.kind,
+        "payload": node.payload,
+        "ts": node.ts,
+        "payload_hash": node.phash,
+    }
+
+
 def export_tir(
     node_log: NodeLog,
     trajectory_id: str,
@@ -124,18 +236,37 @@ def export_tir(
     mode: PackageMode = "thin",
     artifacts: list[ArtifactRef] | None = None,
     artifact_bytes: dict[str, bytes] | None = None,
+    tenant_id: str | None = None,
+    redacted: bool = False,
 ) -> Path:
-    """Export a trajectory from ``node_log`` to a ``.tir`` zip at ``dest``."""
+    """Export a trajectory from ``node_log`` to a ``.tir`` zip at ``dest``.
+
+    Args:
+        tenant_id: When set, only that tenant's nodes are exported (isolation).
+        redacted: When True, strip thoughts and secret-like fields before export.
+    """
     if mode not in ("thin", "fat"):
         raise TirError(f"unsupported mode {mode!r}; use thin or fat")
 
-    nodes = node_log.list_nodes(trajectory_id)
+    nodes = node_log.list_nodes(trajectory_id, tenant_id=tenant_id)
     if not nodes:
         raise TirError(f"no nodes for trajectory_id={trajectory_id!r}")
 
-    tenant_id = nodes[0]["tenant_id"]
+    export_tenant = nodes[0]["tenant_id"]
     for n in nodes:
+        if n["tenant_id"] != export_tenant:
+            raise TirError(
+                "trajectory contains mixed tenant_id values; pass tenant_id= to scope export"
+            )
         _verify_node_record(n)
+
+    if redacted:
+        nodes = [_redact_node(n) for n in nodes]
+        # Fat artifacts may hold secrets; omit bytes in redacted mode.
+        if mode == "fat":
+            mode = "thin"
+            artifacts = []
+            artifact_bytes = {}
 
     artifacts = list(artifacts or [])
     artifact_bytes = dict(artifact_bytes or {})
@@ -146,19 +277,23 @@ def export_tir(
                 raise TirError(f"fat export missing bytes for content_hash={ref.content_hash}")
             if _content_hash(data) != ref.content_hash:
                 raise TirError(f"artifact bytes do not match content_hash={ref.content_hash}")
+            if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
+                raise TirLimitError(f"artifact {ref.content_hash} exceeds size limit")
+        if len(artifacts) > MAX_ARTIFACTS:
+            raise TirLimitError(f"too many artifacts: {len(artifacts)} > {MAX_ARTIFACTS}")
     else:
-        # thin: drop embedded bytes even if provided
         artifact_bytes = {}
 
     seals = _seals_from_nodes(nodes)
     manifest = {
         "package_format": PACKAGE_FORMAT_VERSION,
         "trajectory_id": trajectory_id,
-        "tenant_id": tenant_id,
+        "tenant_id": export_tenant,
         "mode": mode,
         "node_count": len(nodes),
         "seal_count": len(seals),
         "signature": None,
+        "redacted": redacted,
     }
     artifacts_manifest = [
         {
@@ -190,7 +325,6 @@ def export_tir(
         zf.writestr("nodes.ndjson", ndjson)
         if mode == "fat":
             for h, data in artifact_bytes.items():
-                # sharded layout cas/ab/cdef... under artifacts/
                 shard = h[:2]
                 zf.writestr(f"artifacts/cas/{shard}/{h}", data)
 
@@ -198,44 +332,78 @@ def export_tir(
 
 
 def load_tir(path: str | Path, *, verify: bool = True) -> TirPackage:
-    """Load and optionally verify a ``.tir`` zip without writing to a NodeLog."""
+    """Load and verify a ``.tir`` zip without writing to a NodeLog.
+
+    Verification is required for untrusted packages. To intentionally skip
+    verification (tests / recovery tools only), call
+    :func:`load_tir_unverified`.
+    """
+    if not verify:
+        raise TirError(
+            "load_tir(verify=False) is disabled for safety; "
+            "use load_tir_unverified() if you explicitly accept an unverified package"
+        )
+    return _load_tir_impl(path, verify=True)
+
+
+def load_tir_unverified(path: str | Path) -> TirPackage:
+    """Load a package without hash verification. UNSAFE for untrusted input."""
+    return _load_tir_impl(path, verify=False)
+
+
+def _load_tir_impl(path: str | Path, *, verify: bool) -> TirPackage:
     path = Path(path)
     if not path.is_file():
         raise TirError(f"package not found: {path}")
 
     with zipfile.ZipFile(path, "r") as zf:
-        names = set(zf.namelist())
-        required = {
-            "manifest.json",
-            "nodes.ndjson",
-            "seals.json",
-            "artifacts-manifest.json",
-            "COMPAT.json",
-        }
-        missing = required - names
+        names = zf.namelist()
+        if len(names) > MAX_ZIP_ENTRIES:
+            raise TirLimitError(f"too many zip entries: {len(names)} > {MAX_ZIP_ENTRIES}")
+        name_set = set(names)
+        missing = _REQUIRED_MEMBERS - name_set
         if missing:
             raise TirError(f"package missing files: {sorted(missing)}")
 
-        manifest = json.loads(zf.read("manifest.json"))
-        seals = json.loads(zf.read("seals.json"))
-        artifacts_manifest = json.loads(zf.read("artifacts-manifest.json"))
+        for name in names:
+            _safe_zip_name(name)
+
+        budget = [MAX_TOTAL_UNCOMPRESSED_BYTES]
+        manifest = json.loads(_read_zip_member(zf, "manifest.json", budget=budget))
+        seals = json.loads(_read_zip_member(zf, "seals.json", budget=budget))
+        artifacts_manifest = json.loads(
+            _read_zip_member(zf, "artifacts-manifest.json", budget=budget)
+        )
+        # COMPAT is advisory for now but must still be readable under budget.
+        _read_zip_member(zf, "COMPAT.json", budget=budget)
+
+        nodes_raw = _read_zip_member(zf, "nodes.ndjson", budget=budget).decode("utf-8")
         nodes: list[dict[str, Any]] = []
-        for line in zf.read("nodes.ndjson").decode("utf-8").splitlines():
+        for line in nodes_raw.splitlines():
             line = line.strip()
             if not line:
                 continue
             nodes.append(json.loads(line))
+            if len(nodes) > MAX_NODES:
+                raise TirLimitError(f"too many nodes: > {MAX_NODES}")
+
+        if isinstance(artifacts_manifest, list) and len(artifacts_manifest) > MAX_ARTIFACTS:
+            raise TirLimitError(f"too many artifact manifest entries: > {MAX_ARTIFACTS}")
 
         artifact_bytes: dict[str, bytes] = {}
         for name in names:
             if name.startswith("artifacts/cas/") and not name.endswith("/"):
-                data = zf.read(name)
+                data = _read_zip_member(zf, name, budget=budget)
                 h = Path(name).name
+                if len(h) != 64 or any(c not in "0123456789abcdef" for c in h.lower()):
+                    raise TirVerificationError(f"invalid artifact content hash name: {h!r}")
                 if _content_hash(data) != h:
                     raise TirVerificationError(
                         f"embedded artifact name {h} does not match content hash"
                     )
                 artifact_bytes[h] = data
+                if len(artifact_bytes) > MAX_ARTIFACTS:
+                    raise TirLimitError(f"too many embedded artifacts: > {MAX_ARTIFACTS}")
 
     if verify:
         if not nodes:
@@ -243,7 +411,6 @@ def load_tir(path: str | Path, *, verify: bool = True) -> TirPackage:
         for n in nodes:
             _verify_node_record(n)
         expected_seals = _seals_from_nodes(nodes)
-        # Allow seals.json to be a subset or equal recomputation of DECISION seals
         by_id = {s["node_id"]: s for s in seals}
         for exp in expected_seals:
             got = by_id.get(exp["node_id"])
@@ -258,7 +425,6 @@ def load_tir(path: str | Path, *, verify: bool = True) -> TirPackage:
                 if h not in artifact_bytes:
                     raise TirVerificationError(f"fat package missing artifact bytes {h}")
         if mode == "thin" and artifact_bytes:
-            # thin packages should not embed bytes
             raise TirVerificationError("thin package must not embed artifact bytes")
 
     return TirPackage(
@@ -278,11 +444,16 @@ def import_tir(
 ) -> TirPackage:
     """Verify a package and append its nodes into ``node_log`` (idempotent by id).
 
-    Does not acquire a writer lease (README §9).
+    Does not acquire a writer lease (README §9). Verification cannot be disabled
+    on import — forged packages must not enter a durable log.
     """
-    pkg = load_tir(path, verify=verify)
+    if not verify:
+        raise TirError(
+            "import_tir refuses verify=False; forged packages must not enter a NodeLog. "
+            "Use load_tir_unverified() only for inspection, never for durable import."
+        )
+    pkg = load_tir(path, verify=True)
     for n in pkg.nodes:
-        # Rebuild via Node so append stores consistent fields; id must match.
         node = Node(
             kind=n["kind"],
             trajectory_id=n["trajectory_id"],
@@ -292,7 +463,6 @@ def import_tir(
             payload=n["payload"],
             ts=float(n.get("ts") or 0.0),
         )
-        # Node regenerates id from payload; must equal package record.
         if node.id != n["id"]:
             raise TirVerificationError(f"rebuilt node id {node.id} != package id {n['id']}")
         node_log.append(

--- a/pkg/trajectory_ir/resume/gate.py
+++ b/pkg/trajectory_ir/resume/gate.py
@@ -33,25 +33,27 @@ def make_gated_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_n
     (TOOL_RESULT, or ABORT when blocked) at `seq + 1`. Callers must space tool
     calls accordingly so no two nodes in a step collide on seq -- see
     `resume/step.py`.
+
+    The claim of the TOOL_CALL slot is atomic (``BEGIN IMMEDIATE`` + insert)
+    so concurrent workers cannot both pass a non-atomic has-then-append race.
     """
 
     def gated(**kwargs):
-        # A TOOL_CALL node at *this exact* (step_n, seq) is by itself proof that
-        # this call was already attempted, so any re-entry must block.
+        # Atomic claim: first successful insert of TOOL_CALL at this seq wins.
+        # Re-entry (or a concurrent loser) must block — never re-run the effect.
         #
         # Deliberately NOT `TOOL_CALL and not TOOL_RESULT`: TOOL_RESULT is
         # appended and committed to SQLite before the durable backend records
         # the step's memoized output, so a crash in that window leaves *both*
-        # nodes present. A `not TOOL_RESULT` conjunct fails open there -- the
-        # gate would wave the replay through and silently re-run the side
-        # effect, which is exactly the invariant this gate exists to protect.
-        # Returning the logged TOOL_RESULT instead of blocking would be unsound
-        # too: we cannot know the effect actually reached the outside world.
-        #
-        # Scoping to `seq` is what makes "this call" precise. Unscoped, one
-        # completed tool's TOOL_RESULT masks an unrelated interrupted tool's
-        # missing one, and the same silent re-run follows.
-        if node_log.has(trajectory_id, step_n, "TOOL_CALL", seq=seq):
+        # nodes present. A `not TOOL_RESULT` conjunct fails open there.
+        claimed = node_log.claim_tool_call(
+            step_n,
+            {"tool": tool_name, "args": kwargs},
+            trajectory_id,
+            tenant_id,
+            seq,
+        )
+        if not claimed:
             node_log.append(
                 "ABORT",
                 step_n,
@@ -62,14 +64,6 @@ def make_gated_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_n
             )
             raise BlockedNeedsGate(step_n, tool_name)
 
-        node_log.append(
-            "TOOL_CALL",
-            step_n,
-            {"tool": tool_name, "args": kwargs},
-            trajectory_id,
-            tenant_id,
-            seq,
-        )
         result = tool_fn(**kwargs)
         node_log.append(
             "TOOL_RESULT",

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -1,8 +1,13 @@
 import json
 import sqlite3
+import threading
 from typing import Any
 
 from trajectory_ir.runtime.nodes import Node
+
+
+class SlotConflictError(ValueError):
+    """Raised when a different payload is written to an occupied (trajectory, step, seq, kind) slot."""
 
 
 class NodeLog:
@@ -13,13 +18,17 @@ class NodeLog:
     workflow replay safe to layer on top of -- re-running an already-appended
     step produces the same node id and is silently absorbed instead of
     duplicating history, so there is no separate "seal" operation needed.
+
+    Concurrent writers are serialized with a lock and ``BEGIN IMMEDIATE`` so
+    the block-and-gate claim path cannot double-run a non-idempotent tool.
     """
 
     def __init__(self, db_path: str):
         # check_same_thread=False: the durable backend replays a crashed
         # workflow on its own recovery thread, so the log must be writable from a
-        # thread other than the one that opened it. Only one thread executes a
-        # given workflow body at a time, so no extra locking is needed.
+        # thread other than the one that opened it. Access is serialized via
+        # self._lock; only one thread mutates the connection at a time.
+        self._lock = threading.RLock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute(
             """
@@ -33,6 +42,20 @@ class NodeLog:
                 payload_json TEXT NOT NULL,
                 ts REAL NOT NULL
             )
+            """,
+        )
+        # Logical slot uniqueness per tenant: same content id is still
+        # INSERT OR IGNORE; a different payload at the same slot is rejected.
+        self._conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_slot
+            ON nodes (tenant_id, trajectory_id, IFNULL(step_n, -1), seq, kind)
+            """,
+        )
+        self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_nodes_traj_tenant
+            ON nodes (trajectory_id, tenant_id)
             """,
         )
         self._conn.commit()
@@ -54,22 +77,97 @@ class NodeLog:
             seq=seq,
             payload=payload,
         )
-        self._conn.execute(
-            "INSERT OR IGNORE INTO nodes (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                node.id,
-                node.trajectory_id,
-                node.tenant_id,
-                node.step_n,
-                node.seq,
-                node.kind,
-                json.dumps(node.payload),
-                node.ts,
-            ),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR IGNORE INTO nodes "
+                "(id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    node.id,
+                    node.trajectory_id,
+                    node.tenant_id,
+                    node.step_n,
+                    node.seq,
+                    node.kind,
+                    json.dumps(node.payload),
+                    node.ts,
+                ),
+            )
+            # INSERT OR IGNORE also swallows unique-slot conflicts. Detect a
+            # different payload occupying this logical slot and fail closed.
+            cur = self._conn.execute(
+                "SELECT id FROM nodes WHERE tenant_id = ? AND trajectory_id = ? "
+                "AND IFNULL(step_n, -1) = IFNULL(?, -1) AND seq = ? AND kind = ?",
+                (tenant_id, trajectory_id, step_n, seq, kind),
+            )
+            row = cur.fetchone()
+            if row is not None and row[0] != node.id:
+                self._conn.rollback()
+                raise SlotConflictError(
+                    f"slot conflict trajectory={trajectory_id!r} step={step_n} "
+                    f"seq={seq} kind={kind!r}: different payload already stored"
+                )
+            self._conn.commit()
         return node
+
+    def claim_tool_call(
+        self,
+        step_n: int,
+        payload: dict,
+        trajectory_id: str,
+        tenant_id: str,
+        seq: int,
+    ) -> bool:
+        """Atomically claim a TOOL_CALL slot.
+
+        Returns True if this caller inserted the TOOL_CALL (may run the tool).
+        Returns False if a TOOL_CALL already occupied this (trajectory, step, seq).
+        """
+        node = Node(
+            kind="TOOL_CALL",
+            trajectory_id=trajectory_id,
+            tenant_id=tenant_id,
+            step_n=step_n,
+            seq=seq,
+            payload=payload,
+        )
+        with self._lock:
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                cur = self._conn.execute(
+                    "SELECT 1 FROM nodes WHERE tenant_id = ? AND trajectory_id = ? "
+                    "AND step_n = ? AND kind = ? AND seq = ? LIMIT 1",
+                    (tenant_id, trajectory_id, step_n, "TOOL_CALL", seq),
+                )
+                if cur.fetchone() is not None:
+                    self._conn.execute("COMMIT")
+                    return False
+                self._conn.execute(
+                    "INSERT INTO nodes "
+                    "(id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        node.id,
+                        node.trajectory_id,
+                        node.tenant_id,
+                        node.step_n,
+                        node.seq,
+                        node.kind,
+                        json.dumps(node.payload),
+                        node.ts,
+                    ),
+                )
+                self._conn.execute("COMMIT")
+                return True
+            except sqlite3.IntegrityError:
+                self._conn.execute("ROLLBACK")
+                return False
+            except Exception:
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
 
     def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
         """Does a node of `kind` exist for this trajectory/step?
@@ -85,39 +183,54 @@ class NodeLog:
         if seq is not None:
             sql += " AND seq = ?"
             params.append(seq)
-        cur = self._conn.execute(sql + " LIMIT 1", params)
-        return cur.fetchone() is not None
+        with self._lock:
+            cur = self._conn.execute(sql + " LIMIT 1", params)
+            return cur.fetchone() is not None
 
     def count(self, node_id: str) -> int:
-        cur = self._conn.execute("SELECT COUNT(*) FROM nodes WHERE id = ?", (node_id,))
-        return cur.fetchone()[0]
+        with self._lock:
+            cur = self._conn.execute("SELECT COUNT(*) FROM nodes WHERE id = ?", (node_id,))
+            return cur.fetchone()[0]
 
-    def list_nodes(self, trajectory_id: str) -> list[dict[str, Any]]:
-        """Return all stored nodes for a trajectory ordered by step then seq."""
-        cur = self._conn.execute(
-            """
+    def list_nodes(
+        self,
+        trajectory_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return stored nodes for a trajectory ordered by step then seq.
+
+        When ``tenant_id`` is set, only that tenant's rows are returned
+        (multi-tenant isolation at the read path).
+        """
+        sql = """
             SELECT id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts
             FROM nodes
             WHERE trajectory_id = ?
-            ORDER BY COALESCE(step_n, -1), seq
-            """,
-            (trajectory_id,),
-        )
-        rows: list[dict[str, Any]] = []
-        for row in cur.fetchall():
-            rows.append(
-                {
-                    "id": row[0],
-                    "trajectory_id": row[1],
-                    "tenant_id": row[2],
-                    "step_n": row[3],
-                    "seq": row[4],
-                    "kind": row[5],
-                    "payload": json.loads(row[6]),
-                    "ts": row[7],
-                }
-            )
-        return rows
+            """
+        params: list[object] = [trajectory_id]
+        if tenant_id is not None:
+            sql += " AND tenant_id = ?"
+            params.append(tenant_id)
+        sql += " ORDER BY COALESCE(step_n, -1), seq"
+        with self._lock:
+            cur = self._conn.execute(sql, params)
+            rows: list[dict[str, Any]] = []
+            for row in cur.fetchall():
+                rows.append(
+                    {
+                        "id": row[0],
+                        "trajectory_id": row[1],
+                        "tenant_id": row[2],
+                        "step_n": row[3],
+                        "seq": row[4],
+                        "kind": row[5],
+                        "payload": json.loads(row[6]),
+                        "ts": row[7],
+                    }
+                )
+            return rows
 
     def close(self):
-        self._conn.close()
+        with self._lock:
+            self._conn.close()

--- a/pkg/trajectory_ir/runtime/nodes.py
+++ b/pkg/trajectory_ir/runtime/nodes.py
@@ -25,10 +25,34 @@ NODE_KINDS = frozenset(
     }
 )
 
+# Identity fields are joined with '|'. Forbid that delimiter and control chars
+# so tenant_id / trajectory_id cannot alias across the preimage boundary.
+_FORBIDDEN_ID_CHARS = frozenset({"|", "\n", "\r", "\x00"})
+
+
+class NodeValidationError(ValueError):
+    """Raised when node fields violate IR identity or payload rules."""
+
+
+def validate_id_component(name: str, value: str) -> str:
+    """Validate a tenant_id or trajectory_id for safe node_id composition."""
+    if not isinstance(value, str) or not value:
+        raise NodeValidationError(f"{name} must be a non-empty string")
+    if any(ch in value for ch in _FORBIDDEN_ID_CHARS):
+        raise NodeValidationError(
+            f"{name} must not contain '|' or control characters (identity delimiter safety)"
+        )
+    if len(value) > 512:
+        raise NodeValidationError(f"{name} exceeds maximum length 512")
+    return value
+
 
 def payload_hash(payload: dict) -> str:
     """RFC 8785 canonicalize, then SHA-256. `ts` must never be hashed (spec §6.3)."""
-    assert "ts" not in payload, "wall-clock ts must never be hashed (spec §6.3)"
+    if not isinstance(payload, dict):
+        raise NodeValidationError("payload must be an object")
+    if "ts" in payload:
+        raise NodeValidationError("wall-clock ts must never be hashed (spec §6.3)")
     canon = rfc8785.dumps(payload)
     return hashlib.sha256(canon).hexdigest()
 
@@ -41,6 +65,8 @@ def node_id(
     kind: str,
     phash: str,
 ) -> str:
+    validate_id_component("tenant_id", tenant_id)
+    validate_id_component("trajectory_id", trajectory_id)
     raw = f"{tenant_id}|{trajectory_id}|{step_n}|{seq}|{kind}|{phash}".encode()
     return hashlib.sha256(raw).hexdigest()
 
@@ -56,7 +82,10 @@ class Node:
     ts: float = field(default_factory=time.time)
 
     def __post_init__(self):
-        assert self.kind in NODE_KINDS, f"unknown node kind: {self.kind}"
+        if self.kind not in NODE_KINDS:
+            raise NodeValidationError(f"unknown node kind: {self.kind}")
+        validate_id_component("tenant_id", self.tenant_id)
+        validate_id_component("trajectory_id", self.trajectory_id)
         self.phash = payload_hash(self.payload)
         self.id = node_id(
             self.tenant_id,

--- a/test/unit/test_effects.py
+++ b/test/unit/test_effects.py
@@ -34,3 +34,17 @@ def test_destructive_hint_true_fails_closed_even_if_idempotent():
 def test_contradictory_readonly_and_destructive_fails_closed():
     annotations = {"readOnlyHint": True, "destructiveHint": True}
     assert classify_from_mcp(annotations) == EffectClass.NON_IDEMPOTENT_WRITE
+
+
+def test_open_world_idempotent_write_fails_closed():
+    annotations = {
+        "readOnlyHint": False,
+        "idempotentHint": True,
+        "destructiveHint": False,
+        "openWorldHint": True,
+    }
+    assert classify_from_mcp(annotations) == EffectClass.NON_IDEMPOTENT_WRITE
+
+
+def test_non_dict_annotations_fail_closed():
+    assert classify_from_mcp(None) == EffectClass.NON_IDEMPOTENT_WRITE  # type: ignore[arg-type]

--- a/test/unit/test_node_identity.py
+++ b/test/unit/test_node_identity.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 
-from trajectory_ir.runtime.nodes import Node
+from trajectory_ir.runtime.nodes import Node, NodeValidationError
 
 
 def test_identical_payload_different_key_order_same_hash():
@@ -47,7 +47,7 @@ def test_ts_never_affects_hash():
 
 
 def test_unknown_kind_rejected():
-    with pytest.raises(AssertionError):
+    with pytest.raises(NodeValidationError):
         Node(
             kind="NOT_A_KIND",
             trajectory_id="t1",
@@ -59,7 +59,7 @@ def test_unknown_kind_rejected():
 
 
 def test_ts_key_in_payload_rejected():
-    with pytest.raises(AssertionError):
+    with pytest.raises(NodeValidationError):
         Node(
             kind="STATE_SET",
             trajectory_id="t1",
@@ -67,4 +67,28 @@ def test_ts_key_in_payload_rejected():
             step_n=1,
             seq=1,
             payload={"ts": 123},
+        )
+
+
+def test_pipe_in_tenant_id_rejected():
+    with pytest.raises(NodeValidationError, match="delimiter"):
+        Node(
+            kind="STATE_SET",
+            trajectory_id="t1",
+            tenant_id="a|b",
+            step_n=1,
+            seq=1,
+            payload={"a": 1},
+        )
+
+
+def test_pipe_in_trajectory_id_rejected():
+    with pytest.raises(NodeValidationError, match="delimiter"):
+        Node(
+            kind="STATE_SET",
+            trajectory_id="x|y",
+            tenant_id="demo",
+            step_n=1,
+            seq=1,
+            payload={"a": 1},
         )

--- a/test/unit/test_node_log.py
+++ b/test/unit/test_node_log.py
@@ -1,9 +1,10 @@
 import os
 import tempfile
+import threading
 
 import pytest
 
-from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.log import NodeLog, SlotConflictError
 
 
 @pytest.fixture
@@ -48,3 +49,42 @@ def test_append_is_idempotent_by_content(log):
     )
     assert n1.id == n2.id
     assert log.count(n1.id) == 1
+
+
+def test_claim_tool_call_atomic_single_winner(log):
+    wins = []
+
+    def worker():
+        claimed = log.claim_tool_call(
+            1,
+            {"tool": "deploy", "args": {"v": "1"}},
+            "t1",
+            "demo",
+            2,
+        )
+        wins.append(claimed)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(1 for w in wins if w) == 1
+    assert sum(1 for w in wins if not w) == 7
+    assert log.has("t1", 1, "TOOL_CALL", seq=2)
+
+
+def test_list_nodes_tenant_filter(log):
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "tenant-a", 1)
+    log.append("DECISION", 1, {"plan": "b"}, "t1", "tenant-b", 2)
+    only_a = log.list_nodes("t1", tenant_id="tenant-a")
+    assert len(only_a) == 1
+    assert only_a[0]["tenant_id"] == "tenant-a"
+    all_nodes = log.list_nodes("t1")
+    assert len(all_nodes) == 2
+
+
+def test_slot_conflict_different_payload(log):
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "demo", 1)
+    with pytest.raises(SlotConflictError):
+        log.append("DECISION", 1, {"plan": "b"}, "t1", "demo", 1)

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -10,6 +10,7 @@ import pytest
 
 from trajectory_ir.package import (
     ArtifactRef,
+    TirError,
     TirVerificationError,
     export_tir,
     import_tir,
@@ -160,3 +161,66 @@ def test_thin_rejects_embedded_bytes(sample_log: NodeLog, tmp_path: Path) -> Non
     # content hash of b"nope" won't match filename either — either error is fine
     with pytest.raises(TirVerificationError):
         load_tir(bad)
+
+
+def test_load_tir_rejects_verify_false(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "run.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    with pytest.raises(TirError, match="load_tir_unverified"):
+        load_tir(out, verify=False)
+
+
+def test_import_tir_rejects_verify_false(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "run.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    dest = NodeLog(str(tmp_path / "dest.sqlite"))
+    try:
+        with pytest.raises(TirError, match="import_tir refuses"):
+            import_tir(out, dest, verify=False)
+    finally:
+        dest.close()
+
+
+def test_rejects_path_traversal_member(sample_log: NodeLog, tmp_path: Path) -> None:
+    out = tmp_path / "good.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    bad = tmp_path / "traversal.tir"
+    with zipfile.ZipFile(out, "r") as zin, zipfile.ZipFile(bad, "w") as zout:
+        for item in zin.infolist():
+            zout.writestr(item, zin.read(item.filename))
+        zout.writestr("../evil.txt", b"x")
+    with pytest.raises(TirVerificationError, match="unsafe"):
+        load_tir(bad)
+
+
+def test_redacted_export_strips_secrets(sample_log: NodeLog, tmp_path: Path) -> None:
+    sample_log.append(
+        "TOOL_CALL",
+        2,
+        {"tool": "login", "args": {"api_key": "super-secret", "user": "a"}},
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=10,
+    )
+    out = tmp_path / "redacted.tir"
+    export_tir(sample_log, "t-export", out, mode="thin", redacted=True)
+    pkg = load_tir(out)
+    assert pkg.manifest.get("redacted") is True
+    tool_calls = [n for n in pkg.nodes if n["kind"] == "TOOL_CALL" and n["seq"] == 10]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["payload"]["args"]["api_key"] == "[REDACTED]"
+    assert tool_calls[0]["payload"]["args"]["user"] == "a"
+
+
+def test_export_tenant_scope(sample_log: NodeLog, tmp_path: Path) -> None:
+    other = NodeLog(str(tmp_path / "mixed.sqlite"))
+    try:
+        other.append("DECISION", 1, {"plan": "a"}, "shared", "tenant-a", 1)
+        other.append("DECISION", 1, {"plan": "b"}, "shared", "tenant-b", 1)
+        out = tmp_path / "scoped.tir"
+        export_tir(other, "shared", out, mode="thin", tenant_id="tenant-a")
+        pkg = load_tir(out)
+        assert len(pkg.nodes) == 1
+        assert pkg.nodes[0]["tenant_id"] == "tenant-a"
+    finally:
+        other.close()


### PR DESCRIPTION
## Summary
Implements library-stage security hardening from the senior security audit so Trajectory IR is safer for open-source consumers who load packages, run concurrent workers, or share logs.

### Fixed (P0/P1)
- **\.tir\ DoS / path safety**  per-entry and total uncompressed limits, entry caps, reject \..\ / absolute zip paths
- **Atomic block-and-gate**  \claim_tool_call\ / \ClaimToolCall\ with transactional claim so concurrent workers cannot double-run \NON_IDEMPOTENT_WRITE\
- **Import trust**  \load_tir(verify=False)\ and \import_tir(verify=False)\ disabled; explicit \load_tir_unverified()\ for inspection only
- **Identity delimiter safety**  reject \|\ / control chars in \	enant_id\ / \	rajectory_id\ (Python + Go)
- **Slot fork prevention** unique slot index + conflict detection for different payloads
- **Tenant-scoped reads/export**  \list_nodes(..., tenant_id=)\ and \xport_tir(..., tenant_id=)\
- **Redacted export** strip secret-like keys and thought bodies (\
edacted=True\)
- **Effect mapping**  open-world idempotent writes fail closed; non-dict annotations fail closed
- **Temporal prod config**  TLS + API key env/options (\TEMPORAL_TLS\, \TEMPORAL_API_KEY\)
- **SECURITY.md**  honest implemented vs planned table + pip-audit maintainer guidance

### Intentionally not in this PR
- Package digital signatures (spec-reserved)
- Full multi-tenant SaaS product surface
- Go \.tir\ (#38 stays open; apply same limits when implemented)
- Fluid/k8s profile controls
- Direct \.github/workflows\ edit for pip-audit (OAuth token lacks \workflow\ scope); documented for maintainers to land with elevated auth

## Test plan
- [x] \pytest test/unit test/e2e conformance\  42 passed
- [x] \go test ./...\ all packages pass
- [x] \
uff\ + \mypy\
- [x] clean-venv \pip-audit --skip-editable\  no known vulns
- [ ] CI green on this PR

## Risk notes
- \ssert\ validation replaced with \NodeValidationError\ (API clarity; tests updated)
- \Tool.effect_class\ remains caller-trusted (documented); mislabeling still bypasses the gate by design of the library trust model
