### PR TITLE
fix: catch secret-shaped values in .tir redacted export

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,7 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 | Fail-closed MCP effect mapping | Implemented |
 | Atomic TOOL_CALL claim (gate) | Implemented |
 | `.tir` size / path safety limits | Implemented |
-| Redacted export (secret-like keys + thoughts) | Implemented (basic) |
+| Redacted export (secret-like keys/values + thoughts) | Implemented (basic, keyword/pattern heuristic — not a secret scanner; still review before external sharing) |
 | Package digital signatures | Not implemented (reserved) |
 | Full multi-tenant SaaS isolation | Not a product surface yet; tenant_id filter on list/export exists |
 | Fluid / k8s cache poisoning controls | Design only (future profile) |

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -58,8 +58,23 @@ _REQUIRED_MEMBERS = frozenset(
 
 # Keys whose values are redacted in redacted export mode (case-insensitive).
 _SECRET_KEY_RE = re.compile(
-    r"(password|passwd|secret|token|api[_-]?key|authorization|auth|credential|private[_-]?key)",
+    r"(password|passwd|pass[_-]?phrase|secret|token|api[_-]?key|access[_-]?key"
+    r"|authorization|auth|credential|private[_-]?key)",
     re.IGNORECASE,
+)
+
+# Value shapes that look like a secret regardless of the field's key name
+# (e.g. a bearer token embedded in a free-text "note" field). Not a general
+# secret scanner: a fixed set of common, low-false-positive formats. See
+# SECURITY.md "Redacted export" for the scope and limits of this heuristic.
+_SECRET_VALUE_RE = re.compile(
+    r"(AKIA[0-9A-Z]{16}"  # AWS access key id
+    r"|[Bb]earer\s+[A-Za-z0-9\-_.=]{10,}"  # bearer token
+    r"|gh[pousr]_[A-Za-z0-9]{20,}"  # GitHub token
+    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI-style secret key
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"  # Slack token
+    r"|-----BEGIN[ A-Z]*PRIVATE KEY-----"  # PEM private key block
+    r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"  # JWT
 )
 
 
@@ -191,6 +206,8 @@ def _redact_value(key: str, value: Any) -> Any:
         return {k: _redact_value(str(k), v) for k, v in value.items()}
     if isinstance(value, list):
         return [_redact_value(key, item) for item in value]
+    if isinstance(value, str) and _SECRET_VALUE_RE.search(value):
+        return "[REDACTED]"
     return value
 
 
@@ -243,7 +260,11 @@ def export_tir(
 
     Args:
         tenant_id: When set, only that tenant's nodes are exported (isolation).
-        redacted: When True, strip thoughts and secret-like fields before export.
+        redacted: When True, strip thoughts and fields that match a secret-like
+            key name or value shape before export. This is a keyword/pattern
+            heuristic, not a general secret scanner: it will not catch every
+            secret, so ``redacted=True`` output still needs a human review
+            pass before being shared outside the tenant.
     """
     if mode not in ("thin", "fat"):
         raise TirError(f"unsupported mode {mode!r}; use thin or fat")

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -212,6 +212,63 @@ def test_redacted_export_strips_secrets(sample_log: NodeLog, tmp_path: Path) -> 
     assert tool_calls[0]["payload"]["args"]["user"] == "a"
 
 
+def test_redacted_export_strips_missed_key_patterns(
+    sample_log: NodeLog, tmp_path: Path
+) -> None:
+    sample_log.append(
+        "TOOL_CALL",
+        2,
+        {
+            "tool": "login",
+            "args": {
+                "pass_phrase": "correct horse battery staple",
+                "client_aws_access_key": "irrelevant-by-key",
+                "user": "a",
+            },
+        },
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=11,
+    )
+    out = tmp_path / "redacted-keys.tir"
+    export_tir(sample_log, "t-export", out, mode="thin", redacted=True)
+    pkg = load_tir(out)
+    tool_calls = [n for n in pkg.nodes if n["kind"] == "TOOL_CALL" and n["seq"] == 11]
+    assert tool_calls[0]["payload"]["args"]["pass_phrase"] == "[REDACTED]"
+    assert tool_calls[0]["payload"]["args"]["client_aws_access_key"] == "[REDACTED]"
+    assert tool_calls[0]["payload"]["args"]["user"] == "a"
+
+
+def test_redacted_export_strips_secret_shaped_values(
+    sample_log: NodeLog, tmp_path: Path
+) -> None:
+    sample_log.append(
+        "TOOL_CALL",
+        2,
+        {
+            "tool": "note",
+            "args": {
+                "note": "found it: AKIAABCDEFGHIJKLMNOP",
+                "header": "Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+                "message": "just a normal string",
+            },
+        },
+        trajectory_id="t-export",
+        tenant_id="demo",
+        seq=12,
+    )
+    out = tmp_path / "redacted-values.tir"
+    export_tir(sample_log, "t-export", out, mode="thin", redacted=True)
+    pkg = load_tir(out)
+    tool_calls = [n for n in pkg.nodes if n["kind"] == "TOOL_CALL" and n["seq"] == 12]
+    args = tool_calls[0]["payload"]["args"]
+    # Neither "note" nor "header" match _SECRET_KEY_RE; both are caught by
+    # the value-shape pass (AWS access key id, bearer token).
+    assert args["note"] == "[REDACTED]"
+    assert args["header"] == "[REDACTED]"
+    assert args["message"] == "just a normal string"
+
+
 def test_export_tenant_scope(sample_log: NodeLog, tmp_path: Path) -> None:
     other = NodeLog(str(tmp_path / "mixed.sqlite"))
     try:

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -212,9 +212,7 @@ def test_redacted_export_strips_secrets(sample_log: NodeLog, tmp_path: Path) -> 
     assert tool_calls[0]["payload"]["args"]["user"] == "a"
 
 
-def test_redacted_export_strips_missed_key_patterns(
-    sample_log: NodeLog, tmp_path: Path
-) -> None:
+def test_redacted_export_strips_missed_key_patterns(sample_log: NodeLog, tmp_path: Path) -> None:
     sample_log.append(
         "TOOL_CALL",
         2,
@@ -239,9 +237,7 @@ def test_redacted_export_strips_missed_key_patterns(
     assert tool_calls[0]["payload"]["args"]["user"] == "a"
 
 
-def test_redacted_export_strips_secret_shaped_values(
-    sample_log: NodeLog, tmp_path: Path
-) -> None:
+def test_redacted_export_strips_secret_shaped_values(sample_log: NodeLog, tmp_path: Path) -> None:
     sample_log.append(
         "TOOL_CALL",
         2,


### PR DESCRIPTION
Closes #46.

The redacted export only looked at field keys, so a couple of things slipped through:

- key patterns that don't match `_SECRET_KEY_RE`, like `pass_phrase` or `access_key`
- values that look like a secret (AWS keys, bearer tokens, GitHub/OpenAI/Slack tokens, PEM private key blocks, JWTs) sitting under an unrelated key name, e.g. a `note` field containing `key=sk-abc123`

Changes:
- added `pass[_-]?phrase` and `access[_-]?key` to `_SECRET_KEY_RE`
- added a second pass, `_SECRET_VALUE_RE`, that checks string values against a small set of known secret shapes and redacts on match even when the key itself looks harmless
- noted in SECURITY.md and the `export_tir` docstring that this is a keyword/pattern heuristic, not a general secret scanner, so redacted output still needs a human review pass before sharing outside the tenant

Go's `tir.go` doesn't implement redacted export yet (the README already says it's Python-only for now), so there's nothing to port there for this change.

<img width="1183" height="290" alt="image" src="https://github.com/user-attachments/assets/33d0e15d-c1b2-4bf1-8c24-74379613467d" />
<img width="1548" height="279" alt="image" src="https://github.com/user-attachments/assets/0e7f9562-22f8-46bf-b18d-022d18b1be7c" />


## Test plan
- `pytest test/unit/test_tir_package.py -v`
- `pytest conformance/r05_tir_roundtrip_test.py -v`
- manually checked a handful of benign strings (`unbearable`, `authentic`, etc.) don't false-positive against the new value regex