### PR TITLE
ci: add pip-audit gate to Python CI (Quality unit tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security hardening: `.tir` zip size/path limits, atomic TOOL_CALL claim (Python + Go),
   identity delimiter validation, tenant-scoped list/export, redacted export mode,
   Temporal TLS/API key config, safer import verification API.
+- CI: `pip-audit` gate in Python unit tests under CI (parity with Go `govulncheck`);
+  `pip-audit` added to the `dev` extra.
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,10 @@ Defined in `.github/workflows/ci.yml`:
 | Check | What it does |
 |-------|----------------|
 | **DCO** | Every commit on the PR has `Signed-off-by` |
-| **Quality** | install, Ruff, Mypy, hash goldens, unit, e2e, R01/R02 (Python 3.11 and 3.12) |
+| **Quality** | install, Ruff, Mypy, hash goldens, unit (includes `pip-audit` gate), e2e, R01/R02 (Python 3.11 and 3.12) |
 | **Go** | hash goldens, `go test ./...`, `govulncheck` |
+
+Python dependency audit (`pip-audit`) is part of the unit suite under CI (`test/unit/test_pip_audit.py`), so it fails the existing **Quality** checks without a separate job.
 
 Cross language hash vectors live in `testdata/hash_vectors.json` and must stay
 identical in Python (`test/unit/test_hash_vectors.py`) and Go

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,8 +57,8 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 | Fluid / k8s cache poisoning controls | Design only (future profile) |
 
 ### F. Continuous dependency scanning
-- **Go**: `govulncheck ./...` runs in CI.
-- **Python**: maintainers should run `pip install pip-audit && pip-audit --skip-editable` in a clean venv after `pip install -e ".[dev]"` before release. Adding a permanent CI job requires a token with the GitHub `workflow` scope when editing `.github/workflows/ci.yml`.
+- **Go**: `govulncheck ./...` runs in the CI `Go` job.
+- **Python**: `pip-audit --skip-editable` runs under CI via `test/unit/test_pip_audit.py` (part of the Quality unit suite when `CI=true`). Locally: `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q` in a clean venv after `pip install -e ".[dev]"`.
 
 ## 4. Security Accountability for Contributors
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -17,11 +17,13 @@ GitHub → Settings → Branches → Branch protection rule for `main`:
 Match the names shown in the Actions UI:
 
 1. `DCO` (pull requests only; may appear after the first PR with the DCO job)
-2. `Quality (Python 3.11)`
-3. `Quality (Python 3.12)`
-4. `Go`
+2. `Quality (Python 3.11)` — includes `pip-audit` via unit tests
+3. `Quality (Python 3.12)` — includes `pip-audit` via unit tests
+4. `Go` (includes `govulncheck`)
 
 If GitHub shows a slightly different label, use the exact string from the check run.
+
+Also enable org/repo **secret scanning** and **push protection** when available (Settings → Code security).
 
 ## Order
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "mypy"]
+dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
 
 [build-system]
 requires = ["hatchling"]

--- a/test/unit/test_pip_audit.py
+++ b/test/unit/test_pip_audit.py
@@ -20,15 +20,26 @@ def test_installed_dependency_tree_has_no_known_vulns() -> None:
     if os.environ.get("CI") != "true" and os.environ.get("RUN_PIP_AUDIT") != "1":
         pytest.skip("set RUN_PIP_AUDIT=1 to run pip-audit outside CI")
 
-    # Prefer already-installed pip-audit (dev extra); install if missing.
+    # Ensure audit tooling and known-vulnerable build backends are current.
+    # Hosted Python 3.11 images can ship an older setuptools that pip-audit flags.
     install = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-q", "pip-audit"],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-q",
+            "-U",
+            "pip",
+            "setuptools>=83",
+            "pip-audit",
+        ],
         capture_output=True,
         text=True,
         check=False,
     )
     if install.returncode != 0:
-        pytest.fail(f"could not install pip-audit:\n{install.stdout}\n{install.stderr}")
+        pytest.fail(f"could not install pip-audit tooling:\n{install.stdout}\n{install.stderr}")
 
     # --skip-editable: ignore the local trajectory-ir package (not on PyPI).
     audit = subprocess.run(

--- a/test/unit/test_pip_audit.py
+++ b/test/unit/test_pip_audit.py
@@ -1,0 +1,44 @@
+"""CI dependency vulnerability gate (Python parity with Go govulncheck).
+
+Runs under GitHub Actions (CI=true). Locally: ``RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py``.
+Skip with ``SKIP_PIP_AUDIT=1`` when needed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def test_installed_dependency_tree_has_no_known_vulns() -> None:
+    """Fail when pip-audit reports known vulnerabilities in the installed tree."""
+    if os.environ.get("SKIP_PIP_AUDIT") == "1":
+        pytest.skip("SKIP_PIP_AUDIT=1")
+    if os.environ.get("CI") != "true" and os.environ.get("RUN_PIP_AUDIT") != "1":
+        pytest.skip("set RUN_PIP_AUDIT=1 to run pip-audit outside CI")
+
+    # Prefer already-installed pip-audit (dev extra); install if missing.
+    install = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-q", "pip-audit"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if install.returncode != 0:
+        pytest.fail(f"could not install pip-audit:\n{install.stdout}\n{install.stderr}")
+
+    # --skip-editable: ignore the local trajectory-ir package (not on PyPI).
+    audit = subprocess.run(
+        [sys.executable, "-m", "pip_audit", "--skip-editable"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if audit.returncode != 0:
+        pytest.fail(
+            "pip-audit found known vulnerabilities (or failed).\n"
+            f"stdout:\n{audit.stdout}\nstderr:\n{audit.stderr}"
+        )


### PR DESCRIPTION
## Summary

Adds a **Python dependency vulnerability gate** so CI fails on known CVEs parity with Go `govulncheck`  without editing `.github/workflows/*` (OAuth tokens without the `workflow` scope cannot push workflow file changes).

### What changed
- `test/unit/test_pip_audit.py` runs `pip-audit --skip-editable` when `CI=true` (GitHub Actions sets this)
- `pip-audit` added to the `dev` optional dependency extra
- Docs: CONTRIBUTING, SECURITY, branch-protection, CHANGELOG

### How it strengthens CI
Existing **Quality (Python 3.11 / 3.12)** jobs already run `pytest test/unit`. The new test runs there automatically and fails the check if `pip-audit` reports vulnerabilities.

Local:
```bash
pip install -e ".[dev]"
RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q
```

Skip if needed: `SKIP_PIP_AUDIT=1`.

### Why not a dedicated workflow job?
GitHub rejects pushes that create/update files under `.github/workflows/` unless the credential has the **`workflow`** OAuth scope. This approach delivers the same security outcome on every Quality run without that permission.

Optional later (with `workflow` scope): split into a named `Python security` job + `persist-credentials: false` + timeouts on workflow steps.

## Test plan
- [x] Clean venv: `CI=true pytest test/unit/test_pip_audit.py` passes
- [x] Branch pushed without workflow edits
- [ ] CI green on this PR (Quality must run pip-audit and pass)
- [ ] Confirm required checks on `main` still include Quality 3.11 / 3.12 / Go
