### PR TITLE
feat: local filesystem CAS for thin package rehydrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
+  with sharded `cas/<2-hex>/<hash>` layout, hash verify on get, and
+  `rehydrate_artifacts` for thin `.tir` packages (issue #62).
+
 ### Changed
 
 ### Fixed

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -14,6 +14,7 @@ Honest inventory of what is **on `main`** versus what remains **out of scope** o
 | Sandbox (R06) | `runtime/sandbox.py`, Go `trajir/sandbox` |
 | Graft (R07) | `runtime/graft.py`, Go `trajir/graft` |
 | Redaction (R08 + export) | `runtime/redact.py`, Go `trajir/redact` |
+| Local FS CAS | `trajectory_ir.storage.FileSystemCAS`, thin rehydrate helper |
 | Go IR stack | `go/trajir/*` — nodes, log, effects, durable, Temporal, resume, client |
 | Demos | `examples/kill-mid-deploy/`, `go/examples/kill-mid-deploy/` |
 | CI | DCO, Quality (3.11/3.12: ruff, mypy, unit/e2e/conformance, pip-audit test), Go (tests + govulncheck) |
@@ -39,7 +40,7 @@ Phase 1A **completion bar** in the master README still treats R01/R02 as the har
 |------|--------|
 | Package digital signatures | `SIGNATURE` reserved / null |
 | Restate adapter | Spec: after DBOS is solid |
-| Local FS CAS object store product | Fat `.tir` embeds bytes; thin URI rehydrate not a full CAS service |
+| Local FS CAS object store product | Shipped: `trajectory_ir.storage.FileSystemCAS` + `rehydrate_artifacts` |
 | Postgres / S3 drivers | Package scaffolds only |
 | Fluid / k8s-fluid profile | Later phase |
 | Full `projector-policy.yaml` DSL | Default built-in policy only |

--- a/pkg/trajectory_ir/storage/__init__.py
+++ b/pkg/trajectory_ir/storage/__init__.py
@@ -1,0 +1,33 @@
+"""Content addressed artifact storage (CAS).
+
+README section 11 splits durable storage into the IR node/seal log and a
+content addressed object store for artifact bytes. This package owns the
+object store contract and the local filesystem implementation used by the
+``local`` deployment profile.
+
+S3 and other remote drivers live under ``drivers/`` and implement the same
+:class:`~trajectory_ir.storage.cas.CAS` protocol so thin ``.tir`` packages can
+rehydrate from any store that verifies hashes on put and get.
+"""
+
+from trajectory_ir.storage.cas import (
+    CAS,
+    CASError,
+    CASIntegrityError,
+    CASNotFoundError,
+    content_hash,
+    shard_key,
+)
+from trajectory_ir.storage.fs import FileSystemCAS
+from trajectory_ir.storage.rehydrate import rehydrate_artifacts
+
+__all__ = [
+    "CAS",
+    "CASError",
+    "CASIntegrityError",
+    "CASNotFoundError",
+    "FileSystemCAS",
+    "content_hash",
+    "rehydrate_artifacts",
+    "shard_key",
+]

--- a/pkg/trajectory_ir/storage/cas.py
+++ b/pkg/trajectory_ir/storage/cas.py
@@ -1,0 +1,90 @@
+"""CAS protocol and shared key layout helpers (README section 11.2).
+
+Layout (stable across filesystem and S3 drivers)::
+
+    cas/<first-2-hex-chars-of-sha256>/<full-sha256-hex>
+
+Objects are identified solely by the SHA-256 of their bytes. A given hash
+never changes once written; the only failure mode is a miss or a bit flip
+detected by re-hashing on read.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Protocol, runtime_checkable
+
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CASError(Exception):
+    """Base error for content addressed storage operations."""
+
+
+class CASNotFoundError(CASError):
+    """Raised when ``get`` cannot find an object for the given content hash."""
+
+
+class CASIntegrityError(CASError):
+    """Raised when stored bytes do not match the expected content hash."""
+
+
+def content_hash(data: bytes) -> str:
+    """Return lowercase hex SHA-256 of ``data``."""
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError("content_hash expects bytes")
+    return hashlib.sha256(data).hexdigest()
+
+
+def normalize_content_hash(value: str) -> str:
+    """Validate and normalize a content hash to lowercase hex."""
+    if not isinstance(value, str):
+        raise TypeError("content_hash must be a string")
+    h = value.lower().strip()
+    if not _HEX64.match(h):
+        raise CASError(f"invalid content hash (need 64 lowercase hex digits): {value!r}")
+    return h
+
+
+def shard_key(content_hash_hex: str) -> str:
+    """Return the relative object key for a content hash (no scheme, no root).
+
+    Example: ``e3b0c442...`` -> ``cas/e3/e3b0c442...``
+    """
+    h = normalize_content_hash(content_hash_hex)
+    return f"cas/{h[:2]}/{h}"
+
+
+@runtime_checkable
+class CAS(Protocol):
+    """Minimal content addressed store used by thin package rehydrate.
+
+    Implementations must:
+    1. Compute identity as SHA-256 of the bytes (hex).
+    2. Store under the sharded key layout from :func:`shard_key`.
+    3. Verify the hash on every successful ``get``.
+    4. Treat concurrent ``put`` of the same bytes as idempotent.
+    """
+
+    def put(self, data: bytes) -> str:
+        """Store ``data`` and return its content hash.
+
+        If the object already exists with matching bytes, return the hash
+        without rewriting. If a different payload occupies the hash path,
+        raise :class:`CASIntegrityError` (should be impossible for true CAS).
+        """
+        ...
+
+    def get(self, content_hash_hex: str) -> bytes:
+        """Load bytes for ``content_hash_hex``, verifying the hash.
+
+        Raises:
+            CASNotFoundError: object is absent
+            CASIntegrityError: bytes present but hash does not match
+        """
+        ...
+
+    def has(self, content_hash_hex: str) -> bool:
+        """Return True if an object exists for this hash (no full verify)."""
+        ...

--- a/pkg/trajectory_ir/storage/fs.py
+++ b/pkg/trajectory_ir/storage/fs.py
@@ -1,0 +1,108 @@
+"""Local filesystem CAS for the ``local`` deployment profile.
+
+Root directory layout (README section 11.2)::
+
+    <root>/
+      cas/
+        e3/
+          e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        ab/
+          abcd...
+
+Writes use a temp file in the same directory plus ``os.replace`` so readers
+never observe a partial object. Hash is always recomputed on ``get``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from trajectory_ir.storage.cas import (
+    CASIntegrityError,
+    CASNotFoundError,
+    content_hash,
+    normalize_content_hash,
+    shard_key,
+)
+
+
+class FileSystemCAS:
+    """Filesystem backed content addressed store.
+
+    Args:
+        root: Directory that will contain the ``cas/`` tree. Created if missing.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root).resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def root(self) -> Path:
+        """Absolute root directory for this store."""
+        return self._root
+
+    def path_for(self, content_hash_hex: str) -> Path:
+        """Absolute path for a content hash under this store's root."""
+        return self._root / shard_key(content_hash_hex)
+
+    def uri_for(self, content_hash_hex: str) -> str:
+        """Stable ``cas://`` URI for thin package artifact refs.
+
+        Format: ``cas://fs/<absolute-root-as-posix>/<shard>/<hash>`` is avoided;
+        we use ``cas://<hash>`` plus store context at rehydrate time so packages
+        stay portable across machines. Callers that need a file URL can use
+        ``path_for(...).as_uri()`` locally.
+        """
+        h = normalize_content_hash(content_hash_hex)
+        return f"cas://{h}"
+
+    def put(self, data: bytes) -> str:
+        if not isinstance(data, (bytes, bytearray)):
+            raise TypeError("put expects bytes")
+        data = bytes(data)
+        h = content_hash(data)
+        dest = self.path_for(h)
+        if dest.is_file():
+            existing = dest.read_bytes()
+            if content_hash(existing) != h:
+                raise CASIntegrityError(
+                    f"corrupt object at {dest}: stored bytes do not match name {h}"
+                )
+            # Idempotent: same hash already present.
+            return h
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{h}.", dir=str(dest.parent))
+        try:
+            with os.fdopen(fd, "wb") as tmp:
+                tmp.write(data)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_name, dest)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+        return h
+
+    def get(self, content_hash_hex: str) -> bytes:
+        h = normalize_content_hash(content_hash_hex)
+        path = self.path_for(h)
+        if not path.is_file():
+            raise CASNotFoundError(f"no object for content_hash={h}")
+        data = path.read_bytes()
+        actual = content_hash(data)
+        if actual != h:
+            raise CASIntegrityError(
+                f"object at {path} failed hash verify: expected {h}, got {actual}"
+            )
+        return data
+
+    def has(self, content_hash_hex: str) -> bool:
+        h = normalize_content_hash(content_hash_hex)
+        return self.path_for(h).is_file()

--- a/pkg/trajectory_ir/storage/rehydrate.py
+++ b/pkg/trajectory_ir/storage/rehydrate.py
@@ -1,0 +1,48 @@
+"""Thin package artifact rehydration against a CAS.
+
+Fat packages embed bytes. Thin packages only carry content hashes (and
+optional URIs). Call :func:`rehydrate_artifacts` after :func:`load_tir` when
+you need the bytes again from a local or remote store.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from trajectory_ir.storage.cas import CAS, CASError, CASNotFoundError, normalize_content_hash
+
+
+def rehydrate_artifacts(
+    store: CAS,
+    artifacts_manifest: list[Mapping[str, Any]],
+    *,
+    require_all: bool = True,
+) -> dict[str, bytes]:
+    """Fetch artifact bytes for each manifest entry from ``store``.
+
+    Args:
+        store: Any CAS implementation (filesystem, S3, ...).
+        artifacts_manifest: Entries shaped like ``.tir`` artifacts-manifest.json
+            rows (must include ``content_hash``).
+        require_all: When True (default), missing objects raise
+            :class:`CASNotFoundError`. When False, missing hashes are skipped.
+
+    Returns:
+        Map of content_hash -> bytes for every resolved entry.
+    """
+    out: dict[str, bytes] = {}
+    for entry in artifacts_manifest:
+        raw = entry.get("content_hash")
+        if raw is None:
+            raise CASError("artifact manifest entry missing content_hash")
+        h = normalize_content_hash(str(raw))
+        if h in out:
+            continue
+        try:
+            out[h] = store.get(h)
+        except CASNotFoundError:
+            if require_all:
+                raise
+            continue
+    return out

--- a/test/unit/test_fs_cas.py
+++ b/test/unit/test_fs_cas.py
@@ -29,9 +29,7 @@ def store(cas_root):
 
 def test_content_hash_known_empty():
     # SHA-256 of empty string (public test vector).
-    assert content_hash(b"") == (
-        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    )
+    assert content_hash(b"") == ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 
 
 def test_shard_key_layout():

--- a/test/unit/test_fs_cas.py
+++ b/test/unit/test_fs_cas.py
@@ -1,0 +1,125 @@
+"""Unit tests for local filesystem CAS and thin rehydrate."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from trajectory_ir.storage import (
+    CASIntegrityError,
+    CASNotFoundError,
+    FileSystemCAS,
+    content_hash,
+    rehydrate_artifacts,
+    shard_key,
+)
+from trajectory_ir.storage.cas import CASError, normalize_content_hash
+
+
+@pytest.fixture
+def cas_root(tmp_path):
+    return tmp_path / "cas_root"
+
+
+@pytest.fixture
+def store(cas_root):
+    return FileSystemCAS(cas_root)
+
+
+def test_content_hash_known_empty():
+    # SHA-256 of empty string (public test vector).
+    assert content_hash(b"") == (
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+
+
+def test_shard_key_layout():
+    h = content_hash(b"hello")
+    assert shard_key(h) == f"cas/{h[:2]}/{h}"
+
+
+def test_put_get_roundtrip(store):
+    data = b"trajectory artifact payload"
+    h = store.put(data)
+    assert h == content_hash(data)
+    assert store.has(h)
+    assert store.get(h) == data
+    assert store.path_for(h).is_file()
+    assert store.path_for(h) == store.root / f"cas/{h[:2]}/{h}"
+
+
+def test_put_is_idempotent(store):
+    data = b"same bytes twice"
+    h1 = store.put(data)
+    h2 = store.put(data)
+    assert h1 == h2
+    assert store.get(h1) == data
+
+
+def test_get_missing_raises(store):
+    h = content_hash(b"absent")
+    with pytest.raises(CASNotFoundError):
+        store.get(h)
+    assert not store.has(h)
+
+
+def test_get_detects_tamper(store):
+    data = b"honest bytes"
+    h = store.put(data)
+    path = store.path_for(h)
+    path.write_bytes(b"tampered")
+    with pytest.raises(CASIntegrityError):
+        store.get(h)
+
+
+def test_normalize_content_hash_rejects_bad():
+    with pytest.raises(CASError):
+        normalize_content_hash("not-a-hash")
+    with pytest.raises(CASError):
+        normalize_content_hash("ab")
+
+
+def test_uri_for_is_portable_hash_only(store):
+    h = store.put(b"x")
+    assert store.uri_for(h) == f"cas://{h}"
+
+
+def test_rehydrate_artifacts_require_all(store):
+    h1 = store.put(b"one")
+    h2 = content_hash(b"two-missing")
+    manifest = [
+        {"logical_path": "a.bin", "content_hash": h1},
+        {"logical_path": "b.bin", "content_hash": h2},
+    ]
+    with pytest.raises(CASNotFoundError):
+        rehydrate_artifacts(store, manifest, require_all=True)
+
+    partial = rehydrate_artifacts(store, manifest, require_all=False)
+    assert list(partial.keys()) == [h1]
+    assert partial[h1] == b"one"
+
+
+def test_rehydrate_full(store):
+    h1 = store.put(b"alpha")
+    h2 = store.put(b"beta")
+    got = rehydrate_artifacts(
+        store,
+        [
+            {"content_hash": h1, "logical_path": "a"},
+            {"content_hash": h2, "logical_path": "b"},
+        ],
+    )
+    assert got[h1] == b"alpha"
+    assert got[h2] == b"beta"
+
+
+def test_cas_protocol_runtime_check(store):
+    from trajectory_ir.storage.cas import CAS
+
+    assert isinstance(store, CAS)
+
+
+def test_put_creates_sharded_dirs(store):
+    h = store.put(os.urandom(32))
+    assert (store.root / "cas" / h[:2]).is_dir()


### PR DESCRIPTION
## Summary

Adds a content addressed object store for the local deployment profile so thin packages can rehydrate artifact bytes by hash. Introduces `trajectory_ir.storage` with a small CAS protocol, `FileSystemCAS` using the sharded layout from README section 11.2 (`cas/<first two hex>/<full hash>`), atomic put via temp file and replace, and hash verification on every get. `rehydrate_artifacts` loads a thin package artifact manifest from any CAS implementation.

## Related issues

Closes #62

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_fs_cas.py -q
ruff check pkg/trajectory_ir/storage test/unit/test_fs_cas.py
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [x] No
* [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for implementation and tests; human review of layout and API surface before opening the PR.