### PR TITLE
release: prepare v0.1.0 changelog and maintainer release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.1.0] - 2026-08-05
+
+First library-tagged release of the Phase 1A surface: dual-language IR, portable `.tir`, and runnable R01–R08.
+
+### Added
+
 - Phase 1A buildable core (nodes, NodeLog, effects, DBOS adapter, seal/resume gate, client SDK, kill-mid-deploy, R01/R02).
 - Issue templates, PR template, DCO CI job, Ruff/Mypy in CI alongside unit/e2e/conformance.
 - Maintainer note for branch protection on `main`.
@@ -34,34 +46,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - R03 PURE recompute-on-resume: `requires_block_and_gate` / `RequiresBlockAndGate`,
   conformance + Go tests; only NON_IDEMPOTENT_WRITE is gated.
 - R04 default context projector (`project_context` / `trajir/projector`) with
-  CONSTRAINT+pinned budget safety and `BUDGET_IMPOSSIBLE`.
+  CONSTRAINT+pinned budget safety and `BUDGET_IMPOSSIBLE` (RFC 8785 size metric).
 - R06 sandbox mode (`RunMode.SANDBOX`) rejects NON_IDEMPOTENT_WRITE before side effects.
 - R07 `graft_artifact_ref` / `trajir/graft` transfers artifact refs only (never THOUGHT).
 - R08 projection redaction (`runtime/redact`, `trajir/redact`); shared with `.tir` redacted export.
-
-
-
-
-
-
-
-
-
+- Maintainer release notes and process: `docs/RELEASE.md`, `docs/RELEASE_NOTES_0.1.0.md`.
 
 ### Changed
+
 - CONTRIBUTING and infrastructure docs describe the CI gates that actually run.
 - Lint cleanups for Ruff/Mypy on the core package and test harness.
 
 ## [v0.1.0-draft] - 2026-07-27
+
 ### Added
+
 - **Master Specification (`README.md`)**: The authoritative definition of Trajectory IR (Spec v0.2-draft).
 - **Infrastructure Blueprint (`infrastructure.md`)**: Detailed DevOps rules targeting `local`, `server-s3`, and `k8s-fluid` profiles. Outlines the sharded CAS layout and fallback mechanisms.
 - **Community Governance**: Added CNCF `CODE_OF_CONDUCT.md`.
 - **Contribution Guidelines**: Added `CONTRIBUTING.md`, enforcing DCO sign-offs (`Signed-off-by`), Everything Claude Code (ECC) subagent suite integration, and governance accountability rules.
 - **Security Policy**: Added `SECURITY.md`, detailing threat models specific to tool execution (Safety Boundary Bypasses, Seal Tampering, Cache Poisoning) and establishing GitHub Private Advisories for confidential reporting.
-- **Quickstart Guide**: Added `QUICKSTART.md` for rapid prototyping using the embedded DBOS backend and SQLite/FileSystem CAS behind an abstract `@Trajectory.workflow()` wrapper.
+- **Quickstart Guide**: Added `QUICKSTART.md` for local prototyping (updated later to match real APIs).
 
 ### Changed
+
 - **Session Storage Consolidation (formerly CLOOP)**: Folded CLOOP's session storage design (mutable short-term state, append-only event log, and sharded CAS artifact store) directly into Trajectory IR's unified database and storage schemas rather than maintaining a separate runtime project.
 - **Declarative Memory Provisioning (formerly CAMI)**: Deferred Kubernetes declarative memory-provisioning claims and storage classes to an optional future phase without blocking core package portability or Phase 1A development.
 - **Durable Execution Rebuild Strategy**: Delegated crash-safe step execution, lease/heartbeat coordination, and deterministic replay to hardened, pluggable third-party backends (**DBOS** and Restate) rather than rebuilding custom execution orchestration engines.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,56 @@
+# Release process (maintainers)
+
+How to cut a GitHub release after the release-prep PR is merged. **Do not** push tags from unreviewed automation.
+
+## Preconditions
+
+1. `main` is green (DCO not required on push to main if merges only; Quality + Go green on the merge commit / latest PR).
+2. Release-prep PR merged (CHANGELOG has a version section; this file is up to date).
+3. Working tree clean; `git pull origin main`.
+
+## Version numbers
+
+| Surface | Where | Notes |
+|---------|--------|--------|
+| Python package | `pyproject.toml` → `project.version` | Currently `0.1.0` |
+| Git tag | `v0.1.0` | Prefer `v` prefix |
+| Go module | `go/go.mod` | No separate semver tag yet; consumers use commit or future `go/v0.1.0` policy if we split versioning later |
+
+## Steps for v0.1.0
+
+```bash
+git checkout main
+git pull origin main
+
+# Annotated tag (example date; use actual merge day if different)
+git tag -a v0.1.0 -m "Trajectory IR v0.1.0 — Phase 1A library surface (R01–R08, dual .tir)"
+
+git push origin v0.1.0
+```
+
+Create a **GitHub Release** for `v0.1.0`:
+
+1. Title: `v0.1.0`
+2. Body: paste or adapt [RELEASE_NOTES_0.1.0.md](RELEASE_NOTES_0.1.0.md)
+3. Attach nothing required (source zip is automatic)
+
+Optional PyPI (when ready; not required to call the tag a release):
+
+```bash
+pip install build twine
+python -m build
+# twine upload dist/*   # only with package owner credentials
+```
+
+## After the release
+
+1. Confirm the GitHub Release page renders.
+2. If something critical was missed, ship `0.1.1` rather than moving the tag.
+3. Open issues for next work (client integration, FS CAS, etc.) under a clean Unreleased section.
+
+## Checklist
+
+- [ ] CHANGELOG `[0.1.0]` section accurate
+- [ ] Tag pushed
+- [ ] GitHub Release published
+- [ ] Announce (Discord/org) with install-from-git or PyPI link

--- a/docs/RELEASE_NOTES_0.1.0.md
+++ b/docs/RELEASE_NOTES_0.1.0.md
@@ -1,0 +1,46 @@
+# Trajectory IR v0.1.0
+
+First numbered library release of **Trajectory IR**: a portable, hash-verifiable intermediate representation for agent runs (seals, effect classes, block-and-gate, `.tir` packages) on top of pluggable durable backends.
+
+## Highlights
+
+- **Python IR core** with DBOS-backed durable steps and SQLite NodeLog
+- **Go IR stack** (`go/trajir`) with LocalSQLite/Memory memoization and optional Temporal
+- **Portable `.tir`** thin/fat packages (Python + Go), with verification and resource limits
+- **Conformance R01–R08** runnable under `pytest conformance/` (and Go package tests where noted)
+- **Sandbox mode (R06)**, **graft (R07)**, **projection redaction (R08)**, **projector budget safety (R04)**
+- OSS process: DCO, CI (Ruff/Mypy/pytest/govulncheck/pip-audit gate), Dependabot, SECURITY.md
+
+## Install (from source)
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR
+pip install -e ".[dev]"
+```
+
+Go:
+
+```bash
+cd go && go test ./...
+```
+
+See [QUICKSTART.md](../QUICKSTART.md) and [PHASE_1A_STATUS.md](PHASE_1A_STATUS.md).
+
+## Not in 0.1.0
+
+- Package digital signatures  
+- Restate adapter  
+- Full FS/S3 CAS product and Fluid  
+- Multi-tenant SaaS control plane  
+- Automated PyPI publish (optional maintainer follow-up)
+
+## CNCF context
+
+Positioned against the storage gap described in the CNCF TAG Infrastructure white paper:
+
+https://www.cncf.io/wp-content/uploads/2026/07/DoK_DataAnalyticsAIMLWorkloads_070826.pdf
+
+## Full changelog
+
+See [CHANGELOG.md](../CHANGELOG.md) section `[0.1.0]`.


### PR DESCRIPTION
## Summary
**v0.1.0 release preparation** (docs/metadata only). Closes #59.

- CHANGELOG: `[0.1.0] - 2026-08-05` with current Phase 1A feature set; clean Unreleased stub
- `docs/RELEASE.md` — maintainer steps to tag `v0.1.0` after merge
- `docs/RELEASE_NOTES_0.1.0.md` — GitHub Release body draft
- `pyproject.toml` already at `0.1.0` (unchanged)

**Not in this PR:** git tag push, PyPI upload (human after review/merge).

## Test plan
- [x] Docs only
- [ ] CI green

**Do not merge until reviewed.** Suggested order: merge housekeeping #60 first (optional), then this release prep; then tag on main.