### PR TITLE
fix: require tenant_id on NodeLog list_nodes / ListNodes

### DIFF
--- a/conformance/r05_tir_roundtrip_test.py
+++ b/conformance/r05_tir_roundtrip_test.py
@@ -63,7 +63,7 @@ def test_r05_thin_export_import_preserves_node_ids_and_seals(tmp_path: Path) -> 
     src = NodeLog(str(tmp_path / "src.sqlite"))
     try:
         _seed_trajectory(src)
-        original = src.list_nodes("r05-traj")
+        original = src.list_nodes("r05-traj", tenant_id="demo")
         original_ids = [n["id"] for n in original]
         original_decision_hashes = {
             n["id"]: payload_hash(n["payload"]) for n in original if n["kind"] == "DECISION"
@@ -75,7 +75,7 @@ def test_r05_thin_export_import_preserves_node_ids_and_seals(tmp_path: Path) -> 
         dest = NodeLog(str(tmp_path / "dest.sqlite"))
         try:
             pkg = import_tir(pkg_path, dest)
-            reloaded = dest.list_nodes("r05-traj")
+            reloaded = dest.list_nodes("r05-traj", tenant_id="demo")
             assert [n["id"] for n in reloaded] == original_ids
             assert len(pkg.seals) == len(original_decision_hashes)
             for seal in pkg.seals:
@@ -116,8 +116,8 @@ def test_r05_fat_export_import_preserves_artifact_hashes(tmp_path: Path) -> None
         dest = NodeLog(str(tmp_path / "dest.sqlite"))
         try:
             pkg = import_tir(pkg_path, dest)
-            original_ids = [n["id"] for n in src.list_nodes("r05-fat")]
-            assert [n["id"] for n in dest.list_nodes("r05-fat")] == original_ids
+            original_ids = [n["id"] for n in src.list_nodes("r05-fat", tenant_id="demo")]
+            assert [n["id"] for n in dest.list_nodes("r05-fat", tenant_id="demo")] == original_ids
             assert pkg.manifest["trajectory_id"] == "r05-fat"
         finally:
             dest.close()
@@ -147,6 +147,6 @@ def test_r05_go_golden_fixture_loads_with_matching_ids(tmp_path: Path) -> None:
     try:
         import_tir(golden, dest)
         traj = pkg.manifest["trajectory_id"]
-        assert [n["id"] for n in dest.list_nodes(traj)] == [n["id"] for n in pkg.nodes]
+        assert [n["id"] for n in dest.list_nodes_all_tenants(traj)] == [n["id"] for n in pkg.nodes]
     finally:
         dest.close()

--- a/go/trajir/log/log.go
+++ b/go/trajir/log/log.go
@@ -208,8 +208,23 @@ func (l *NodeLog) Count(nodeID string) (int, error) {
 	return n, err
 }
 
-// ListNodes returns nodes for a trajectory, optionally scoped to tenantID.
-func (l *NodeLog) ListNodes(trajectoryID string, tenantID *string) ([]map[string]any, error) {
+// ListNodes returns nodes for a trajectory scoped to tenantID. tenantID is
+// required so this method always enforces tenant isolation at the read path.
+// Callers that genuinely need rows across tenants (e.g. tir.Export's own
+// mixed-tenant check) must use ListNodesAllTenants explicitly instead.
+func (l *NodeLog) ListNodes(trajectoryID, tenantID string) ([]map[string]any, error) {
+	return l.listNodes(trajectoryID, &tenantID)
+}
+
+// ListNodesAllTenants returns nodes for a trajectory across all tenants.
+// This bypasses tenant isolation and should only be used by code that
+// performs its own tenant-scoping check on the result, such as tir.Export
+// detecting a trajectory with mixed tenant_id values.
+func (l *NodeLog) ListNodesAllTenants(trajectoryID string) ([]map[string]any, error) {
+	return l.listNodes(trajectoryID, nil)
+}
+
+func (l *NodeLog) listNodes(trajectoryID string, tenantID *string) ([]map[string]any, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/go/trajir/log/log_test.go
+++ b/go/trajir/log/log_test.go
@@ -187,13 +187,19 @@ func TestListNodesTenantFilter(t *testing.T) {
 	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "b"}, "t1", "tenant-b", 2); err != nil {
 		t.Fatal(err)
 	}
-	tenant := "tenant-a"
-	rows, err := nl.ListNodes("t1", &tenant)
+	rows, err := nl.ListNodes("t1", "tenant-a")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(rows) != 1 || rows[0]["tenant_id"] != "tenant-a" {
 		t.Fatalf("rows=%v", rows)
+	}
+	allRows, err := nl.ListNodesAllTenants("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allRows) != 2 {
+		t.Fatalf("allRows=%v", allRows)
 	}
 }
 

--- a/go/trajir/tir/tir.go
+++ b/go/trajir/tir/tir.go
@@ -272,7 +272,13 @@ func Export(nodeLog *nodelog.NodeLog, trajectoryID, dest string, opts ExportOpti
 		return "", fmt.Errorf("%w: unsupported mode %q; use thin or fat", ErrTir, mode)
 	}
 
-	nodeList, err := nodeLog.ListNodes(trajectoryID, opts.TenantID)
+	var nodeList []map[string]any
+	var err error
+	if opts.TenantID != nil {
+		nodeList, err = nodeLog.ListNodes(trajectoryID, *opts.TenantID)
+	} else {
+		nodeList, err = nodeLog.ListNodesAllTenants(trajectoryID)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/go/trajir/tir/tir_test.go
+++ b/go/trajir/tir/tir_test.go
@@ -88,11 +88,11 @@ func TestExportImportRoundTripThin(t *testing.T) {
 		t.Fatalf("count=%d err=%v", n, err)
 	}
 
-	srcNodes, err := src.ListNodes("t-export", nil)
+	srcNodes, err := src.ListNodes("t-export", "demo")
 	if err != nil {
 		t.Fatal(err)
 	}
-	dstNodes, err := dest.ListNodes("t-export", nil)
+	dstNodes, err := dest.ListNodes("t-export", "demo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestIdempotentReimport(t *testing.T) {
 	if _, err := tir.Import(out, dest); err != nil {
 		t.Fatal(err)
 	}
-	nodes, err := dest.ListNodes("t-export", nil)
+	nodes, err := dest.ListNodes("t-export", "demo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func TestImportPythonGoldenFixture(t *testing.T) {
 		t.Fatal("empty package")
 	}
 	traj, _ := pkg.Manifest["trajectory_id"].(string)
-	nodes, err := dest.ListNodes(traj, nil)
+	nodes, err := dest.ListNodesAllTenants(traj)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -248,7 +248,10 @@ def export_tir(
     if mode not in ("thin", "fat"):
         raise TirError(f"unsupported mode {mode!r}; use thin or fat")
 
-    nodes = node_log.list_nodes(trajectory_id, tenant_id=tenant_id)
+    if tenant_id is not None:
+        nodes = node_log.list_nodes(trajectory_id, tenant_id=tenant_id)
+    else:
+        nodes = node_log.list_nodes_all_tenants(trajectory_id)
     if not nodes:
         raise TirError(f"no nodes for trajectory_id={trajectory_id!r}")
 

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -196,13 +196,32 @@ class NodeLog:
         self,
         trajectory_id: str,
         *,
-        tenant_id: str | None = None,
+        tenant_id: str,
     ) -> list[dict[str, Any]]:
         """Return stored nodes for a trajectory ordered by step then seq.
 
-        When ``tenant_id`` is set, only that tenant's rows are returned
-        (multi-tenant isolation at the read path).
+        ``tenant_id`` is required so this method always enforces tenant
+        isolation at the read path. Callers that genuinely need rows across
+        tenants (e.g. ``export_tir``'s own mixed-tenant check) must use
+        ``list_nodes_all_tenants`` explicitly instead.
         """
+        return self._list_nodes(trajectory_id, tenant_id=tenant_id)
+
+    def list_nodes_all_tenants(self, trajectory_id: str) -> list[dict[str, Any]]:
+        """Return stored nodes for a trajectory across all tenants.
+
+        This bypasses tenant isolation and should only be used by code that
+        performs its own tenant-scoping check on the result, such as
+        ``export_tir`` detecting a trajectory with mixed ``tenant_id`` values.
+        """
+        return self._list_nodes(trajectory_id, tenant_id=None)
+
+    def _list_nodes(
+        self,
+        trajectory_id: str,
+        *,
+        tenant_id: str | None,
+    ) -> list[dict[str, Any]]:
         sql = """
             SELECT id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts
             FROM nodes

--- a/test/unit/test_node_log.py
+++ b/test/unit/test_node_log.py
@@ -80,7 +80,7 @@ def test_list_nodes_tenant_filter(log):
     only_a = log.list_nodes("t1", tenant_id="tenant-a")
     assert len(only_a) == 1
     assert only_a[0]["tenant_id"] == "tenant-a"
-    all_nodes = log.list_nodes("t1")
+    all_nodes = log.list_nodes_all_tenants("t1")
     assert len(all_nodes) == 2
 
 

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -82,17 +82,19 @@ def test_export_import_round_trip_thin(sample_log: NodeLog, tmp_path: Path) -> N
         # Round-trip preserves hashes
         for n in pkg.nodes:
             assert payload_hash(n["payload"]) == payload_hash(
-                sample_log.list_nodes("t-export")[
+                sample_log.list_nodes("t-export", tenant_id="demo")[
                     next(
                         i
-                        for i, x in enumerate(sample_log.list_nodes("t-export"))
+                        for i, x in enumerate(sample_log.list_nodes("t-export", tenant_id="demo"))
                         if x["id"] == n["id"]
                     )
                 ]["payload"]
             )
-        reloaded = dest.list_nodes("t-export")
+        reloaded = dest.list_nodes("t-export", tenant_id="demo")
         assert len(reloaded) == 5
-        assert [n["id"] for n in reloaded] == [n["id"] for n in sample_log.list_nodes("t-export")]
+        assert [n["id"] for n in reloaded] == [
+            n["id"] for n in sample_log.list_nodes("t-export", tenant_id="demo")
+        ]
     finally:
         dest.close()
 
@@ -143,7 +145,7 @@ def test_idempotent_reimport(sample_log: NodeLog, tmp_path: Path) -> None:
     try:
         import_tir(out, dest)
         import_tir(out, dest)
-        assert len(dest.list_nodes("t-export")) == 5
+        assert len(dest.list_nodes("t-export", tenant_id="demo")) == 5
     finally:
         dest.close()
 


### PR DESCRIPTION
Closes #47.

`NodeLog.list_nodes` in `runtime/log.py` and `ListNodes` in `log/log.go` accepted an optional tenant_id and returned every row for a trajectory_id across all tenants when it was omitted. The only caller (`export_tir` / `Export`) caught mixed-tenant results after the fact, so nothing leaked today, but that safety was incidental to the caller, not enforced by the log layer itself. The next caller that looks up nodes by trajectory id without its own tenant check (an API endpoint, a CLI command, anything) would get another tenant's node payloads for free if trajectory ids ever collide across tenants.

Changes:
- `tenant_id` is now a required keyword arg on `list_nodes` (Python) and `tenantID` a required positional arg on `ListNodes` (Go)
- added `list_nodes_all_tenants` / `ListNodesAllTenants` as the explicit "give me cross-tenant rows" escape hatch, used only by `export_tir` / `Export` for their own mixed-tenant check when no tenant_id is passed in
- updated the existing tests and fixtures to pass tenant_id explicitly where the tenant is known, or use the new all-tenants method where it isn't (golden fixture round trip tests)
<img width="1443" height="186" alt="image" src="https://github.com/user-attachments/assets/3bb02681-3a5d-4438-905b-fc39880a4e29" />

## Test plan
- `pytest test/unit/test_node_log.py test/unit/test_tir_package.py conformance/r05_tir_roundtrip_test.py -v`
- `pytest` (full suite)
- `go test ./...`
- `go build ./...` and `go vet ./...`
