### PR TITLE
feat: R06 sandbox, R07 graft, R08 projection redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - R05 conformance tests for `.tir` thin/fat round-trip and golden fixture load.
 - R03 PURE recompute-on-resume: `requires_block_and_gate` / `RequiresBlockAndGate`,
   conformance + Go tests; only NON_IDEMPOTENT_WRITE is gated.
+- R06 sandbox mode (`RunMode.SANDBOX`) rejects NON_IDEMPOTENT_WRITE before side effects.
+- R07 `graft_artifact_ref` / `trajir/graft` transfers artifact refs only (never THOUGHT).
+- R08 projection redaction (`runtime/redact`, `trajir/redact`); shared with `.tir` redacted export.
 
 
 

--- a/README.md
+++ b/README.md
@@ -297,9 +297,9 @@ These are runnable tests, not descriptions of intent. R01 and R02 are the hard g
 | R03 | A `PURE` tool may be recomputed freely on resume. Runnable: `conformance/r03_pure_recompute_test.py` (and Go `go test ./trajir/resume -run R03`). |
 | R04 | A `CONSTRAINT` node is never silently dropped under budget pressure; the system either includes it or raises a hard error. |
 | R05 | Export and re import of a `.tir` package preserves all node hashes and seals exactly. Runnable: `conformance/r05_tir_roundtrip_test.py` (and Go `go test ./trajir/tir`). |
-| R06 | A sandbox/what if branch rejects any real `NON_IDEMPOTENT_WRITE` execution. |
-| R07 | Grafting an artifact between agents transfers only the artifact reference, never private `THOUGHT` nodes. |
-| R08 | Redaction removes secrets/flagged content from what gets projected into context. |
+| R06 | A sandbox/what if branch rejects any real `NON_IDEMPOTENT_WRITE` execution. Runnable: `conformance/r06_sandbox_test.py`. |
+| R07 | Grafting an artifact between agents transfers only the artifact reference, never private `THOUGHT` nodes. Runnable: `conformance/r07_graft_test.py`. |
+| R08 | Redaction removes secrets/flagged content from what gets projected into context. Runnable: `conformance/r08_projection_redaction_test.py`. |
 
 **Phase 1A completion bar:** DBOS backend adapter wired in, SQLite (or file backed) IR log, Python SDK, R01 and R02 passing against the adapter, and a recorded kill-mid-deploy demonstration. R03–R08 are tracked but not blocking for this milestone.
 

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -5,6 +5,7 @@ from drivers.durable_backend.dbos.adapter import init_backend
 from trajectory_ir.effects import requires_block_and_gate
 from trajectory_ir.resume.gate import make_gated_tool_call
 from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
 from trajectory_ir.runtime.tool import Tool
 
 
@@ -13,6 +14,7 @@ class Trajectory:
     trajectory_id: str
     tenant_id: str
     db_path: str
+    mode: RunMode = RunMode.LIVE
 
 
 @dataclass
@@ -34,10 +36,20 @@ class ToolResult:
 
 
 def open_trajectory(
-    tenant_id: str, trajectory_id: str, db_path: str = "trajectory.sqlite"
+    tenant_id: str,
+    trajectory_id: str,
+    db_path: str = "trajectory.sqlite",
+    *,
+    mode: RunMode | str = RunMode.LIVE,
 ) -> Trajectory:
+    """Open a trajectory. ``mode=\"sandbox\"`` rejects NON_IDEMPOTENT_WRITE tools (R06)."""
     init_backend(app_name=trajectory_id)
-    return Trajectory(trajectory_id=trajectory_id, tenant_id=tenant_id, db_path=db_path)
+    return Trajectory(
+        trajectory_id=trajectory_id,
+        tenant_id=tenant_id,
+        db_path=db_path,
+        mode=normalize_run_mode(mode),
+    )
 
 
 def project(trajectory: Trajectory, step_n: int, context: dict) -> ProjectContext:
@@ -78,6 +90,11 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool, seq: 
     Returns:
         ToolResult with the tool execution result
     """
+    assert_tool_allowed_in_mode(
+        trajectory.mode,
+        tool_name=tool.name,
+        effect_class=tool.effect_class,
+    )
     log = NodeLog(trajectory.db_path)
     if requires_block_and_gate(tool.effect_class):
         fn = make_gated_tool_call(
@@ -114,7 +131,16 @@ def commit_step(trajectory: Trajectory, step_n: int, seq: int) -> None:
 
 
 def resume(
-    trajectory_id: str, tenant_id: str = "demo", db_path: str = "trajectory.sqlite"
+    trajectory_id: str,
+    tenant_id: str = "demo",
+    db_path: str = "trajectory.sqlite",
+    *,
+    mode: RunMode | str = RunMode.LIVE,
 ) -> Trajectory:
     init_backend(app_name=trajectory_id)
-    return Trajectory(trajectory_id=trajectory_id, tenant_id=tenant_id, db_path=db_path)
+    return Trajectory(
+        trajectory_id=trajectory_id,
+        tenant_id=tenant_id,
+        db_path=db_path,
+        mode=normalize_run_mode(mode),
+    )

--- a/conformance/r06_sandbox_test.py
+++ b/conformance/r06_sandbox_test.py
@@ -1,0 +1,68 @@
+"""Conformance R06: sandbox rejects real NON_IDEMPOTENT_WRITE."""
+
+from __future__ import annotations
+
+import pytest
+
+from client.python.trajectory_client import exec_tool, open_trajectory
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.runtime.sandbox import RunMode, SandboxForbidden
+from trajectory_ir.runtime.tool import Tool
+
+
+def test_r06_sandbox_rejects_non_idempotent(tmp_path) -> None:
+    side = {"n": 0}
+
+    def deploy(version: str = "1") -> dict:
+        side["n"] += 1
+        return {"deployed": version}
+
+    traj = open_trajectory(
+        "demo",
+        "r06-sandbox",
+        db_path=str(tmp_path / "t.sqlite"),
+        mode=RunMode.SANDBOX,
+    )
+    tool = Tool(name="deploy_server", fn=deploy, effect_class=EffectClass.NON_IDEMPOTENT_WRITE)
+    with pytest.raises(SandboxForbidden) as ei:
+        exec_tool(traj, 1, {"args": {"version": "1"}}, tool, seq=2)
+    assert "SANDBOX_REJECTS" in str(ei.value)
+    assert side["n"] == 0
+
+
+def test_r06_sandbox_allows_pure(tmp_path) -> None:
+    calls = {"n": 0}
+
+    def compute(x: int = 0) -> int:
+        calls["n"] += 1
+        return x + 1
+
+    traj = open_trajectory(
+        "demo",
+        "r06-pure",
+        db_path=str(tmp_path / "t.sqlite"),
+        mode="sandbox",
+    )
+    tool = Tool(name="compute", fn=compute, effect_class=EffectClass.PURE)
+    result = exec_tool(traj, 1, {"args": {"x": 1}}, tool, seq=2)
+    assert result.result == 2
+    assert calls["n"] == 1
+
+
+def test_r06_live_allows_non_idempotent(tmp_path) -> None:
+    side = {"n": 0}
+
+    def deploy(version: str = "1") -> dict:
+        side["n"] += 1
+        return {"deployed": version}
+
+    traj = open_trajectory(
+        "demo",
+        "r06-live",
+        db_path=str(tmp_path / "t.sqlite"),
+        mode=RunMode.LIVE,
+    )
+    tool = Tool(name="deploy_server", fn=deploy, effect_class=EffectClass.NON_IDEMPOTENT_WRITE)
+    result = exec_tool(traj, 1, {"args": {"version": "9"}}, tool, seq=2)
+    assert result.result == {"deployed": "9"}
+    assert side["n"] == 1

--- a/conformance/r07_graft_test.py
+++ b/conformance/r07_graft_test.py
@@ -1,0 +1,86 @@
+"""Conformance R07: graft transfers artifact refs only, never THOUGHT."""
+
+from __future__ import annotations
+
+import pytest
+
+from trajectory_ir.runtime.graft import GraftError, graft_artifact_ref
+from trajectory_ir.runtime.log import NodeLog
+
+
+def test_r07_graft_artifact_ref_not_thoughts(tmp_path) -> None:
+    src = NodeLog(str(tmp_path / "src.sqlite"))
+    dst = NodeLog(str(tmp_path / "dst.sqlite"))
+    try:
+        h = "ab" + "0" * 62
+        src.append(
+            "THOUGHT",
+            1,
+            {"text": "private reasoning about secret deploy"},
+            "src-traj",
+            "demo",
+            0,
+        )
+        src.append(
+            "ARTIFACT_PUT",
+            1,
+            {"content_hash": h, "logical_path": "out.bin", "uri": "cas://" + h},
+            "src-traj",
+            "demo",
+            1,
+        )
+        source_nodes = src.list_nodes("src-traj", tenant_id="demo")
+        assert any(n["kind"] == "THOUGHT" for n in source_nodes)
+
+        node = graft_artifact_ref(
+            dst,
+            content_hash=h,
+            target_trajectory_id="dst-traj",
+            target_tenant_id="demo",
+            seq=0,
+            step_n=1,
+            source_nodes=source_nodes,
+        )
+        assert node.kind == "ARTIFACT_REF"
+        assert node.payload["content_hash"] == h
+        assert node.payload.get("grafted") is True
+        assert node.payload.get("logical_path") == "out.bin"
+
+        grafted = dst.list_nodes("dst-traj", tenant_id="demo")
+        kinds = {n["kind"] for n in grafted}
+        assert "ARTIFACT_REF" in kinds
+        assert "THOUGHT" not in kinds
+        for n in grafted:
+            assert "private reasoning" not in str(n.get("payload"))
+    finally:
+        src.close()
+        dst.close()
+
+
+def test_r07_refuses_graft_from_thought_payload_hash(tmp_path) -> None:
+    """If the only match would be a private kind, refuse."""
+    src = NodeLog(str(tmp_path / "src.sqlite"))
+    dst = NodeLog(str(tmp_path / "dst.sqlite"))
+    try:
+        h = "cd" + "1" * 62
+        src.append(
+            "THOUGHT",
+            1,
+            {"content_hash": h, "text": "should not graft"},
+            "src-traj",
+            "demo",
+            0,
+        )
+        with pytest.raises(GraftError, match="refusing|no ARTIFACT"):
+            graft_artifact_ref(
+                dst,
+                content_hash=h,
+                target_trajectory_id="dst-traj",
+                target_tenant_id="demo",
+                seq=0,
+                source_nodes=src.list_nodes("src-traj", tenant_id="demo"),
+            )
+        assert dst.list_nodes("dst-traj", tenant_id="demo") == []
+    finally:
+        src.close()
+        dst.close()

--- a/conformance/r08_projection_redaction_test.py
+++ b/conformance/r08_projection_redaction_test.py
@@ -1,0 +1,75 @@
+"""Conformance R08: redaction removes secrets from projected context."""
+
+from __future__ import annotations
+
+from trajectory_ir.runtime.redact import redact_projection_context
+
+
+def test_r08_redacts_secret_shaped_values_in_items() -> None:
+    context = {
+        "items": [
+            {
+                "id": "n1",
+                "kind": "TOOL_CALL",
+                "payload": {
+                    "tool": "note",
+                    "args": {
+                        "note": "found it: AKIAABCDEFGHIJKLMNOP",
+                        "message": "benign",
+                    },
+                },
+                "step_n": 1,
+                "seq": 2,
+            },
+            {
+                "id": "c1",
+                "kind": "CONSTRAINT",
+                "payload": {"rule": "always-include", "api_key": "should-scrub"},
+                "step_n": 1,
+                "seq": 0,
+            },
+            {
+                "id": "th1",
+                "kind": "THOUGHT",
+                "payload": {"text": "private chain of thought"},
+                "step_n": 1,
+                "seq": 1,
+            },
+        ],
+        "included_ids": ["c1", "th1", "n1"],
+        "budget": 99999,
+        "metric": "rfc8785_bytes",
+    }
+    out = redact_projection_context(context)
+    assert out["redacted"] is True
+    by_id = {item["id"]: item for item in out["items"]}
+    # CONSTRAINT node remains present (R04) but secret field scrubbed.
+    assert "c1" in by_id
+    assert by_id["c1"]["kind"] == "CONSTRAINT"
+    assert by_id["c1"]["payload"]["rule"] == "always-include"
+    assert by_id["c1"]["payload"]["api_key"] == "[REDACTED]"
+    # Secret-shaped free text scrubbed.
+    assert by_id["n1"]["payload"]["args"]["note"] == "[REDACTED]"
+    assert by_id["n1"]["payload"]["args"]["message"] == "benign"
+    # THOUGHT body not projected as raw text.
+    assert by_id["th1"]["payload"] == {"redacted": True}
+    assert "private chain" not in str(out)
+
+
+def test_r08_constraint_still_listed_after_redaction() -> None:
+    context = {
+        "items": [
+            {
+                "id": "c-only",
+                "kind": "CONSTRAINT",
+                "payload": {"rule": "keep-me"},
+                "step_n": 0,
+                "seq": 0,
+            }
+        ],
+        "included_ids": ["c-only"],
+    }
+    out = redact_projection_context(context)
+    assert len(out["items"]) == 1
+    assert out["items"][0]["id"] == "c-only"
+    assert out["items"][0]["payload"]["rule"] == "keep-me"

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
 	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/sandbox"
 )
 
 // Options configure workdir paths and optional durable backend injection.
@@ -34,6 +35,8 @@ type Options struct {
 	WorkflowID string
 	// Backend overrides LocalSQLite when non nil. Caller owns Close unless Open created it.
 	Backend durable.Backend
+	// Mode is live (default) or sandbox (R06).
+	Mode sandbox.Mode
 }
 
 // Trajectory is an open IR run handle.
@@ -41,6 +44,7 @@ type Trajectory struct {
 	TrajectoryID string
 	TenantID     string
 	WorkflowID   string
+	Mode         sandbox.Mode
 
 	log         *nodelog.NodeLog
 	backend     durable.Backend
@@ -76,6 +80,13 @@ func OpenTrajectory(tenantID, trajectoryID string, opts Options) (*Trajectory, e
 	if wf == "" {
 		wf = trajectoryID
 	}
+	mode := opts.Mode
+	if mode == "" {
+		mode = sandbox.ModeLive
+	}
+	if mode != sandbox.ModeLive && mode != sandbox.ModeSandbox {
+		return nil, fmt.Errorf("client: unsupported mode %q", mode)
+	}
 
 	nl, err := nodelog.Open(nodesPath)
 	if err != nil {
@@ -99,6 +110,7 @@ func OpenTrajectory(tenantID, trajectoryID string, opts Options) (*Trajectory, e
 		TrajectoryID: trajectoryID,
 		TenantID:     tenantID,
 		WorkflowID:   wf,
+		Mode:         mode,
 		log:          nl,
 		backend:      backend,
 		ownsBackend:  ownsBackend,
@@ -172,6 +184,9 @@ func (t *Trajectory) ExecTool(stepN, seq int, tool resume.Tool, args map[string]
 	if args == nil {
 		args = map[string]any{}
 	}
+	if err := sandbox.AssertToolAllowed(t.Mode, tool.Name, tool.Effect); err != nil {
+		return nil, err
+	}
 	fn := tool.Fn
 	if effects.RequiresBlockAndGate(tool.Effect) {
 		fn = resume.MakeGatedToolCall(
@@ -226,6 +241,7 @@ func (t *Trajectory) RunStep(
 		TrajectoryID: t.TrajectoryID,
 		WorkflowID:   t.WorkflowID,
 		Tools:        tools,
+		Mode:         t.Mode,
 	}
 	if len(opts) > 0 {
 		cfg.OnDecisionSealed = opts[0].OnDecisionSealed

--- a/go/trajir/graft/graft.go
+++ b/go/trajir/graft/graft.go
@@ -1,0 +1,169 @@
+// Package graft transfers artifact refs between trajectories (R07).
+// Never copies THOUGHT (or other private kinds) as nodes.
+package graft
+
+import (
+	"fmt"
+	"sort"
+
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/nodes"
+)
+
+// PrivateKinds must never cross a graft boundary as full nodes.
+var PrivateKinds = map[string]struct{}{
+	"THOUGHT": {},
+}
+
+var artifactKinds = map[string]struct{}{
+	"ARTIFACT_PUT": {},
+	"ARTIFACT_REF": {},
+}
+
+// Error is a graft failure.
+type Error struct {
+	Msg string
+}
+
+func (e *Error) Error() string { return e.Msg }
+
+func payloadContentHash(payload map[string]any) string {
+	if payload == nil {
+		return ""
+	}
+	for _, key := range []string{"content_hash", "hash", "sha256"} {
+		if v, ok := payload[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// FindArtifactRef returns source ARTIFACT_* metadata for contentHash.
+func FindArtifactRef(sourceNodes []map[string]any, contentHash string) (map[string]any, error) {
+	if contentHash == "" {
+		return nil, &Error{Msg: "content_hash is required"}
+	}
+	var matches []map[string]any
+	for _, n := range sourceNodes {
+		kind, _ := n["kind"].(string)
+		if _, priv := PrivateKinds[kind]; priv {
+			continue
+		}
+		if _, ok := artifactKinds[kind]; !ok {
+			continue
+		}
+		payload, _ := n["payload"].(map[string]any)
+		if payloadContentHash(payload) == contentHash {
+			matches = append(matches, n)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, &Error{Msg: fmt.Sprintf("no ARTIFACT_PUT/ARTIFACT_REF with content_hash=%q", contentHash)}
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		ki, _ := matches[i]["kind"].(string)
+		kj, _ := matches[j]["kind"].(string)
+		pi, pj := 1, 1
+		if ki == "ARTIFACT_REF" {
+			pi = 0
+		}
+		if kj == "ARTIFACT_REF" {
+			pj = 0
+		}
+		if pi != pj {
+			return pi < pj
+		}
+		si, sj := 0, 0
+		if v, ok := matches[i]["seq"].(int); ok {
+			si = v
+		} else if v, ok := matches[i]["seq"].(float64); ok {
+			si = int(v)
+		}
+		if v, ok := matches[j]["seq"].(int); ok {
+			sj = v
+		} else if v, ok := matches[j]["seq"].(float64); ok {
+			sj = int(v)
+		}
+		return si < sj
+	})
+	return matches[0], nil
+}
+
+// GraftOptions configure GraftArtifactRef.
+type GraftOptions struct {
+	ContentHash         string
+	TargetTrajectoryID  string
+	TargetTenantID      string
+	Seq                 int
+	StepN               *int
+	SourceNodes         []map[string]any
+	LogicalPath         string
+	URI                 string
+	SourceTrajectoryID  string
+	HasLogicalPath      bool
+	HasURI              bool
+	HasSourceTrajectory bool
+}
+
+// GraftArtifactRef appends ARTIFACT_REF on target. Never copies THOUGHT nodes.
+func GraftArtifactRef(target *nodelog.NodeLog, opts GraftOptions) (*nodes.Node, error) {
+	if target == nil {
+		return nil, &Error{Msg: "nil NodeLog"}
+	}
+	logicalPath := opts.LogicalPath
+	uri := opts.URI
+	srcTraj := opts.SourceTrajectoryID
+	if opts.SourceNodes != nil {
+		for _, n := range opts.SourceNodes {
+			kind, _ := n["kind"].(string)
+			if _, priv := PrivateKinds[kind]; priv {
+				payload, _ := n["payload"].(map[string]any)
+				if payloadContentHash(payload) == opts.ContentHash {
+					return nil, &Error{Msg: "refusing to graft from a THOUGHT/private node"}
+				}
+			}
+		}
+		src, err := FindArtifactRef(opts.SourceNodes, opts.ContentHash)
+		if err != nil {
+			return nil, err
+		}
+		payload, _ := src["payload"].(map[string]any)
+		if !opts.HasLogicalPath {
+			if v, ok := payload["logical_path"].(string); ok {
+				logicalPath = v
+			}
+		}
+		if !opts.HasURI {
+			if v, ok := payload["uri"].(string); ok {
+				uri = v
+			}
+		}
+		if !opts.HasSourceTrajectory {
+			if v, ok := src["trajectory_id"].(string); ok {
+				srcTraj = v
+			}
+		}
+	}
+	payload := map[string]any{
+		"content_hash": opts.ContentHash,
+		"grafted":      true,
+	}
+	if logicalPath != "" || opts.HasLogicalPath {
+		payload["logical_path"] = logicalPath
+	}
+	if uri != "" || opts.HasURI {
+		payload["uri"] = uri
+	}
+	if srcTraj != "" || opts.HasSourceTrajectory {
+		payload["source_trajectory_id"] = srcTraj
+	}
+	return target.Append(
+		"ARTIFACT_REF",
+		opts.StepN,
+		payload,
+		opts.TargetTrajectoryID,
+		opts.TargetTenantID,
+		opts.Seq,
+	)
+}

--- a/go/trajir/graft/graft_test.go
+++ b/go/trajir/graft/graft_test.go
@@ -1,0 +1,61 @@
+package graft_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/graft"
+	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+)
+
+func TestGraftArtifactNotThought(t *testing.T) {
+	src, err := nodelog.Open(filepath.Join(t.TempDir(), "src.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	dst, err := nodelog.Open(filepath.Join(t.TempDir(), "dst.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = dst.Close() })
+
+	step := 1
+	h := "ab" + "00000000000000000000000000000000000000000000000000000000000000"[:62]
+	if _, err := src.Append("THOUGHT", &step, map[string]any{"text": "private"}, "src", "demo", 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.Append("ARTIFACT_PUT", &step, map[string]any{
+		"content_hash": h,
+		"logical_path": "out.bin",
+	}, "src", "demo", 1); err != nil {
+		t.Fatal(err)
+	}
+	nodes, err := src.ListNodes("src", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := graft.GraftArtifactRef(dst, graft.GraftOptions{
+		ContentHash:        h,
+		TargetTrajectoryID: "dst",
+		TargetTenantID:     "demo",
+		Seq:                0,
+		StepN:              &step,
+		SourceNodes:        nodes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Kind != "ARTIFACT_REF" {
+		t.Fatalf("kind=%s", n.Kind)
+	}
+	out, err := dst.ListNodes("dst", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range out {
+		if row["kind"] == "THOUGHT" {
+			t.Fatal("THOUGHT leaked into target")
+		}
+	}
+}

--- a/go/trajir/redact/redact.go
+++ b/go/trajir/redact/redact.go
@@ -1,0 +1,102 @@
+// Package redact implements shared secret/thought scrubbing for export and projection (R08).
+package redact
+
+import (
+	"regexp"
+)
+
+var (
+	secretKeyRE = regexp.MustCompile(`(?i)(password|passwd|pass[_-]?phrase|secret|token|api[_-]?key|access[_-]?key|authorization|auth|credential|private[_-]?key)`)
+	secretValRE = regexp.MustCompile(
+		`AKIA[0-9A-Z]{16}` +
+			`|[Bb]earer\s+[A-Za-z0-9\-_.=]{10,}` +
+			`|gh[pousr]_[A-Za-z0-9]{20,}` +
+			`|sk-[A-Za-z0-9]{20,}` +
+			`|xox[baprs]-[A-Za-z0-9-]{10,}` +
+			`|-----BEGIN[ A-Z]*PRIVATE KEY-----` +
+			`|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`,
+	)
+)
+
+const Redacted = "[REDACTED]"
+
+// RedactValue scrubs a value by key name or secret-shaped string.
+func RedactValue(key string, value any) any {
+	if secretKeyRE.MatchString(key) {
+		return Redacted
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, child := range v {
+			out[k] = RedactValue(k, child)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, child := range v {
+			out[i] = RedactValue(key, child)
+		}
+		return out
+	case string:
+		if secretValRE.MatchString(v) {
+			return Redacted
+		}
+		return v
+	default:
+		return value
+	}
+}
+
+// RedactPayload scrubs a node payload for projection/export.
+func RedactPayload(kind string, payload any) map[string]any {
+	if kind == "THOUGHT" {
+		return map[string]any{"redacted": true}
+	}
+	if m, ok := payload.(map[string]any); ok {
+		out := make(map[string]any, len(m))
+		for k, v := range m {
+			out[k] = RedactValue(k, v)
+		}
+		return out
+	}
+	return map[string]any{"redacted": true}
+}
+
+// RedactProjectionContext scrubs a projector-style context map (items list).
+func RedactProjectionContext(context map[string]any) map[string]any {
+	if context == nil {
+		return map[string]any{"redacted": true}
+	}
+	rawItems, ok := context["items"].([]any)
+	if !ok {
+		// Free-form dict: redact top-level keys.
+		out := make(map[string]any, len(context))
+		for k, v := range context {
+			out[k] = RedactValue(k, v)
+		}
+		out["redacted"] = true
+		return out
+	}
+	newItems := make([]any, 0, len(rawItems))
+	for _, it := range rawItems {
+		item, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind, _ := item["kind"].(string)
+		cp := make(map[string]any, len(item))
+		for k, v := range item {
+			cp[k] = v
+		}
+		cp["payload"] = RedactPayload(kind, item["payload"])
+		newItems = append(newItems, cp)
+	}
+	out := make(map[string]any, len(context)+1)
+	for k, v := range context {
+		out[k] = v
+	}
+	out["items"] = newItems
+	out["redacted"] = true
+	return out
+}

--- a/go/trajir/redact/redact_test.go
+++ b/go/trajir/redact/redact_test.go
@@ -1,0 +1,62 @@
+package redact_test
+
+import (
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/redact"
+)
+
+func TestRedactProjectionContext(t *testing.T) {
+	ctx := map[string]any{
+		"items": []any{
+			map[string]any{
+				"id":   "n1",
+				"kind": "TOOL_CALL",
+				"payload": map[string]any{
+					"args": map[string]any{
+						"note":    "found it: AKIAABCDEFGHIJKLMNOP",
+						"message": "benign",
+					},
+				},
+			},
+			map[string]any{
+				"id":   "c1",
+				"kind": "CONSTRAINT",
+				"payload": map[string]any{
+					"rule":    "keep",
+					"api_key": "x",
+				},
+			},
+			map[string]any{
+				"id":      "th1",
+				"kind":    "THOUGHT",
+				"payload": map[string]any{"text": "private"},
+			},
+		},
+	}
+	out := redact.RedactProjectionContext(ctx)
+	if out["redacted"] != true {
+		t.Fatal("expected redacted flag")
+	}
+	items := out["items"].([]any)
+	byID := map[string]map[string]any{}
+	for _, it := range items {
+		m := it.(map[string]any)
+		byID[m["id"].(string)] = m
+	}
+	args := byID["n1"]["payload"].(map[string]any)["args"].(map[string]any)
+	if args["note"] != redact.Redacted {
+		t.Fatalf("note=%v", args["note"])
+	}
+	if args["message"] != "benign" {
+		t.Fatalf("message=%v", args["message"])
+	}
+	cp := byID["c1"]["payload"].(map[string]any)
+	if cp["rule"] != "keep" || cp["api_key"] != redact.Redacted {
+		t.Fatalf("constraint payload=%v", cp)
+	}
+	tp := byID["th1"]["payload"].(map[string]any)
+	if tp["redacted"] != true {
+		t.Fatalf("thought=%v", tp)
+	}
+}

--- a/go/trajir/resume/step.go
+++ b/go/trajir/resume/step.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/durable"
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
 	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/sandbox"
 )
 
 // Tool is a named tool with an effect class and implementation.
@@ -29,6 +30,8 @@ type RunStepConfig struct {
 	WorkflowID       string // durable memo scope; often same as TrajectoryID
 	Tools            map[string]Tool
 	OnDecisionSealed func() // optional test hook after DECISION is appended
+	// Mode is live (default) or sandbox (R06: reject NON_IDEMPOTENT_WRITE).
+	Mode sandbox.Mode
 }
 
 // RunStep executes one agent step: project context, durable infer, DECISION seal,
@@ -52,6 +55,9 @@ func RunStep(
 	}
 	if cfg.WorkflowID == "" {
 		cfg.WorkflowID = cfg.TrajectoryID
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = sandbox.ModeLive
 	}
 	if stepContext == nil {
 		stepContext = map[string]any{}
@@ -109,6 +115,9 @@ func RunStep(
 		args := call.Args
 		if args == nil {
 			args = map[string]any{}
+		}
+		if err := sandbox.AssertToolAllowed(cfg.Mode, call.Name, tool.Effect); err != nil {
+			return nil, err
 		}
 
 		var result any

--- a/go/trajir/sandbox/sandbox.go
+++ b/go/trajir/sandbox/sandbox.go
@@ -1,0 +1,51 @@
+// Package sandbox implements live vs sandbox run modes (R06).
+package sandbox
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+)
+
+// Mode is the trajectory execution mode.
+type Mode string
+
+const (
+	ModeLive    Mode = "live"
+	ModeSandbox Mode = "sandbox"
+)
+
+// Forbidden is raised when sandbox rejects a tool effect.
+type Forbidden struct {
+	ToolName string
+	Effect   effects.EffectClass
+}
+
+func (e *Forbidden) Error() string {
+	return fmt.Sprintf(
+		"SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE: tool %q effect=%s is forbidden in sandbox mode",
+		e.ToolName,
+		e.Effect,
+	)
+}
+
+// NormalizeMode maps string/empty to ModeLive or ModeSandbox.
+func NormalizeMode(mode string) (Mode, error) {
+	m := strings.TrimSpace(strings.ToLower(mode))
+	if m == "" || m == "live" {
+		return ModeLive, nil
+	}
+	if m == "sandbox" {
+		return ModeSandbox, nil
+	}
+	return "", fmt.Errorf("unsupported run mode %q; use live or sandbox", mode)
+}
+
+// AssertToolAllowed raises Forbidden in sandbox for gated effects.
+func AssertToolAllowed(mode Mode, toolName string, effect effects.EffectClass) error {
+	if mode == ModeSandbox && effects.RequiresBlockAndGate(effect) {
+		return &Forbidden{ToolName: toolName, Effect: effect}
+	}
+	return nil
+}

--- a/go/trajir/sandbox/sandbox_test.go
+++ b/go/trajir/sandbox/sandbox_test.go
@@ -1,0 +1,29 @@
+package sandbox_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/sandbox"
+)
+
+func TestSandboxRejectsNonIdempotent(t *testing.T) {
+	err := sandbox.AssertToolAllowed(sandbox.ModeSandbox, "deploy", effects.NON_IDEMPOTENT_WRITE)
+	var f *sandbox.Forbidden
+	if !errors.As(err, &f) {
+		t.Fatalf("want Forbidden, got %v", err)
+	}
+}
+
+func TestSandboxAllowsPure(t *testing.T) {
+	if err := sandbox.AssertToolAllowed(sandbox.ModeSandbox, "compute", effects.PURE); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveAllowsNonIdempotent(t *testing.T) {
+	if err := sandbox.AssertToolAllowed(sandbox.ModeLive, "deploy", effects.NON_IDEMPOTENT_WRITE); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +27,7 @@ from typing import Any, Literal
 
 from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.nodes import Node, NodeValidationError, node_id, payload_hash
+from trajectory_ir.runtime.redact import redact_payload
 
 PackageMode = Literal["thin", "fat"]
 
@@ -56,26 +56,7 @@ _REQUIRED_MEMBERS = frozenset(
     }
 )
 
-# Keys whose values are redacted in redacted export mode (case-insensitive).
-_SECRET_KEY_RE = re.compile(
-    r"(password|passwd|pass[_-]?phrase|secret|token|api[_-]?key|access[_-]?key"
-    r"|authorization|auth|credential|private[_-]?key)",
-    re.IGNORECASE,
-)
-
-# Value shapes that look like a secret regardless of the field's key name
-# (e.g. a bearer token embedded in a free-text "note" field). Not a general
-# secret scanner: a fixed set of common, low-false-positive formats. See
-# SECURITY.md "Redacted export" for the scope and limits of this heuristic.
-_SECRET_VALUE_RE = re.compile(
-    r"(AKIA[0-9A-Z]{16}"  # AWS access key id
-    r"|[Bb]earer\s+[A-Za-z0-9\-_.=]{10,}"  # bearer token
-    r"|gh[pousr]_[A-Za-z0-9]{20,}"  # GitHub token
-    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI-style secret key
-    r"|xox[baprs]-[A-Za-z0-9-]{10,}"  # Slack token
-    r"|-----BEGIN[ A-Z]*PRIVATE KEY-----"  # PEM private key block
-    r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"  # JWT
-)
+# Redaction patterns live in runtime.redact (shared with R08 projection).
 
 
 class TirError(Exception):
@@ -199,28 +180,10 @@ def _seals_from_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return seals
 
 
-def _redact_value(key: str, value: Any) -> Any:
-    if _SECRET_KEY_RE.search(key):
-        return "[REDACTED]"
-    if isinstance(value, dict):
-        return {k: _redact_value(str(k), v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_redact_value(key, item) for item in value]
-    if isinstance(value, str) and _SECRET_VALUE_RE.search(value):
-        return "[REDACTED]"
-    return value
-
-
 def _redact_node(rec: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of a node record with thoughts/secrets stripped for sharing."""
     kind = rec["kind"]
-    payload = rec["payload"]
-    if kind == "THOUGHT":
-        new_payload: dict[str, Any] = {"redacted": True}
-    elif isinstance(payload, dict):
-        new_payload = {k: _redact_value(str(k), v) for k, v in payload.items()}
-    else:
-        new_payload = {"redacted": True}
+    new_payload = redact_payload(kind, rec.get("payload"))
 
     # Rebuild via Node so id matches redacted payload (export is a new package).
     node = Node(

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -5,9 +5,18 @@ from drivers.durable_backend.dbos.adapter import (
 )
 from trajectory_ir.effects import requires_block_and_gate
 from trajectory_ir.resume.gate import make_gated_tool_call
+from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
 
 
-def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision_sealed=None):
+def make_run_step(
+    node_log,
+    tenant_id,
+    trajectory_id,
+    tool_registry,
+    on_decision_sealed=None,
+    *,
+    mode: RunMode | str = RunMode.LIVE,
+):
     """Build a durable run_step workflow for one agent step.
 
     Resume matrix (README §8, R02 / R03):
@@ -15,7 +24,10 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
     - ``PURE`` and other non-gated classes: no gate; body may re-run on resume
       when durable memo is absent (R03 for PURE). Prior TOOL_CALL rows alone
       must not raise ``BlockedNeedsGate`` for these classes.
+
+    Sandbox mode (R06): rejects NON_IDEMPOTENT_WRITE before the tool body runs.
     """
+    run_mode = normalize_run_mode(mode)
 
     @durable_workflow
     def run_step(step_n: int, model_call, context: dict):
@@ -44,6 +56,11 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
             # call already attempted" by looking up (step_n, seq), so seq has to
             # identify one call unambiguously.
             seq = 2 + 2 * i
+            assert_tool_allowed_in_mode(
+                run_mode,
+                tool_name=call["name"],
+                effect_class=tool.effect_class,
+            )
             if requires_block_and_gate(tool.effect_class):
                 gated = make_gated_tool_call(
                     node_log,

--- a/pkg/trajectory_ir/runtime/__init__.py
+++ b/pkg/trajectory_ir/runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Runtime primitives: nodes, log, tools, sandbox, graft, redaction."""
+
+from trajectory_ir.runtime.graft import GraftError, graft_artifact_ref
+from trajectory_ir.runtime.redact import redact_payload, redact_projection_context
+from trajectory_ir.runtime.sandbox import RunMode, SandboxForbidden, assert_tool_allowed_in_mode
+
+__all__ = [
+    "GraftError",
+    "RunMode",
+    "SandboxForbidden",
+    "assert_tool_allowed_in_mode",
+    "graft_artifact_ref",
+    "redact_payload",
+    "redact_projection_context",
+]

--- a/pkg/trajectory_ir/runtime/graft.py
+++ b/pkg/trajectory_ir/runtime/graft.py
@@ -1,0 +1,111 @@
+"""Graft artifact references between trajectories (README §10 R07).
+
+Transfers only artifact identity (content hash / ref metadata). Never copies
+private THOUGHT nodes (or other private kinds) from source history.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.nodes import Node
+
+# Node kinds that must never cross a graft boundary.
+PRIVATE_KINDS = frozenset({"THOUGHT"})
+
+ARTIFACT_KINDS = frozenset({"ARTIFACT_PUT", "ARTIFACT_REF"})
+
+
+class GraftError(Exception):
+    """Raised when a graft request is invalid or would leak private data."""
+
+
+def _payload_content_hash(payload: dict[str, Any]) -> str | None:
+    for key in ("content_hash", "hash", "sha256"):
+        v = payload.get(key)
+        if isinstance(v, str) and v:
+            return v
+    return None
+
+
+def find_artifact_ref(
+    source_nodes: list[dict[str, Any]],
+    content_hash: str,
+) -> dict[str, Any]:
+    """Locate ARTIFACT_PUT/REF metadata for content_hash; ignore private kinds."""
+    if not content_hash or not isinstance(content_hash, str):
+        raise GraftError("content_hash is required")
+    # Reject accidental use of a thought id or non-hash token without search.
+    matches: list[dict[str, Any]] = []
+    for n in source_nodes:
+        kind = n.get("kind")
+        if kind in PRIVATE_KINDS:
+            continue
+        if kind not in ARTIFACT_KINDS:
+            continue
+        payload = n.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        if _payload_content_hash(payload) == content_hash:
+            matches.append(n)
+    if not matches:
+        raise GraftError(f"no ARTIFACT_PUT/ARTIFACT_REF with content_hash={content_hash!r}")
+    # Prefer ARTIFACT_REF then PUT; stable by seq.
+    matches.sort(key=lambda n: (0 if n.get("kind") == "ARTIFACT_REF" else 1, n.get("seq") or 0))
+    return matches[0]
+
+
+def graft_artifact_ref(
+    target_log: NodeLog,
+    *,
+    content_hash: str,
+    target_trajectory_id: str,
+    target_tenant_id: str,
+    seq: int,
+    step_n: int | None = None,
+    source_nodes: list[dict[str, Any]] | None = None,
+    logical_path: str | None = None,
+    uri: str | None = None,
+    source_trajectory_id: str | None = None,
+) -> Node:
+    """Append an ARTIFACT_REF on the target log for ``content_hash``.
+
+    If ``source_nodes`` is provided, metadata is taken from the first matching
+    artifact node (never from THOUGHT). Private kinds are never copied as nodes.
+    """
+    if source_nodes is not None:
+        # Fail closed if caller tries to pass a private-kind node as the only "match".
+        for n in source_nodes:
+            if n.get("kind") in PRIVATE_KINDS:
+                ph = n.get("payload") if isinstance(n.get("payload"), dict) else {}
+                if isinstance(ph, dict) and _payload_content_hash(ph) == content_hash:
+                    raise GraftError("refusing to graft from a THOUGHT/private node")
+        src = find_artifact_ref(source_nodes, content_hash)
+        payload_src = src.get("payload") or {}
+        if not isinstance(payload_src, dict):
+            payload_src = {}
+        logical_path = logical_path or payload_src.get("logical_path")  # type: ignore[assignment]
+        uri = uri if uri is not None else payload_src.get("uri")  # type: ignore[assignment]
+        if source_trajectory_id is None:
+            source_trajectory_id = src.get("trajectory_id")  # type: ignore[assignment]
+
+    payload: dict[str, Any] = {
+        "content_hash": content_hash,
+        "grafted": True,
+    }
+    if logical_path is not None:
+        payload["logical_path"] = logical_path
+    if uri is not None:
+        payload["uri"] = uri
+    if source_trajectory_id is not None:
+        payload["source_trajectory_id"] = source_trajectory_id
+
+    return target_log.append(
+        "ARTIFACT_REF",
+        step_n,
+        payload,
+        target_trajectory_id,
+        target_tenant_id,
+        seq,
+    )

--- a/pkg/trajectory_ir/runtime/redact.py
+++ b/pkg/trajectory_ir/runtime/redact.py
@@ -1,0 +1,90 @@
+"""Shared redaction heuristics for package export and context projection.
+
+This is a keyword/pattern heuristic, not a general secret scanner. See
+SECURITY.md. Used by:
+- ``package/tir.py`` redacted export
+- projection redaction (R08)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Keys whose values are redacted (case-insensitive substring match).
+SECRET_KEY_RE = re.compile(
+    r"(password|passwd|pass[_-]?phrase|secret|token|api[_-]?key|access[_-]?key"
+    r"|authorization|auth|credential|private[_-]?key)",
+    re.IGNORECASE,
+)
+
+# Value shapes that look like a secret regardless of field name.
+SECRET_VALUE_RE = re.compile(
+    r"(AKIA[0-9A-Z]{16}"  # AWS access key id
+    r"|[Bb]earer\s+[A-Za-z0-9\-_.=]{10,}"  # bearer token
+    r"|gh[pousr]_[A-Za-z0-9]{20,}"  # GitHub token
+    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI-style secret key
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"  # Slack token
+    r"|-----BEGIN[ A-Z]*PRIVATE KEY-----"  # PEM private key block
+    r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"  # JWT
+)
+
+REDACTED = "[REDACTED]"
+
+
+def redact_value(key: str, value: Any) -> Any:
+    """Redact a single value by key name or secret-shaped string content."""
+    if SECRET_KEY_RE.search(key):
+        return REDACTED
+    if isinstance(value, dict):
+        return {k: redact_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_value(key, item) for item in value]
+    if isinstance(value, str) and SECRET_VALUE_RE.search(value):
+        return REDACTED
+    return value
+
+
+def redact_payload(kind: str, payload: Any) -> dict[str, Any]:
+    """Redact a node payload for projection or export.
+
+    THOUGHT bodies are replaced with ``{\"redacted\": true}`` so private
+    reasoning never enters projected context (R08) or shared packages.
+    CONSTRAINT payloads are still redacted for secrets but keep structure
+    (R04: never drop the node; only scrub fields).
+    """
+    if kind == "THOUGHT":
+        return {"redacted": True}
+    if isinstance(payload, dict):
+        return {k: redact_value(str(k), v) for k, v in payload.items()}
+    return {"redacted": True}
+
+
+def redact_projection_context(context: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a projector-style context with secrets/thoughts scrubbed.
+
+    Expected shape (from R04 ``ProjectResult.context`` or equivalent)::
+
+        {\"items\": [{\"id\", \"kind\", \"payload\", ...}, ...], ...}
+
+    CONSTRAINT items stay present; only payload fields are redacted in place.
+    """
+    items_in = context.get("items")
+    if not isinstance(items_in, list):
+        # Treat free-form context dict as a single redaction pass on top-level keys.
+        return {k: redact_value(str(k), v) for k, v in context.items()}
+
+    new_items: list[dict[str, Any]] = []
+    for item in items_in:
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("kind") or "")
+        payload = item.get("payload")
+        new_item = dict(item)
+        new_item["payload"] = redact_payload(kind, payload)
+        new_items.append(new_item)
+
+    out = dict(context)
+    out["items"] = new_items
+    out["redacted"] = True
+    return out

--- a/pkg/trajectory_ir/runtime/sandbox.py
+++ b/pkg/trajectory_ir/runtime/sandbox.py
@@ -1,0 +1,54 @@
+"""Sandbox / what-if trajectory mode (README §10 R06).
+
+Live mode is the default. Sandbox mode allows planning and non-gated tools
+(PURE, READ_ONLY, etc.) but rejects real NON_IDEMPOTENT_WRITE side effects
+before the tool body runs.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from trajectory_ir.effects import EffectClass, requires_block_and_gate
+
+
+class RunMode(StrEnum):
+    LIVE = "live"
+    SANDBOX = "sandbox"
+
+
+class SandboxForbidden(Exception):
+    """Raised when sandbox mode rejects a tool effect class (R06)."""
+
+    def __init__(self, tool_name: str, effect_class: EffectClass):
+        self.tool_name = tool_name
+        self.effect_class = effect_class
+        super().__init__(
+            f"SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE: tool {tool_name!r} "
+            f"effect={effect_class.value} is forbidden in sandbox mode"
+        )
+
+
+def normalize_run_mode(mode: RunMode | str | None) -> RunMode:
+    if mode is None:
+        return RunMode.LIVE
+    if isinstance(mode, RunMode):
+        return mode
+    m = str(mode).strip().lower()
+    if m in ("live", ""):
+        return RunMode.LIVE
+    if m == "sandbox":
+        return RunMode.SANDBOX
+    raise ValueError(f"unsupported run mode {mode!r}; use live or sandbox")
+
+
+def assert_tool_allowed_in_mode(
+    mode: RunMode | str | None,
+    *,
+    tool_name: str,
+    effect_class: EffectClass,
+) -> None:
+    """Raise SandboxForbidden if this tool must not run under the given mode."""
+    run_mode = normalize_run_mode(mode)
+    if run_mode is RunMode.SANDBOX and requires_block_and_gate(effect_class):
+        raise SandboxForbidden(tool_name, effect_class)


### PR DESCRIPTION
## Summary
Implements the three open §10 issues after R03:

| ID | Issue | What |
|----|-------|------|
| **R06** | #54 | `RunMode.SANDBOX` rejects `NON_IDEMPOTENT_WRITE` before side effects |
| **R07** | #55 | `graft_artifact_ref` / `trajir/graft`  artifact ref only, never THOUGHT |
| **R08** | #56 | `redact_projection_context` / `trajir/redact` secrets + THOUGHT scrub for projected context |

Closes #54, #55, #56.

### Design notes (senior constraints)
- **R06:** enforcement at client `exec_tool` and `make_run_step` / Go `ExecTool` + `RunStep`; default remains `live` so demos and R01/R02 unchanged.
- **R07:** only appends `ARTIFACT_REF`; refuses private kinds; does not copy source node history.
- **R08:** shared heuristics with `.tir` redacted export (`runtime/redact`); CONSTRAINT nodes stay present with scrubbed fields (compatible with R04 when #53 merges). Does not require projector on main.
- Heuristic redaction is documented as not a full secret scanner (same honesty as existing export redaction).

### Test plan
- [x] `pytest conformance/r06_* r07_* r08_*` + related unit tests
- [x] `go build ./trajir/...` and `go vet` on new packages
- [ ] CI green (Linux authoritative for Windows Application Control flakes)
