### PR TITLE
feat: R04 default context projector with CONSTRAINT budget safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - R05 conformance tests for `.tir` thin/fat round-trip and golden fixture load.
 - R03 PURE recompute-on-resume: `requires_block_and_gate` / `RequiresBlockAndGate`,
   conformance + Go tests; only NON_IDEMPOTENT_WRITE is gated.
+- R04 default context projector (`project_context` / `trajir/projector`) with
+  CONSTRAINT+pinned budget safety and `BUDGET_IMPOSSIBLE`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ These are runnable tests, not descriptions of intent. R01 and R02 are the hard g
 | **R01** | Seal a decision, kill the process, resume: the model is not invoked again; tools execute from the seal. |
 | **R02** | A non idempotent tool (e.g. simulated deploy) is killed mid execution; on resume, the system does not double execute it, it follows the block and gate path. |
 | R03 | A `PURE` tool may be recomputed freely on resume. Runnable: `conformance/r03_pure_recompute_test.py` (and Go `go test ./trajir/resume -run R03`). |
-| R04 | A `CONSTRAINT` node is never silently dropped under budget pressure; the system either includes it or raises a hard error. |
+| R04 | A `CONSTRAINT` node is never silently dropped under budget pressure; the system either includes it or raises a hard error. Runnable: `conformance/r04_constraint_budget_test.py` (and Go `go test ./trajir/projector`). |
 | R05 | Export and re import of a `.tir` package preserves all node hashes and seals exactly. Runnable: `conformance/r05_tir_roundtrip_test.py` (and Go `go test ./trajir/tir`). |
 | R06 | A sandbox/what if branch rejects any real `NON_IDEMPOTENT_WRITE` execution. |
 | R07 | Grafting an artifact between agents transfers only the artifact reference, never private `THOUGHT` nodes. |

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -41,6 +41,12 @@ def open_trajectory(
 
 
 def project(trajectory: Trajectory, step_n: int, context: dict) -> ProjectContext:
+    """Record a PROJECT_CONTEXT node (caller-supplied or projector-built context).
+
+    For budgeted assembly from the node log, use
+    ``trajectory_ir.runtime.project_context`` first, then pass its
+    ``ProjectResult.context`` here.
+    """
     NodeLog(trajectory.db_path).append(
         "PROJECT_CONTEXT",
         step_n,

--- a/conformance/r04_constraint_budget_test.py
+++ b/conformance/r04_constraint_budget_test.py
@@ -1,0 +1,71 @@
+"""Conformance test for R04: CONSTRAINT never silently dropped under budget.
+
+README §10 R04 — A CONSTRAINT node is never silently dropped under budget
+pressure; the system either includes it or raises a hard error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trajectory_ir.runtime.projector import (
+    BudgetImpossible,
+    node_size_units,
+    project_context,
+)
+
+
+def _node(nid: str, kind: str, payload: dict, *, seq: int = 0) -> dict:
+    return {
+        "id": nid,
+        "kind": kind,
+        "payload": payload,
+        "step_n": 1,
+        "seq": seq,
+        "trajectory_id": "r04",
+        "tenant_id": "demo",
+    }
+
+
+def test_r04_all_constraints_included_when_budget_allows() -> None:
+    nodes = [
+        _node("c-a", "CONSTRAINT", {"rule": "A"}, seq=0),
+        _node("c-b", "CONSTRAINT", {"rule": "B"}, seq=1),
+        _node("thought", "THOUGHT", {"text": "optional"}, seq=2),
+    ]
+    budget = sum(node_size_units(n) for n in nodes)
+    result = project_context(nodes, budget=budget)
+    assert "c-a" in result.included_ids
+    assert "c-b" in result.included_ids
+    assert set(result.context["included_ids"]) == set(result.included_ids)
+
+
+def test_r04_budget_impossible_never_partial_drops_constraints() -> None:
+    """If constraints alone exceed budget, fail hard — do not return a subset."""
+    payload = {"rule": "long-" + ("Z" * 300)}
+    nodes = [
+        _node("c1", "CONSTRAINT", payload, seq=0),
+        _node("c2", "CONSTRAINT", payload, seq=1),
+    ]
+    must = sum(node_size_units(n) for n in nodes)
+    with pytest.raises(BudgetImpossible) as ei:
+        project_context(nodes, budget=max(1, must // 2))
+    assert ei.value.required_size > ei.value.budget
+    assert "BUDGET_IMPOSSIBLE" in str(ei.value)
+
+
+def test_r04_trims_optional_nodes_but_keeps_every_constraint() -> None:
+    constraints = [
+        _node("c1", "CONSTRAINT", {"rule": "must"}, seq=0),
+        _node("c2", "CONSTRAINT", {"rule": "also"}, seq=1),
+    ]
+    optional = [_node(f"o{i}", "STATE_SET", {"k": "v" * 30}, seq=10 + i) for i in range(8)]
+    nodes = constraints + optional
+    c_size = sum(node_size_units(n) for n in constraints)
+    # Enough for both constraints + zero or one optional
+    budget = c_size + node_size_units(optional[0])
+    result = project_context(nodes, budget=budget)
+    assert "c1" in result.included_ids and "c2" in result.included_ids
+    for cid in ("c1", "c2"):
+        assert cid not in result.dropped_ids
+    assert any(d.startswith("o") for d in result.dropped_ids)

--- a/go/README.md
+++ b/go/README.md
@@ -14,7 +14,7 @@ Second language implementation of Trajectory IR primitives. Python remains the P
 | `trajir/resume` | Block and gate, and RunStep seal path for one agent step |
 | `trajir/client` | Thin SDK: open, project, seal, exec, commit, resume, RunStep |
 | `trajir/tir` | Portable `.tir` package export / import (thin and fat) |
-| `trajir/projector` | Default context projector (R04 CONSTRAINT budget safety) |
+| `trajir/projector` | Default context projector (R04; size metric = RFC 8785 / JCS bytes) |
 
 ## Durable backend decision (issues #16 and #24)
 

--- a/go/README.md
+++ b/go/README.md
@@ -14,6 +14,7 @@ Second language implementation of Trajectory IR primitives. Python remains the P
 | `trajir/resume` | Block and gate, and RunStep seal path for one agent step |
 | `trajir/client` | Thin SDK: open, project, seal, exec, commit, resume, RunStep |
 | `trajir/tir` | Portable `.tir` package export / import (thin and fat) |
+| `trajir/projector` | Default context projector (R04 CONSTRAINT budget safety) |
 
 ## Durable backend decision (issues #16 and #24)
 

--- a/go/trajir/projector/projector.go
+++ b/go/trajir/projector/projector.go
@@ -1,15 +1,20 @@
 // Package projector implements the default context projector (R04).
 //
-// Metric json_chars: UTF-8 length of compact sort-keyed JSON
-// {"kind":...,"payload":...} per node. Matches Python
-// pkg/trajectory_ir/runtime/projector.py.
+// Metric rfc8785_bytes: length of RFC 8785 (JCS) canonical form of
+// {"kind":...,"payload":...} per node. Same JCS stack as trajir/nodes
+// (github.com/gowebpki/jcs) so size units match Python rfc8785.
 package projector
 
 import (
 	"encoding/json"
 	"fmt"
 	"sort"
+
+	"github.com/gowebpki/jcs"
 )
+
+// SizeMetric is the documented budget unit name (parity with Python SIZE_METRIC).
+const SizeMetric = "rfc8785_bytes"
 
 // BudgetImpossible is raised when CONSTRAINT/pinned nodes alone exceed budget.
 type BudgetImpossible struct {
@@ -35,19 +40,23 @@ type Result struct {
 	Metric      string
 }
 
-// NodeSizeUnits returns the json_chars size of one node record.
+// NodeSizeUnits returns the rfc8785_bytes size of one node record (JCS length).
 func NodeSizeUnits(node map[string]any) (int, error) {
 	kind, _ := node["kind"].(string)
 	payload := node["payload"]
 	if payload == nil {
 		payload = map[string]any{}
 	}
+	// encoding/json then jcs.Transform — same pattern as nodes.PayloadHash.
 	raw, err := json.Marshal(map[string]any{"kind": kind, "payload": payload})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("json marshal: %w", err)
 	}
-	// encoding/json sorts map keys; matches Python sort_keys=True for this shape.
-	return len(raw), nil
+	canon, err := jcs.Transform(raw)
+	if err != nil {
+		return 0, fmt.Errorf("jcs: %w", err)
+	}
+	return len(canon), nil
 }
 
 type sortKey struct {
@@ -192,11 +201,11 @@ func ProjectContext(nodes []map[string]any, budget int, pinnedIDs map[string]str
 		})
 	}
 	ctx := map[string]any{
-		"items":         items,
-		"included_ids":  ids,
-		"budget":        budget,
-		"size_units":    used,
-		"metric":        "json_chars",
+		"items":        items,
+		"included_ids": ids,
+		"budget":       budget,
+		"size_units":   used,
+		"metric":       SizeMetric,
 	}
 	return &Result{
 		IncludedIDs: ids,
@@ -204,6 +213,6 @@ func ProjectContext(nodes []map[string]any, budget int, pinnedIDs map[string]str
 		Context:     ctx,
 		SizeUnits:   used,
 		Budget:      budget,
-		Metric:      "json_chars",
+		Metric:      SizeMetric,
 	}, nil
 }

--- a/go/trajir/projector/projector.go
+++ b/go/trajir/projector/projector.go
@@ -1,0 +1,209 @@
+// Package projector implements the default context projector (R04).
+//
+// Metric json_chars: UTF-8 length of compact sort-keyed JSON
+// {"kind":...,"payload":...} per node. Matches Python
+// pkg/trajectory_ir/runtime/projector.py.
+package projector
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// BudgetImpossible is raised when CONSTRAINT/pinned nodes alone exceed budget.
+type BudgetImpossible struct {
+	RequiredSize int
+	Budget       int
+}
+
+func (e *BudgetImpossible) Error() string {
+	return fmt.Sprintf(
+		"BUDGET_IMPOSSIBLE: CONSTRAINT/pinned size %d exceeds budget %d",
+		e.RequiredSize,
+		e.Budget,
+	)
+}
+
+// Result is the outcome of default projection.
+type Result struct {
+	IncludedIDs []string
+	DroppedIDs  []string
+	Context     map[string]any
+	SizeUnits   int
+	Budget      int
+	Metric      string
+}
+
+// NodeSizeUnits returns the json_chars size of one node record.
+func NodeSizeUnits(node map[string]any) (int, error) {
+	kind, _ := node["kind"].(string)
+	payload := node["payload"]
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	raw, err := json.Marshal(map[string]any{"kind": kind, "payload": payload})
+	if err != nil {
+		return 0, err
+	}
+	// encoding/json sorts map keys; matches Python sort_keys=True for this shape.
+	return len(raw), nil
+}
+
+type sortKey struct {
+	step int
+	seq  int
+	id   string
+	node map[string]any
+}
+
+func nodeSortKey(n map[string]any) sortKey {
+	step := 1_000_000_000
+	if v, ok := n["step_n"].(int); ok {
+		step = v
+	} else if v, ok := n["step_n"].(float64); ok {
+		step = int(v)
+	}
+	seq := 1_000_000_000
+	if v, ok := n["seq"].(int); ok {
+		seq = v
+	} else if v, ok := n["seq"].(float64); ok {
+		seq = int(v)
+	}
+	id, _ := n["id"].(string)
+	return sortKey{step: step, seq: seq, id: id, node: n}
+}
+
+func sortNodes(nodes []map[string]any) []map[string]any {
+	keys := make([]sortKey, len(nodes))
+	for i, n := range nodes {
+		keys[i] = nodeSortKey(n)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		if keys[i].step != keys[j].step {
+			return keys[i].step < keys[j].step
+		}
+		if keys[i].seq != keys[j].seq {
+			return keys[i].seq < keys[j].seq
+		}
+		return keys[i].id < keys[j].id
+	})
+	out := make([]map[string]any, len(keys))
+	for i, k := range keys {
+		out[i] = k.node
+	}
+	return out
+}
+
+// ProjectContext applies the default projector policy.
+func ProjectContext(nodes []map[string]any, budget int, pinnedIDs map[string]struct{}) (*Result, error) {
+	if budget < 0 {
+		return nil, fmt.Errorf("budget must be non-negative")
+	}
+	if pinnedIDs == nil {
+		pinnedIDs = map[string]struct{}{}
+	}
+
+	must := make([]map[string]any, 0)
+	seen := map[string]struct{}{}
+	for _, n := range nodes {
+		id, _ := n["id"].(string)
+		kind, _ := n["kind"].(string)
+		_, pin := pinnedIDs[id]
+		if kind == "CONSTRAINT" || pin {
+			if id != "" {
+				if _, ok := seen[id]; !ok {
+					must = append(must, n)
+					seen[id] = struct{}{}
+				}
+			}
+		}
+	}
+	must = sortNodes(must)
+	mustSize := 0
+	for _, n := range must {
+		sz, err := NodeSizeUnits(n)
+		if err != nil {
+			return nil, err
+		}
+		mustSize += sz
+	}
+	if mustSize > budget {
+		return nil, &BudgetImpossible{RequiredSize: mustSize, Budget: budget}
+	}
+
+	included := make([]map[string]any, 0, len(must))
+	included = append(included, must...)
+	includedIDs := map[string]struct{}{}
+	for _, n := range included {
+		if id, ok := n["id"].(string); ok {
+			includedIDs[id] = struct{}{}
+		}
+	}
+	used := mustSize
+
+	optional := make([]map[string]any, 0)
+	for _, n := range nodes {
+		id, _ := n["id"].(string)
+		if _, ok := includedIDs[id]; !ok {
+			optional = append(optional, n)
+		}
+	}
+	optional = sortNodes(optional)
+	for _, n := range optional {
+		sz, err := NodeSizeUnits(n)
+		if err != nil {
+			return nil, err
+		}
+		if used+sz > budget {
+			continue
+		}
+		included = append(included, n)
+		if id, ok := n["id"].(string); ok {
+			includedIDs[id] = struct{}{}
+		}
+		used += sz
+	}
+	included = sortNodes(included)
+
+	dropped := make([]string, 0)
+	for _, n := range nodes {
+		id, _ := n["id"].(string)
+		if id == "" {
+			continue
+		}
+		if _, ok := includedIDs[id]; !ok {
+			dropped = append(dropped, id)
+		}
+	}
+	sort.Strings(dropped)
+
+	ids := make([]string, 0, len(included))
+	items := make([]map[string]any, 0, len(included))
+	for _, n := range included {
+		id, _ := n["id"].(string)
+		ids = append(ids, id)
+		items = append(items, map[string]any{
+			"id":      n["id"],
+			"kind":    n["kind"],
+			"payload": n["payload"],
+			"step_n":  n["step_n"],
+			"seq":     n["seq"],
+		})
+	}
+	ctx := map[string]any{
+		"items":         items,
+		"included_ids":  ids,
+		"budget":        budget,
+		"size_units":    used,
+		"metric":        "json_chars",
+	}
+	return &Result{
+		IncludedIDs: ids,
+		DroppedIDs:  dropped,
+		Context:     ctx,
+		SizeUnits:   used,
+		Budget:      budget,
+		Metric:      "json_chars",
+	}, nil
+}

--- a/go/trajir/projector/projector_test.go
+++ b/go/trajir/projector/projector_test.go
@@ -1,7 +1,11 @@
 package projector_test
 
 import (
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -108,6 +112,47 @@ func TestTrimOptionalKeepConstraints(t *testing.T) {
 	for _, id := range res.DroppedIDs {
 		if id == "c1" {
 			t.Fatal("constraint in dropped set")
+		}
+	}
+}
+
+func TestProjectorSizeVectorsMatchPythonGoldens(t *testing.T) {
+	// Shared goldens with Python test_projector_size_vectors.py (RFC 8785 / JCS).
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("caller")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	path := filepath.Join(root, "testdata", "projector_size_vectors.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc struct {
+		Version int    `json:"version"`
+		Metric  string `json:"metric"`
+		Cases   []struct {
+			Name      string         `json:"name"`
+			Node      map[string]any `json:"node"`
+			SizeUnits int            `json:"size_units"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Version != 1 || doc.Metric != projector.SizeMetric {
+		t.Fatalf("header version=%d metric=%q", doc.Version, doc.Metric)
+	}
+	if len(doc.Cases) == 0 {
+		t.Fatal("no cases")
+	}
+	for _, c := range doc.Cases {
+		got, err := projector.NodeSizeUnits(c.Node)
+		if err != nil {
+			t.Fatalf("%s: %v", c.Name, err)
+		}
+		if got != c.SizeUnits {
+			t.Fatalf("%s: size_units got %d want %d", c.Name, got, c.SizeUnits)
 		}
 	}
 }

--- a/go/trajir/projector/projector_test.go
+++ b/go/trajir/projector/projector_test.go
@@ -1,0 +1,113 @@
+package projector_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/projector"
+)
+
+func node(id, kind string, payload map[string]any, seq int) map[string]any {
+	return map[string]any{
+		"id":            id,
+		"kind":          kind,
+		"payload":       payload,
+		"step_n":        1,
+		"seq":           seq,
+		"trajectory_id": "t1",
+		"tenant_id":     "demo",
+	}
+}
+
+func TestConstraintsIncludedUnderBudget(t *testing.T) {
+	nodes := []map[string]any{
+		node("c1", "CONSTRAINT", map[string]any{"rule": "a"}, 0),
+		node("t1", "THOUGHT", map[string]any{"text": "hello"}, 1),
+		node("c2", "CONSTRAINT", map[string]any{"rule": "b"}, 2),
+	}
+	budget := 0
+	for _, n := range nodes {
+		sz, err := projector.NodeSizeUnits(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		budget += sz
+	}
+	res, err := projector.ProjectContext(nodes, budget, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, id := range res.IncludedIDs {
+		got[id] = true
+	}
+	if !got["c1"] || !got["c2"] {
+		t.Fatalf("missing constraints: %v", res.IncludedIDs)
+	}
+}
+
+func TestBudgetImpossible(t *testing.T) {
+	payload := map[string]any{"rule": strings.Repeat("x", 200)}
+	nodes := []map[string]any{
+		node("c1", "CONSTRAINT", payload, 0),
+		node("c2", "CONSTRAINT", payload, 1),
+	}
+	must := 0
+	for _, n := range nodes {
+		sz, err := projector.NodeSizeUnits(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		must += sz
+	}
+	_, err := projector.ProjectContext(nodes, must-1, nil)
+	var bi *projector.BudgetImpossible
+	if !errors.As(err, &bi) {
+		t.Fatalf("want BudgetImpossible, got %v", err)
+	}
+	if bi.RequiredSize <= bi.Budget {
+		t.Fatalf("required=%d budget=%d", bi.RequiredSize, bi.Budget)
+	}
+}
+
+func TestTrimOptionalKeepConstraints(t *testing.T) {
+	c := node("c1", "CONSTRAINT", map[string]any{"rule": "keep"}, 0)
+	thoughts := []map[string]any{
+		node("th0", "THOUGHT", map[string]any{"text": strings.Repeat("y", 40)}, 1),
+		node("th1", "THOUGHT", map[string]any{"text": strings.Repeat("y", 40)}, 2),
+		node("th2", "THOUGHT", map[string]any{"text": strings.Repeat("y", 40)}, 3),
+		node("th3", "THOUGHT", map[string]any{"text": strings.Repeat("y", 40)}, 4),
+		node("th4", "THOUGHT", map[string]any{"text": strings.Repeat("y", 40)}, 5),
+	}
+	nodes := append([]map[string]any{c}, thoughts...)
+	cSize, err := projector.NodeSizeUnits(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tSize, err := projector.NodeSizeUnits(thoughts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := projector.ProjectContext(nodes, cSize+tSize, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundC := false
+	for _, id := range res.IncludedIDs {
+		if id == "c1" {
+			foundC = true
+		}
+	}
+	if !foundC {
+		t.Fatal("constraint dropped")
+	}
+	if len(res.DroppedIDs) == 0 {
+		t.Fatal("expected some thoughts dropped")
+	}
+	for _, id := range res.DroppedIDs {
+		if id == "c1" {
+			t.Fatal("constraint in dropped set")
+		}
+	}
+}

--- a/pkg/trajectory_ir/runtime/__init__.py
+++ b/pkg/trajectory_ir/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime primitives: nodes, log, tools, projector."""
+
+from trajectory_ir.runtime.projector import BudgetImpossible, ProjectResult, project_context
+
+__all__ = ["BudgetImpossible", "ProjectResult", "project_context"]

--- a/pkg/trajectory_ir/runtime/projector.py
+++ b/pkg/trajectory_ir/runtime/projector.py
@@ -1,0 +1,157 @@
+"""Default context projector (README §9 policy note / R04).
+
+Metric: ``json_chars`` — UTF-8 length of a compact, sort-keyed JSON object
+``{"kind": ..., "payload": ...}`` for each included node. This is deliberately
+not a model-specific tokenizer; it is enough to enforce CONSTRAINT budget
+safety for conformance R04.
+
+Default policy (no projector-policy.yaml):
+- Always include every CONSTRAINT node
+- Always include explicitly pinned node ids
+- If must-include set alone exceeds budget → ``BudgetImpossible`` (never
+  silent drop of a CONSTRAINT or pinned node)
+- Other kinds fill remaining budget in deterministic order
+  (step_n ascending, null last; then seq; then id)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+class BudgetImpossible(Exception):
+    """Raised when CONSTRAINT/pinned nodes alone exceed the projection budget (R04)."""
+
+    def __init__(self, message: str, *, required_size: int, budget: int):
+        self.required_size = required_size
+        self.budget = budget
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class ProjectResult:
+    """Outcome of default projection."""
+
+    included_ids: tuple[str, ...]
+    dropped_ids: tuple[str, ...]
+    context: dict[str, Any]
+    size_units: int
+    budget: int
+    metric: str = "json_chars"
+
+
+def node_size_units(node: dict[str, Any]) -> int:
+    """Size of one node under the json_chars metric."""
+    kind = node.get("kind", "")
+    payload = node.get("payload", {})
+    raw = json.dumps({"kind": kind, "payload": payload}, sort_keys=True, default=str)
+    return len(raw.encode("utf-8"))
+
+
+def _sort_key(node: dict[str, Any]) -> tuple[int, int, str]:
+    step = node.get("step_n")
+    step_ord = step if isinstance(step, int) else 10**9
+    seq = node.get("seq")
+    seq_ord = int(seq) if seq is not None else 10**9
+    nid = str(node.get("id") or "")
+    return (step_ord, seq_ord, nid)
+
+
+def project_context(
+    nodes: list[dict[str, Any]],
+    *,
+    budget: int,
+    pinned_ids: set[str] | frozenset[str] | None = None,
+) -> ProjectResult:
+    """Project nodes into a budgeted context under the default policy.
+
+    Args:
+        nodes: Node records (must include ``id``, ``kind``, ``payload``; optionally
+            ``step_n``, ``seq`` for ordering).
+        budget: Maximum total ``json_chars`` size units.
+        pinned_ids: Node ids that must always appear when present in ``nodes``.
+
+    Returns:
+        ProjectResult with included/dropped ids and an assembled context payload
+        suitable for recording as PROJECT_CONTEXT.
+
+    Raises:
+        BudgetImpossible: if CONSTRAINT + pinned nodes alone exceed ``budget``.
+        ValueError: if ``budget`` is negative.
+    """
+    if budget < 0:
+        raise ValueError("budget must be non-negative")
+
+    pinned = set(pinned_ids or ())
+
+    must: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for n in nodes:
+        nid = str(n.get("id") or "")
+        if n.get("kind") == "CONSTRAINT" or nid in pinned:
+            if nid and nid not in seen:
+                must.append(n)
+                seen.add(nid)
+
+    must_sorted = sorted(must, key=_sort_key)
+    must_size = sum(node_size_units(n) for n in must_sorted)
+    if must_size > budget:
+        raise BudgetImpossible(
+            f"BUDGET_IMPOSSIBLE: CONSTRAINT/pinned size {must_size} exceeds budget {budget}",
+            required_size=must_size,
+            budget=budget,
+        )
+
+    included: list[dict[str, Any]] = list(must_sorted)
+    included_ids: set[str] = {str(n["id"]) for n in included}
+    used = must_size
+
+    optional = sorted(
+        (n for n in nodes if str(n.get("id") or "") not in included_ids),
+        key=_sort_key,
+    )
+    for n in optional:
+        cost = node_size_units(n)
+        if used + cost > budget:
+            continue
+        included.append(n)
+        included_ids.add(str(n["id"]))
+        used += cost
+
+    # Keep output order deterministic: must-include order then optional fill order.
+    # Re-sort full set for stable packaging.
+    included = sorted(included, key=_sort_key)
+    dropped = tuple(
+        sorted(
+            str(n["id"])
+            for n in nodes
+            if n.get("id") is not None and str(n["id"]) not in included_ids
+        )
+    )
+    items = [
+        {
+            "id": n["id"],
+            "kind": n["kind"],
+            "payload": n.get("payload") or {},
+            "step_n": n.get("step_n"),
+            "seq": n.get("seq"),
+        }
+        for n in included
+    ]
+    context: dict[str, Any] = {
+        "items": items,
+        "included_ids": [str(n["id"]) for n in included],
+        "budget": budget,
+        "size_units": used,
+        "metric": "json_chars",
+    }
+    return ProjectResult(
+        included_ids=tuple(str(n["id"]) for n in included),
+        dropped_ids=dropped,
+        context=context,
+        size_units=used,
+        budget=budget,
+        metric="json_chars",
+    )

--- a/pkg/trajectory_ir/runtime/projector.py
+++ b/pkg/trajectory_ir/runtime/projector.py
@@ -1,9 +1,9 @@
 """Default context projector (README §9 policy note / R04).
 
-Metric: ``json_chars`` — UTF-8 length of a compact, sort-keyed JSON object
-``{"kind": ..., "payload": ...}`` for each included node. This is deliberately
-not a model-specific tokenizer; it is enough to enforce CONSTRAINT budget
-safety for conformance R04.
+Metric: ``rfc8785_bytes`` — byte length of the RFC 8785 (JCS) canonical form of
+``{"kind": ..., "payload": ...}`` for each included node. Same canonicalization
+as node identity hashing (``rfc8785`` / Go ``jcs``), so Python and Go agree on
+budget thresholds. This is deliberately not a model-specific tokenizer.
 
 Default policy (no projector-policy.yaml):
 - Always include every CONSTRAINT node
@@ -16,9 +16,12 @@ Default policy (no projector-policy.yaml):
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from typing import Any
+
+import rfc8785
+
+SIZE_METRIC = "rfc8785_bytes"
 
 
 class BudgetImpossible(Exception):
@@ -39,15 +42,20 @@ class ProjectResult:
     context: dict[str, Any]
     size_units: int
     budget: int
-    metric: str = "json_chars"
+    metric: str = SIZE_METRIC
 
 
 def node_size_units(node: dict[str, Any]) -> int:
-    """Size of one node under the json_chars metric."""
+    """Size of one node under the rfc8785_bytes metric (JCS canonical length)."""
     kind = node.get("kind", "")
-    payload = node.get("payload", {})
-    raw = json.dumps({"kind": kind, "payload": payload}, sort_keys=True, default=str)
-    return len(raw.encode("utf-8"))
+    payload = node.get("payload")
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be an object for size measurement")
+    # RFC 8785 JCS — same stack as runtime.nodes.payload_hash (byte-stable vs Go jcs).
+    canon = rfc8785.dumps({"kind": kind, "payload": payload})
+    return len(canon)
 
 
 def _sort_key(node: dict[str, Any]) -> tuple[int, int, str]:
@@ -145,7 +153,7 @@ def project_context(
         "included_ids": [str(n["id"]) for n in included],
         "budget": budget,
         "size_units": used,
-        "metric": "json_chars",
+        "metric": SIZE_METRIC,
     }
     return ProjectResult(
         included_ids=tuple(str(n["id"]) for n in included),
@@ -153,5 +161,5 @@ def project_context(
         context=context,
         size_units=used,
         budget=budget,
-        metric="json_chars",
+        metric=SIZE_METRIC,
     )

--- a/test/unit/test_projector.py
+++ b/test/unit/test_projector.py
@@ -1,0 +1,92 @@
+"""Unit tests for the default context projector (R04)."""
+
+from __future__ import annotations
+
+import pytest
+
+from trajectory_ir.runtime.projector import (
+    BudgetImpossible,
+    node_size_units,
+    project_context,
+)
+
+
+def _node(
+    nid: str,
+    kind: str,
+    payload: dict,
+    *,
+    step_n: int = 1,
+    seq: int = 0,
+) -> dict:
+    return {
+        "id": nid,
+        "kind": kind,
+        "payload": payload,
+        "step_n": step_n,
+        "seq": seq,
+        "trajectory_id": "t1",
+        "tenant_id": "demo",
+    }
+
+
+def test_constraints_always_included_when_under_budget() -> None:
+    nodes = [
+        _node("c1", "CONSTRAINT", {"rule": "never-drop"}, seq=0),
+        _node("t1", "THOUGHT", {"text": "x" * 50}, seq=1),
+        _node("c2", "CONSTRAINT", {"rule": "also-keep"}, seq=2),
+    ]
+    budget = sum(node_size_units(n) for n in nodes)  # room for all
+    result = project_context(nodes, budget=budget)
+    assert "c1" in result.included_ids
+    assert "c2" in result.included_ids
+    assert set(result.included_ids) == {"c1", "c2", "t1"}
+
+
+def test_budget_impossible_when_constraints_alone_exceed() -> None:
+    big = {"rule": "x" * 200}
+    nodes = [
+        _node("c1", "CONSTRAINT", big, seq=0),
+        _node("c2", "CONSTRAINT", big, seq=1),
+    ]
+    must = sum(node_size_units(n) for n in nodes)
+    with pytest.raises(BudgetImpossible) as ei:
+        project_context(nodes, budget=must - 1)
+    assert ei.value.required_size == must
+    assert ei.value.budget == must - 1
+    assert "BUDGET_IMPOSSIBLE" in str(ei.value)
+
+
+def test_non_constraints_trimmed_without_dropping_constraints() -> None:
+    c = _node("c1", "CONSTRAINT", {"rule": "keep"}, seq=0)
+    thoughts = [_node(f"th{i}", "THOUGHT", {"text": "y" * 40}, seq=i + 1) for i in range(5)]
+    nodes = [c, *thoughts]
+    c_size = node_size_units(c)
+    # Budget fits constraint + at most one small thought
+    one_thought = node_size_units(thoughts[0])
+    budget = c_size + one_thought
+    result = project_context(nodes, budget=budget)
+    assert "c1" in result.included_ids
+    assert result.dropped_ids  # some thoughts dropped
+    for did in result.dropped_ids:
+        assert did.startswith("th")
+    # Never drop the constraint
+    assert "c1" not in result.dropped_ids
+
+
+def test_pinned_ids_always_included() -> None:
+    nodes = [
+        _node("c1", "CONSTRAINT", {"rule": "a"}, seq=0),
+        _node("pin1", "INPUT", {"text": "pinned-input"}, seq=1),
+        _node("skip", "THOUGHT", {"text": "z" * 80}, seq=2),
+    ]
+    pin_size = node_size_units(nodes[0]) + node_size_units(nodes[1])
+    result = project_context(nodes, budget=pin_size, pinned_ids={"pin1"})
+    assert "c1" in result.included_ids
+    assert "pin1" in result.included_ids
+    assert "skip" in result.dropped_ids
+
+
+def test_negative_budget_rejected() -> None:
+    with pytest.raises(ValueError, match="budget"):
+        project_context([], budget=-1)

--- a/test/unit/test_projector_size_vectors.py
+++ b/test/unit/test_projector_size_vectors.py
@@ -1,0 +1,39 @@
+"""Cross-language goldens for projector size units (RFC 8785 / JCS)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from trajectory_ir.runtime.projector import SIZE_METRIC, node_size_units
+
+_ROOT = Path(__file__).resolve().parents[2]
+_VECTORS = _ROOT / "testdata" / "projector_size_vectors.json"
+
+
+def test_projector_size_vectors_match_python() -> None:
+    data = json.loads(_VECTORS.read_text(encoding="utf-8"))
+    assert data.get("version") == 1
+    assert data.get("metric") == SIZE_METRIC
+    assert data.get("cases"), "empty size vectors"
+    for case in data["cases"]:
+        got = node_size_units(case["node"])
+        assert got == case["size_units"], case["name"]
+
+
+def test_key_order_does_not_change_size_units() -> None:
+    a = {
+        "id": "x",
+        "kind": "STATE_SET",
+        "payload": {"a": 1, "b": 2},
+        "step_n": 1,
+        "seq": 0,
+    }
+    b = {
+        "id": "x",
+        "kind": "STATE_SET",
+        "payload": {"b": 2, "a": 1},
+        "step_n": 1,
+        "seq": 0,
+    }
+    assert node_size_units(a) == node_size_units(b)

--- a/testdata/projector_size_vectors.json
+++ b/testdata/projector_size_vectors.json
@@ -1,0 +1,69 @@
+{
+  "cases": [
+    {
+      "name": "constraint_rule_a",
+      "node": {
+        "id": "c1",
+        "kind": "CONSTRAINT",
+        "payload": {
+          "rule": "a"
+        },
+        "seq": 0,
+        "step_n": 1,
+        "tenant_id": "demo",
+        "trajectory_id": "t1"
+      },
+      "size_units": 44
+    },
+    {
+      "name": "key_order_independent",
+      "node": {
+        "id": "s1",
+        "kind": "STATE_SET",
+        "payload": {
+          "a": 1,
+          "b": 2
+        },
+        "seq": 1,
+        "step_n": 1,
+        "tenant_id": "demo",
+        "trajectory_id": "t1"
+      },
+      "size_units": 44
+    },
+    {
+      "name": "nested_payload",
+      "node": {
+        "id": "t1",
+        "kind": "THOUGHT",
+        "payload": {
+          "meta": {
+            "n": 3,
+            "ok": true
+          },
+          "text": "hello"
+        },
+        "seq": 0,
+        "step_n": 2,
+        "tenant_id": "demo",
+        "trajectory_id": "t1"
+      },
+      "size_units": 70
+    },
+    {
+      "name": "empty_payload",
+      "node": {
+        "id": "commit",
+        "kind": "COMMIT_STEP",
+        "payload": {},
+        "seq": 4,
+        "step_n": 1,
+        "tenant_id": "demo",
+        "trajectory_id": "t1"
+      },
+      "size_units": 35
+    }
+  ],
+  "metric": "rfc8785_bytes",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
Implements **R04**: CONSTRAINT nodes are never silently dropped under budget pressure. Closes #52.

### Python
- `pkg/trajectory_ir/runtime/projector.py` — `project_context`, `BudgetImpossible`, `ProjectResult`
- Metric: `json_chars` (documented; not a real LLM tokenizer)
- Default policy: always include CONSTRAINT + pinned; hard fail if must-include exceeds budget; optional fill of other kinds
- Unit + `conformance/r04_constraint_budget_test.py`
- Client `project()` docstring points at the pure projector

### Go
- `go/trajir/projector` with matching API + tests
- Documented in `go/README.md`

### Docs
- README §10 R04 runnable; CHANGELOG

## Test plan
- [x] `pytest test/unit/test_projector.py conformance/`
- [x] `go build/vet ./trajir/projector` (local Windows may block package test binaries; CI Linux authoritative)
- [ ] CI green
