### PR TITLE
fix: log TOOL_CALL/TOOL_RESULT for non-gated tools in run_step

### DIFF
--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -48,6 +48,23 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
                 result = durable_tool(gated)(**call["args"])
             else:
                 result = durable_tool(tool.fn)(**call["args"])
+                # Plain tools still need IR history audit; gate path already logs.
+                node_log.append(
+                    "TOOL_CALL",
+                    step_n,
+                    {"tool": call["name"], "args": call["args"]},
+                    trajectory_id,
+                    tenant_id,
+                    seq=seq,
+                )
+                node_log.append(
+                    "TOOL_RESULT",
+                    step_n,
+                    {"result": result},
+                    trajectory_id,
+                    tenant_id,
+                    seq=seq + 1,
+                )
             results.append(result)
 
         node_log.append(

--- a/test/unit/test_step.py
+++ b/test/unit/test_step.py
@@ -1,0 +1,47 @@
+from dbos import SetWorkflowID
+
+from drivers.durable_backend.dbos.adapter import init_backend
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.resume.step import make_run_step
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.tool import Tool
+
+TRAJECTORY_ID = "test-step-plain-tool"
+TENANT_ID = "demo"
+
+
+def _echo(msg):
+    return msg
+
+
+def _model_call(context):
+    return {"tool_calls": [{"name": "echo", "args": {"msg": "hello"}}]}
+
+
+def test_plain_tool_logs_tool_call_and_result(tmp_path, monkeypatch):
+    """Issue #45: PURE/READ_ONLY/IDEMPOTENT_WRITE tools must still append
+    TOOL_CALL/TOOL_RESULT nodes, matching Go's RunStep. Only the
+    NON_IDEMPOTENT_WRITE gate path is exempt from needing extra logging
+    because make_gated_tool_call already logs both nodes itself."""
+    monkeypatch.chdir(tmp_path)
+
+    node_log = NodeLog(str(tmp_path / "nodes.sqlite"))
+
+    tool_registry = {
+        "echo": Tool(
+            name="echo",
+            fn=_echo,
+            effect_class=EffectClass.PURE,
+        ),
+    }
+
+    run_step = make_run_step(node_log, TENANT_ID, TRAJECTORY_ID, tool_registry)
+
+    init_backend(app_name="test-step-plain-tool")
+
+    with SetWorkflowID(TRAJECTORY_ID):
+        results = run_step(step_n=1, model_call=_model_call, context={})
+
+    assert results == ["hello"]
+    assert node_log.has(TRAJECTORY_ID, 1, "TOOL_CALL", seq=2)
+    assert node_log.has(TRAJECTORY_ID, 1, "TOOL_RESULT", seq=3)


### PR DESCRIPTION
## Summary
- `make_run_step` in `resume/step.py` only appended `TOOL_CALL`/`TOOL_RESULT` node log entries for the gated `NON_IDEMPOTENT_WRITE` path. Plain tools (`PURE`, `READ_ONLY`, `IDEMPOTENT_WRITE`) executed but left no trace in the node log, unlike Go's `RunStep` which logs every tool call.
- Appends both nodes after a plain tool call succeeds, matching the seq layout and behavior already used in `step.go`. The gated path is untouched since `make_gated_tool_call` already logs both nodes.
- Checked `conformance/` first: existing tests build node logs directly rather than through `make_run_step`, so nothing there assumed the old (incomplete) Python behavior.

Before:
<img width="1559" height="204" alt="Screenshot 2026-07-31 150319" src="https://github.com/user-attachments/assets/06db42fa-cd9b-4786-a120-bc3b3feb2cc6" />

After:
<img width="1568" height="221" alt="Screenshot 2026-07-31 150357" src="https://github.com/user-attachments/assets/257e409c-19c5-4f93-9642-19987e105cc7" />


## Test plan
- [x] Added `test/unit/test_step.py::test_plain_tool_logs_tool_call_and_result`, verified it fails against the old code and passes with the fix
- [x] `python -m pytest test/unit -q`
- [x] `python -m pytest conformance -q`
- [x] `python -m pytest test/e2e -q`
- [x] `python -m ruff check pkg/trajectory_ir/resume/step.py test/unit/test_step.py`

Closes #45