### PR TITLE
feat: S3 compatible CAS backend for artifact bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
   with sharded `cas/<2-hex>/<hash>` layout, hash verify on get, and
   `rehydrate_artifacts` for thin `.tir` packages (issue #62).
+- S3 compatible CAS driver (`drivers.s3.S3CAS`) with the same sharded key layout
+  and injectable client for tests; optional `boto3` extra (issue #63).
 
 ### Changed
 

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -41,7 +41,7 @@ Phase 1A **completion bar** in the master README still treats R01/R02 as the har
 | Package digital signatures | `SIGNATURE` reserved / null |
 | Restate adapter | Spec: after DBOS is solid |
 | Local FS CAS object store product | Shipped: `trajectory_ir.storage.FileSystemCAS` + `rehydrate_artifacts` |
-| Postgres / S3 drivers | Package scaffolds only |
+| Postgres / S3 drivers | S3 CAS shipped (`drivers.s3`); Postgres NodeLog still deferred |
 | Fluid / k8s-fluid profile | Later phase |
 | Full `projector-policy.yaml` DSL | Default built-in policy only |
 | Multi-tenant SaaS control plane | Library trust model |

--- a/drivers/s3/__init__.py
+++ b/drivers/s3/__init__.py
@@ -1,0 +1,21 @@
+"""S3 compatible content addressed store (server-s3 profile).
+
+Implements the same :class:`~trajectory_ir.storage.cas.CAS` protocol as
+:class:`~trajectory_ir.storage.fs.FileSystemCAS`, using the sharded key layout
+from README section 11.2.
+
+Requires the optional ``boto3`` dependency::
+
+    pip install boto3
+    # or: pip install -e ".[s3]"
+
+Credentials and endpoint come from the environment or an injected client.
+Never hardcode secrets in repository code.
+"""
+
+from drivers.s3.cas import S3CAS, build_s3_client_from_env
+
+__all__ = [
+    "S3CAS",
+    "build_s3_client_from_env",
+]

--- a/drivers/s3/cas.py
+++ b/drivers/s3/cas.py
@@ -21,6 +21,16 @@ from trajectory_ir.storage.cas import (
     shard_key,
 )
 
+# boto3 ClientError codes that mean the object is absent (not auth/network/5xx).
+_NOT_FOUND_CODES = frozenset(
+    {
+        "NoSuchKey",
+        "NotFound",
+        "404",
+        "NoSuchVersion",
+    }
+)
+
 
 class S3ClientProtocol(Protocol):
     """Minimal subset of boto3 S3 client methods used by :class:`S3CAS`."""
@@ -30,6 +40,38 @@ class S3ClientProtocol(Protocol):
     def get_object(self, *, Bucket: str, Key: str, **kwargs: Any) -> Any: ...
 
     def head_object(self, *, Bucket: str, Key: str, **kwargs: Any) -> Any: ...
+
+
+def _error_code(exc: BaseException) -> str | None:
+    """Extract S3/API error code from a boto3 style ClientError, if present."""
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return None
+    error = response.get("Error")
+    if not isinstance(error, dict):
+        return None
+    code = error.get("Code")
+    if code is None:
+        return None
+    return str(code)
+
+
+def _is_not_found(exc: BaseException) -> bool:
+    """True only when the error means the object is missing.
+
+    Must not treat arbitrary ClientError (AccessDenied, 500, throttling) as
+    absence — those must surface to the caller.
+    """
+    code = _error_code(exc)
+    if code is not None:
+        return code in _NOT_FOUND_CODES
+    # In-memory fakes and some SDKs raise KeyError / NoSuchKey without .response.
+    name = type(exc).__name__
+    if name == "NoSuchKey":
+        return True
+    if isinstance(exc, KeyError):
+        return True
+    return False
 
 
 class S3CAS:
@@ -89,17 +131,7 @@ class S3CAS:
         try:
             resp = self._client.get_object(Bucket=self._bucket, Key=key)
         except Exception as exc:
-            # boto3 raises ClientError with Code NoSuchKey; fakes may raise KeyError.
-            name = type(exc).__name__
-            code = ""
-            if hasattr(exc, "response"):
-                code = str(exc.response.get("Error", {}).get("Code", ""))  # type: ignore[union-attr]
-            if (
-                name in {"NoSuchKey", "ClientError", "KeyError"}
-                or code in {"NoSuchKey", "404", "NotFound"}
-                or "NoSuchKey" in str(exc)
-                or "404" in str(exc)
-            ):
+            if _is_not_found(exc):
                 raise CASNotFoundError(f"no object for content_hash={h}") from exc
             raise
         body = resp["Body"]
@@ -117,8 +149,11 @@ class S3CAS:
         try:
             self._client.head_object(Bucket=self._bucket, Key=key)
             return True
-        except Exception:
-            return False
+        except Exception as exc:
+            if _is_not_found(exc):
+                return False
+            # Auth, network, 5xx, throttling, etc. must not look like "missing".
+            raise
 
 
 def build_s3_client_from_env() -> Any:

--- a/drivers/s3/cas.py
+++ b/drivers/s3/cas.py
@@ -1,0 +1,147 @@
+"""S3 compatible CAS backend.
+
+Key layout (identical to FileSystemCAS)::
+
+    cas/<first-2-hex>/<full-sha256-hex>
+
+The client is injected so unit tests can use a fake without AWS or MinIO.
+Production code typically calls :func:`build_s3_client_from_env`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol
+
+from trajectory_ir.storage.cas import (
+    CASIntegrityError,
+    CASNotFoundError,
+    content_hash,
+    normalize_content_hash,
+    shard_key,
+)
+
+
+class S3ClientProtocol(Protocol):
+    """Minimal subset of boto3 S3 client methods used by :class:`S3CAS`."""
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **kwargs: Any) -> Any: ...
+
+    def get_object(self, *, Bucket: str, Key: str, **kwargs: Any) -> Any: ...
+
+    def head_object(self, *, Bucket: str, Key: str, **kwargs: Any) -> Any: ...
+
+
+class S3CAS:
+    """Content addressed store backed by an S3 compatible API.
+
+    Args:
+        client: boto3 style S3 client (or test double).
+        bucket: Bucket name (must already exist).
+        key_prefix: Optional prefix before ``cas/...`` (no leading/trailing
+            slash required; empty string is fine).
+    """
+
+    def __init__(
+        self,
+        client: S3ClientProtocol,
+        bucket: str,
+        *,
+        key_prefix: str = "",
+    ) -> None:
+        if not bucket:
+            raise ValueError("bucket is required")
+        self._client = client
+        self._bucket = bucket
+        self._prefix = key_prefix.strip("/")
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    def object_key(self, content_hash_hex: str) -> str:
+        """Full object key including optional prefix."""
+        rel = shard_key(content_hash_hex)
+        if self._prefix:
+            return f"{self._prefix}/{rel}"
+        return rel
+
+    def uri_for(self, content_hash_hex: str) -> str:
+        """``s3://bucket/key`` URI for thin package artifact refs."""
+        h = normalize_content_hash(content_hash_hex)
+        return f"s3://{self._bucket}/{self.object_key(h)}"
+
+    def put(self, data: bytes) -> str:
+        if not isinstance(data, (bytes, bytearray)):
+            raise TypeError("put expects bytes")
+        data = bytes(data)
+        h = content_hash(data)
+        key = self.object_key(h)
+        if self.has(h):
+            # Idempotent: existing object must match hash on next get.
+            return h
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=data)
+        return h
+
+    def get(self, content_hash_hex: str) -> bytes:
+        h = normalize_content_hash(content_hash_hex)
+        key = self.object_key(h)
+        try:
+            resp = self._client.get_object(Bucket=self._bucket, Key=key)
+        except Exception as exc:
+            # boto3 raises ClientError with Code NoSuchKey; fakes may raise KeyError.
+            name = type(exc).__name__
+            code = ""
+            if hasattr(exc, "response"):
+                code = str(exc.response.get("Error", {}).get("Code", ""))  # type: ignore[union-attr]
+            if (
+                name in {"NoSuchKey", "ClientError", "KeyError"}
+                or code in {"NoSuchKey", "404", "NotFound"}
+                or "NoSuchKey" in str(exc)
+                or "404" in str(exc)
+            ):
+                raise CASNotFoundError(f"no object for content_hash={h}") from exc
+            raise
+        body = resp["Body"]
+        data = body.read() if hasattr(body, "read") else bytes(body)
+        actual = content_hash(data)
+        if actual != h:
+            raise CASIntegrityError(
+                f"s3://{self._bucket}/{key} failed hash verify: expected {h}, got {actual}"
+            )
+        return data
+
+    def has(self, content_hash_hex: str) -> bool:
+        h = normalize_content_hash(content_hash_hex)
+        key = self.object_key(h)
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=key)
+            return True
+        except Exception:
+            return False
+
+
+def build_s3_client_from_env() -> Any:
+    """Build a boto3 S3 client from environment variables.
+
+    Recognized variables:
+
+    * ``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY`` (standard)
+    * ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` (default ``us-east-1``)
+    * ``TRAJIR_S3_ENDPOINT_URL`` optional custom endpoint (MinIO, LocalStack)
+
+    Raises:
+        ImportError: if boto3 is not installed
+        ValueError: if required configuration is missing in a strict way
+    """
+    try:
+        import boto3
+    except ImportError as exc:
+        raise ImportError(
+            "boto3 is required for S3CAS production use; pip install boto3 "
+            'or pip install -e ".[s3]"'
+        ) from exc
+
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+    endpoint = os.environ.get("TRAJIR_S3_ENDPOINT_URL") or None
+    return boto3.client("s3", region_name=region, endpoint_url=endpoint)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
+s3 = ["boto3"]
 
 [build-system]
 requires = ["hatchling"]

--- a/test/unit/test_s3_cas.py
+++ b/test/unit/test_s3_cas.py
@@ -1,0 +1,112 @@
+"""Unit tests for S3 CAS using an in memory fake client (no AWS)."""
+
+from __future__ import annotations
+
+from drivers.s3.cas import S3CAS
+from trajectory_ir.storage.cas import CAS, CASIntegrityError, CASNotFoundError, content_hash
+from trajectory_ir.storage.rehydrate import rehydrate_artifacts
+
+
+class _FakeBody:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class FakeS3Client:
+    """Minimal S3 client double for unit tests."""
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **kwargs):
+        self.objects[(Bucket, Key)] = bytes(Body)
+        return {}
+
+    def get_object(self, *, Bucket: str, Key: str, **kwargs):
+        try:
+            data = self.objects[(Bucket, Key)]
+        except KeyError as exc:
+            err = KeyError("NoSuchKey")
+            raise err from exc
+        return {"Body": _FakeBody(data)}
+
+    def head_object(self, *, Bucket: str, Key: str, **kwargs):
+        if (Bucket, Key) not in self.objects:
+            raise KeyError("NoSuchKey")
+        return {}
+
+
+def test_put_get_roundtrip():
+    client = FakeS3Client()
+    store = S3CAS(client, "trajir-test")
+    data = b"s3 artifact"
+    h = store.put(data)
+    assert h == content_hash(data)
+    assert store.has(h)
+    assert store.get(h) == data
+    assert store.object_key(h) == f"cas/{h[:2]}/{h}"
+    assert store.uri_for(h) == f"s3://trajir-test/cas/{h[:2]}/{h}"
+
+
+def test_key_prefix():
+    client = FakeS3Client()
+    store = S3CAS(client, "b", key_prefix="tenant-a")
+    h = store.put(b"x")
+    assert store.object_key(h).startswith("tenant-a/cas/")
+    assert (store.bucket, store.object_key(h)) in client.objects
+
+
+def test_put_idempotent():
+    client = FakeS3Client()
+    store = S3CAS(client, "b")
+    h1 = store.put(b"same")
+    h2 = store.put(b"same")
+    assert h1 == h2
+    assert len(client.objects) == 1
+
+
+def test_get_missing():
+    store = S3CAS(FakeS3Client(), "b")
+    h = content_hash(b"gone")
+    try:
+        store.get(h)
+        raise AssertionError("expected CASNotFoundError")
+    except CASNotFoundError:
+        pass
+    assert not store.has(h)
+
+
+def test_get_detects_tamper():
+    client = FakeS3Client()
+    store = S3CAS(client, "b")
+    h = store.put(b"good")
+    key = store.object_key(h)
+    client.objects[("b", key)] = b"bad"
+    try:
+        store.get(h)
+        raise AssertionError("expected CASIntegrityError")
+    except CASIntegrityError:
+        pass
+
+
+def test_rehydrate_via_s3_cas():
+    store = S3CAS(FakeS3Client(), "b")
+    h = store.put(b"payload")
+    got = rehydrate_artifacts(store, [{"content_hash": h, "logical_path": "f.bin"}])
+    assert got[h] == b"payload"
+
+
+def test_implements_cas_protocol():
+    store = S3CAS(FakeS3Client(), "b")
+    assert isinstance(store, CAS)
+
+
+def test_bucket_required():
+    try:
+        S3CAS(FakeS3Client(), "")
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass

--- a/test/unit/test_s3_cas.py
+++ b/test/unit/test_s3_cas.py
@@ -110,3 +110,54 @@ def test_bucket_required():
         raise AssertionError("expected ValueError")
     except ValueError:
         pass
+
+
+class FakeClientError(Exception):
+    """Mimics botocore.exceptions.ClientError with a .response Error.Code."""
+
+    def __init__(self, code: str, message: str = "") -> None:
+        super().__init__(message or code)
+        self.response = {"Error": {"Code": code, "Message": message or code}}
+
+
+class ClientErrorS3:
+    """S3 double that raises a given ClientError code on get/head."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, **kwargs):
+        return {}
+
+    def get_object(self, *, Bucket: str, Key: str, **kwargs):
+        raise FakeClientError(self.code)
+
+    def head_object(self, *, Bucket: str, Key: str, **kwargs):
+        raise FakeClientError(self.code)
+
+
+def test_get_maps_nosuchkey_code_to_not_found():
+    store = S3CAS(ClientErrorS3("NoSuchKey"), "b")
+    h = content_hash(b"missing")
+    try:
+        store.get(h)
+        raise AssertionError("expected CASNotFoundError")
+    except CASNotFoundError:
+        pass
+    assert store.has(h) is False
+
+
+def test_get_and_has_propagate_non_404_client_error():
+    """AccessDenied (and other non-missing codes) must not look like absence."""
+    store = S3CAS(ClientErrorS3("AccessDenied"), "b")
+    h = content_hash(b"secret")
+    try:
+        store.get(h)
+        raise AssertionError("expected AccessDenied to propagate")
+    except FakeClientError as exc:
+        assert exc.response["Error"]["Code"] == "AccessDenied"
+    try:
+        store.has(h)
+        raise AssertionError("expected AccessDenied to propagate from has()")
+    except FakeClientError as exc:
+        assert exc.response["Error"]["Code"] == "AccessDenied"


### PR DESCRIPTION
## Summary

Adds an S3 compatible content addressed store (`drivers.s3.S3CAS`) that implements the same CAS protocol and sharded key layout as the local filesystem store. The S3 client is injected so unit tests use an in memory fake without AWS credentials. Optional `boto3` install via the `s3` package extra; production helper `build_s3_client_from_env` reads region and `TRAJIR_S3_ENDPOINT_URL` for MinIO style endpoints. Secrets stay in the environment only.

**Note for reviewers:** this branch is based on `feat/local-fs-cas-62` (PR for #62). Prefer merging the local FS CAS PR first, then this one, or merge this stack as a whole.

## Related issues

Closes #63

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_s3_cas.py -q
ruff check drivers/s3 test/unit/test_s3_cas.py
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [x] No
* [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for implementation and tests; human review of client injection and credential handling.