### PR TITLE
feat: R03 PURE tool recompute-on-resume conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go `.tir` thin/fat export and import (`trajir/tir`) with Python layout parity,
   hash verification, zip limits/path safety, and cross-language golden fixture.
 - R05 conformance tests for `.tir` thin/fat round-trip and golden fixture load.
+- R03 PURE recompute-on-resume: `requires_block_and_gate` / `RequiresBlockAndGate`,
+  conformance + Go tests; only NON_IDEMPOTENT_WRITE is gated.
 
 
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ These are runnable tests, not descriptions of intent. R01 and R02 are the hard g
 |---|---|
 | **R01** | Seal a decision, kill the process, resume: the model is not invoked again; tools execute from the seal. |
 | **R02** | A non idempotent tool (e.g. simulated deploy) is killed mid execution; on resume, the system does not double execute it, it follows the block and gate path. |
-| R03 | A `PURE` tool may be recomputed freely on resume. |
+| R03 | A `PURE` tool may be recomputed freely on resume. Runnable: `conformance/r03_pure_recompute_test.py` (and Go `go test ./trajir/resume -run R03`). |
 | R04 | A `CONSTRAINT` node is never silently dropped under budget pressure; the system either includes it or raises a hard error. |
 | R05 | Export and re import of a `.tir` package preserves all node hashes and seals exactly. Runnable: `conformance/r05_tir_roundtrip_test.py` (and Go `go test ./trajir/tir`). |
 | R06 | A sandbox/what if branch rejects any real `NON_IDEMPOTENT_WRITE` execution. |

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from drivers.durable_backend.dbos.adapter import init_backend
-from trajectory_ir.effects import EffectClass
+from trajectory_ir.effects import requires_block_and_gate
 from trajectory_ir.resume.gate import make_gated_tool_call
 from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.tool import Tool
@@ -79,7 +79,7 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool, seq: 
         ToolResult with the tool execution result
     """
     log = NodeLog(trajectory.db_path)
-    if tool.effect_class == EffectClass.NON_IDEMPOTENT_WRITE:
+    if requires_block_and_gate(tool.effect_class):
         fn = make_gated_tool_call(
             log,
             trajectory.trajectory_id,

--- a/conformance/r03_pure_recompute_test.py
+++ b/conformance/r03_pure_recompute_test.py
@@ -1,0 +1,111 @@
+"""Conformance test for R03: PURE tools may recompute freely on resume.
+
+README §10 R03 — A PURE tool may be recomputed freely on resume.
+
+This is the dual of R02: NON_IDEMPOTENT_WRITE is block-and-gated, while PURE
+must never raise BlockedNeedsGate solely because a prior TOOL_CALL exists for
+the same step/seq.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trajectory_ir.effects import EffectClass, requires_block_and_gate
+from trajectory_ir.resume.gate import BlockedNeedsGate, make_gated_tool_call
+from trajectory_ir.runtime.log import NodeLog
+
+# Module-level callables: DBOS pickles workflow args (same pattern as kill-mid-deploy).
+_R03_CALLS = {"n": 0}
+
+
+def _r03_compute(x: int = 0) -> int:
+    _R03_CALLS["n"] += 1
+    return _R03_CALLS["n"]
+
+
+def _r03_model_call(context: dict) -> dict:
+    return {"tool_calls": [{"name": "compute", "args": {"x": 1}}]}
+
+
+def test_r03_requires_block_and_gate_matrix() -> None:
+    """Only NON_IDEMPOTENT_WRITE is gated; PURE is not (R02 vs R03)."""
+    assert requires_block_and_gate(EffectClass.NON_IDEMPOTENT_WRITE) is True
+    assert requires_block_and_gate(EffectClass.PURE) is False
+    assert requires_block_and_gate(EffectClass.READ_ONLY) is False
+    assert requires_block_and_gate(EffectClass.IDEMPOTENT_WRITE) is False
+
+
+def test_r03_pure_tool_may_recompute_after_prior_tool_call(tmp_path) -> None:
+    """R03: a prior TOOL_CALL for a PURE tool does not block recompute.
+
+    Simulate history with TOOL_CALL at seq=2, then re-run the PURE body (as the
+    non-gated path would). Counter must increase twice; BlockedNeedsGate must
+    not fire on the pure path. The same history under the gate still blocks (R02).
+    """
+    traj, tenant = "r03-pure", "demo"
+    log = NodeLog(str(tmp_path / "nodes.sqlite"))
+    try:
+        log.append(
+            "TOOL_CALL",
+            1,
+            {"tool": "compute", "args": {}},
+            traj,
+            tenant,
+            2,
+        )
+
+        calls = {"n": 0}
+
+        def compute() -> int:
+            calls["n"] += 1
+            return calls["n"]
+
+        # Non-gated path (R03 / make_run_step else branch): call body freely.
+        assert compute() == 1
+        assert compute() == 2
+        assert calls["n"] == 2
+
+        # Contrast R02: the same history under the gate would block.
+        gated = make_gated_tool_call(log, traj, tenant, 1, 2, "compute", compute)
+        with pytest.raises(BlockedNeedsGate) as ei:
+            gated()
+        assert ei.value.step_n == 1
+        assert ei.value.tool_name == "compute"
+        assert calls["n"] == 2
+        assert log.has(traj, 1, "ABORT", seq=3)
+    finally:
+        log.close()
+
+
+def test_r03_pure_run_step_does_not_block_on_second_invocation(tmp_path, monkeypatch) -> None:
+    """R03 via make_run_step: two durable steps with PURE never raise the gate."""
+    from dbos import SetWorkflowID
+
+    from drivers.durable_backend.dbos.adapter import init_backend
+    from trajectory_ir.resume.step import make_run_step
+    from trajectory_ir.runtime.tool import Tool
+
+    monkeypatch.chdir(tmp_path)
+    traj, tenant = "r03-run-step", "demo"
+    log = NodeLog(str(tmp_path / "nodes.sqlite"))
+    _R03_CALLS["n"] = 0
+
+    registry = {
+        "compute": Tool(name="compute", fn=_r03_compute, effect_class=EffectClass.PURE),
+    }
+    run_step = make_run_step(log, tenant, traj, registry)
+    init_backend(app_name="r03-pure-recompute")
+
+    with SetWorkflowID(f"{traj}-a"):
+        r1 = run_step(step_n=1, model_call=_r03_model_call, context={})
+    with SetWorkflowID(f"{traj}-b"):
+        r2 = run_step(step_n=2, model_call=_r03_model_call, context={})
+
+    assert r1 == [1]
+    assert r2 == [2]
+    assert _R03_CALLS["n"] == 2
+    assert log.has(traj, 1, "TOOL_CALL", seq=2)
+    assert log.has(traj, 2, "TOOL_CALL", seq=2)
+    assert not log.has(traj, 1, "ABORT", seq=3)
+    assert not log.has(traj, 2, "ABORT", seq=3)

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -173,7 +173,7 @@ func (t *Trajectory) ExecTool(stepN, seq int, tool resume.Tool, args map[string]
 		args = map[string]any{}
 	}
 	fn := tool.Fn
-	if tool.Effect == effects.NON_IDEMPOTENT_WRITE {
+	if effects.RequiresBlockAndGate(tool.Effect) {
 		fn = resume.MakeGatedToolCall(
 			t.log,
 			t.TrajectoryID,

--- a/go/trajir/effects/effects.go
+++ b/go/trajir/effects/effects.go
@@ -14,6 +14,13 @@ const (
 	SENSITIVE            EffectClass = "SENSITIVE"
 )
 
+// RequiresBlockAndGate reports whether resume must gate this effect (R02).
+// Only NON_IDEMPOTENT_WRITE is gated. PURE (R03) and other classes may
+// re-execute on resume without BlockedNeedsGate.
+func RequiresBlockAndGate(e EffectClass) bool {
+	return e == NON_IDEMPOTENT_WRITE
+}
+
 // ClassifyFromMCP maps MCP tool annotations to an EffectClass.
 // Missing or ambiguous input becomes NON_IDEMPOTENT_WRITE.
 //

--- a/go/trajir/effects/effects_test.go
+++ b/go/trajir/effects/effects_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
 )
 
+func TestRequiresBlockAndGate(t *testing.T) {
+	if !effects.RequiresBlockAndGate(effects.NON_IDEMPOTENT_WRITE) {
+		t.Fatal("NON_IDEMPOTENT_WRITE must be gated (R02)")
+	}
+	for _, e := range []effects.EffectClass{
+		effects.PURE,
+		effects.READ_ONLY,
+		effects.IDEMPOTENT_WRITE,
+		effects.AGENT_SPAWN,
+		effects.SENSITIVE,
+	} {
+		if effects.RequiresBlockAndGate(e) {
+			t.Fatalf("%s must not be gated (R03 matrix)", e)
+		}
+	}
+}
+
 func TestMissingAnnotationsFailClosed(t *testing.T) {
 	if got := effects.ClassifyFromMCP(map[string]any{}); got != effects.NON_IDEMPOTENT_WRITE {
 		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)

--- a/go/trajir/resume/gate_test.go
+++ b/go/trajir/resume/gate_test.go
@@ -110,4 +110,50 @@ func TestErrorTextIncludesStepAndTool(t *testing.T) {
 	}
 }
 
+// TestR03PureRecomputeNotBlocked locks R03: PURE tools are not claim-gated.
+// A prior TOOL_CALL at the same seq would block under MakeGatedToolCall (R02),
+// but the non-gated path may call the body freely and recompute.
+func TestR03PureRecomputeNotBlocked(t *testing.T) {
+	nl := openLog(t)
+	step := 1
+	if _, err := nl.Append(
+		"TOOL_CALL",
+		&step,
+		map[string]any{"tool": "compute", "args": map[string]any{}},
+		"t1",
+		"demo",
+		2,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	pure := func(map[string]any) (any, error) {
+		calls++
+		return calls, nil
+	}
+
+	// Non-gated path (RunStep else branch for PURE): recompute freely.
+	if _, err := pure(nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pure(nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls=%d want 2", calls)
+	}
+
+	// Same history under the gate would block (R02 dual).
+	gated := resume.MakeGatedToolCall(nl, "t1", "demo", 1, 2, "compute", pure)
+	_, err := gated(nil)
+	var blocked *resume.BlockedNeedsGate
+	if !errors.As(err, &blocked) {
+		t.Fatalf("want BlockedNeedsGate, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("gate re-ran body: calls=%d", calls)
+	}
+}
+
 func intPtr(v int) *int { return &v }

--- a/go/trajir/resume/step.go
+++ b/go/trajir/resume/step.go
@@ -32,7 +32,10 @@ type RunStepConfig struct {
 }
 
 // RunStep executes one agent step: project context, durable infer, DECISION seal,
-// tools (gated when NON_IDEMPOTENT_WRITE), then COMMIT_STEP.
+// tools (gated when RequiresBlockAndGate), then COMMIT_STEP.
+//
+// Resume matrix (README §8, R02 / R03): NON_IDEMPOTENT_WRITE is block-and-gated;
+// PURE and other non-gated classes may recompute on resume without BlockedNeedsGate.
 //
 // Seq layout matches Python make_run_step:
 //
@@ -110,7 +113,7 @@ func RunStep(
 
 		var result any
 		stepKey := fmt.Sprintf("%s@%d", call.Name, seq)
-		if tool.Effect == effects.NON_IDEMPOTENT_WRITE {
+		if effects.RequiresBlockAndGate(tool.Effect) {
 			gated := MakeGatedToolCall(
 				cfg.Log,
 				cfg.TrajectoryID,

--- a/pkg/trajectory_ir/effects/__init__.py
+++ b/pkg/trajectory_ir/effects/__init__.py
@@ -1,3 +1,7 @@
-from trajectory_ir.effects.classify import EffectClass, classify_from_mcp
+from trajectory_ir.effects.classify import (
+    EffectClass,
+    classify_from_mcp,
+    requires_block_and_gate,
+)
 
-__all__ = ["EffectClass", "classify_from_mcp"]
+__all__ = ["EffectClass", "classify_from_mcp", "requires_block_and_gate"]

--- a/pkg/trajectory_ir/effects/classify.py
+++ b/pkg/trajectory_ir/effects/classify.py
@@ -10,6 +10,17 @@ class EffectClass(Enum):
     SENSITIVE = "SENSITIVE"
 
 
+def requires_block_and_gate(effect: EffectClass) -> bool:
+    """Whether resume must gate this effect class (README §8 / R02).
+
+    Only ``NON_IDEMPOTENT_WRITE`` is block-and-gated. ``PURE`` (R03) and other
+    non-gated classes may re-execute on resume without raising
+    ``BlockedNeedsGate``; durable memoization may still skip re-running the body
+    when a prior step result was already recorded.
+    """
+    return effect is EffectClass.NON_IDEMPOTENT_WRITE
+
+
 def classify_from_mcp(annotations: dict) -> EffectClass:
     """Fail-closed per spec §7.2. Any missing or ambiguous annotation -> NON_IDEMPOTENT_WRITE.
 

--- a/pkg/trajectory_ir/resume/gate.py
+++ b/pkg/trajectory_ir/resume/gate.py
@@ -24,6 +24,9 @@ def make_gated_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_n
     """Wrap a NON_IDEMPOTENT_WRITE tool so that a crash anywhere after the call
     started blocks instead of silently re-running the side effect on resume.
 
+    Only for effects where ``requires_block_and_gate`` is true (R02). PURE tools
+    (R03) must not use this wrapper — they may recompute freely on resume.
+
     Uses our own content-addressed NodeLog as the source of truth for "was this
     call already attempted," rather than DBOS's internal workflow-status API --
     this avoids depending on an internal API that may change between DBOS

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -3,11 +3,20 @@ from drivers.durable_backend.dbos.adapter import (
     durable_tool,
     durable_workflow,
 )
-from trajectory_ir.effects import EffectClass
+from trajectory_ir.effects import requires_block_and_gate
 from trajectory_ir.resume.gate import make_gated_tool_call
 
 
 def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision_sealed=None):
+    """Build a durable run_step workflow for one agent step.
+
+    Resume matrix (README §8, R02 / R03):
+    - ``NON_IDEMPOTENT_WRITE``: block-and-gate via ``make_gated_tool_call`` (R02).
+    - ``PURE`` and other non-gated classes: no gate; body may re-run on resume
+      when durable memo is absent (R03 for PURE). Prior TOOL_CALL rows alone
+      must not raise ``BlockedNeedsGate`` for these classes.
+    """
+
     @durable_workflow
     def run_step(step_n: int, model_call, context: dict):
         node_log.append("PROJECT_CONTEXT", step_n, context, trajectory_id, tenant_id, seq=0)
@@ -35,7 +44,7 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
             # call already attempted" by looking up (step_n, seq), so seq has to
             # identify one call unambiguously.
             seq = 2 + 2 * i
-            if tool.effect_class == EffectClass.NON_IDEMPOTENT_WRITE:
+            if requires_block_and_gate(tool.effect_class):
                 gated = make_gated_tool_call(
                     node_log,
                     trajectory_id,
@@ -47,6 +56,7 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
                 )
                 result = durable_tool(gated)(**call["args"])
             else:
+                # R03: PURE (and other non-gated classes) are not claim-gated.
                 result = durable_tool(tool.fn)(**call["args"])
                 # Plain tools still need IR history audit; gate path already logs.
                 node_log.append(

--- a/test/unit/test_effects.py
+++ b/test/unit/test_effects.py
@@ -1,4 +1,4 @@
-from trajectory_ir.effects import EffectClass, classify_from_mcp
+from trajectory_ir.effects import EffectClass, classify_from_mcp, requires_block_and_gate
 
 
 def test_missing_annotations_fail_closed():
@@ -48,3 +48,12 @@ def test_open_world_idempotent_write_fails_closed():
 
 def test_non_dict_annotations_fail_closed():
     assert classify_from_mcp(None) == EffectClass.NON_IDEMPOTENT_WRITE  # type: ignore[arg-type]
+
+
+def test_requires_block_and_gate_only_non_idempotent():
+    assert requires_block_and_gate(EffectClass.NON_IDEMPOTENT_WRITE) is True
+    assert requires_block_and_gate(EffectClass.PURE) is False
+    assert requires_block_and_gate(EffectClass.READ_ONLY) is False
+    assert requires_block_and_gate(EffectClass.IDEMPOTENT_WRITE) is False
+    assert requires_block_and_gate(EffectClass.AGENT_SPAWN) is False
+    assert requires_block_and_gate(EffectClass.SENSITIVE) is False


### PR DESCRIPTION
## Summary
Implements **R03** (PURE tools may recompute freely on resume) as a named, tested resume-matrix contract. Closes #44.

### Changes
- `requires_block_and_gate` (Python) / `RequiresBlockAndGate` (Go)  only `NON_IDEMPOTENT_WRITE` is gated
- Wired through `make_run_step`, Python client `exec_tool`, Go `RunStep` / `ExecTool`
- Docs on resume matrix in step/gate modules
- `conformance/r03_pure_recompute_test.py`  matrix + dual vs gate + durable PURE run_step
- Go `TestR03PureRecomputeNotBlocked`
- README §10 marks R03 runnable; CHANGELOG

### Test plan
- [x] `pytest conformance/ test/unit/test_effects.py test/unit/test_step.py`
- [x] `go test ./trajir/effects ./trajir/resume ./trajir/client` (local Windows may block tir.test binary; CI is authoritative)
- [ ] CI green
