### PR TITLE
feat: Postgres NodeLog driver for multi process IR log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- PostgreSQL NodeLog driver (`drivers.postgres.PostgresNodeLog`) matching SQLite
+  append, claim, list, and tenant isolation semantics; optional `psycopg` extra
+  (issue #64).
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
   with sharded `cas/<2-hex>/<hash>` layout, hash verify on get, and
   `rehydrate_artifacts` for thin `.tir` packages (issue #62).

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -41,7 +41,7 @@ Phase 1A **completion bar** in the master README still treats R01/R02 as the har
 | Package digital signatures | `SIGNATURE` reserved / null |
 | Restate adapter | Spec: after DBOS is solid |
 | Local FS CAS object store product | Shipped: `trajectory_ir.storage.FileSystemCAS` + `rehydrate_artifacts` |
-| Postgres / S3 drivers | S3 CAS shipped (`drivers.s3`); Postgres NodeLog still deferred |
+| Postgres / S3 drivers | Postgres NodeLog shipped (`drivers.postgres`); S3 CAS shipped (`drivers.s3`) |
 | Fluid / k8s-fluid profile | Later phase |
 | Full `projector-policy.yaml` DSL | Default built-in policy only |
 | Multi-tenant SaaS control plane | Library trust model |

--- a/drivers/postgres/__init__.py
+++ b/drivers/postgres/__init__.py
@@ -1,0 +1,21 @@
+"""PostgreSQL IR node log driver (server profiles).
+
+The SQLite :class:`~trajectory_ir.runtime.log.NodeLog` remains the Phase 1A
+default for the ``local`` profile. This package provides the same public
+operations against PostgreSQL so multiple processes can share one IR log.
+
+Install the optional dependency::
+
+    pip install "psycopg[binary]>=3"
+    # or: pip install -e ".[postgres]"
+
+Connection strings come from ``DATABASE_URL`` / ``TRAJIR_DATABASE_URL`` or an
+explicit DSN. Never commit credentials.
+"""
+
+from drivers.postgres.log import PostgresNodeLog, open_postgres_node_log
+
+__all__ = [
+    "PostgresNodeLog",
+    "open_postgres_node_log",
+]

--- a/drivers/postgres/log.py
+++ b/drivers/postgres/log.py
@@ -1,0 +1,293 @@
+"""PostgreSQL backed NodeLog matching SQLite semantics.
+
+Hash identity stays client side (RFC 8785 JCS + SHA-256 via
+:class:`~trajectory_ir.runtime.nodes.Node`). This driver only persists rows.
+
+Schema (infrastructure.md section 1.2, aligned with SQLite NodeLog)::
+
+    nodes(
+      id TEXT PRIMARY KEY,
+      trajectory_id TEXT NOT NULL,
+      tenant_id TEXT NOT NULL,
+      step_n INTEGER,
+      seq INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      ts DOUBLE PRECISION NOT NULL
+    )
+
+Logical slot uniqueness: (tenant_id, trajectory_id, coalesce(step_n, -1), seq, kind).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any
+
+from trajectory_ir.runtime.log import SlotConflictError
+from trajectory_ir.runtime.nodes import Node
+
+
+def _require_psycopg():
+    try:
+        import psycopg
+        from psycopg.rows import tuple_row
+    except ImportError as exc:
+        raise ImportError(
+            "psycopg is required for PostgresNodeLog; "
+            'pip install "psycopg[binary]>=3" or pip install -e ".[postgres]"'
+        ) from exc
+    return psycopg, tuple_row
+
+
+class PostgresNodeLog:
+    """Append only, content addressed node log backed by PostgreSQL.
+
+    Public methods mirror :class:`~trajectory_ir.runtime.log.NodeLog` so
+    callers can swap storage without changing seal or gate code.
+    """
+
+    def __init__(self, conn: Any) -> None:
+        """Wrap an open psycopg connection (autocommit disabled)."""
+        self._lock = threading.RLock()
+        self._conn = conn
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._lock:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS nodes (
+                        id TEXT PRIMARY KEY,
+                        trajectory_id TEXT NOT NULL,
+                        tenant_id TEXT NOT NULL,
+                        step_n INTEGER,
+                        seq INTEGER NOT NULL,
+                        kind TEXT NOT NULL,
+                        payload_json TEXT NOT NULL,
+                        ts DOUBLE PRECISION NOT NULL
+                    )
+                    """
+                )
+                cur.execute(
+                    """
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_slot
+                    ON nodes (
+                        tenant_id,
+                        trajectory_id,
+                        (COALESCE(step_n, -1)),
+                        seq,
+                        kind
+                    )
+                    """
+                )
+                cur.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_nodes_traj_tenant
+                    ON nodes (trajectory_id, tenant_id)
+                    """
+                )
+            self._conn.commit()
+
+    def append(
+        self,
+        kind: str,
+        step_n: int | None,
+        payload: dict,
+        trajectory_id: str,
+        tenant_id: str,
+        seq: int,
+    ) -> Node:
+        node = Node(
+            kind=kind,
+            trajectory_id=trajectory_id,
+            tenant_id=tenant_id,
+            step_n=step_n,
+            seq=seq,
+            payload=payload,
+        )
+        with self._lock:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO nodes
+                    (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (id) DO NOTHING
+                    """,
+                    (
+                        node.id,
+                        node.trajectory_id,
+                        node.tenant_id,
+                        node.step_n,
+                        node.seq,
+                        node.kind,
+                        json.dumps(node.payload),
+                        node.ts,
+                    ),
+                )
+                cur.execute(
+                    """
+                    SELECT id FROM nodes
+                    WHERE tenant_id = %s AND trajectory_id = %s
+                      AND COALESCE(step_n, -1) = COALESCE(%s, -1)
+                      AND seq = %s AND kind = %s
+                    """,
+                    (tenant_id, trajectory_id, step_n, seq, kind),
+                )
+                row = cur.fetchone()
+                if row is not None and row[0] != node.id:
+                    self._conn.rollback()
+                    raise SlotConflictError(
+                        f"slot conflict trajectory={trajectory_id!r} step={step_n} "
+                        f"seq={seq} kind={kind!r}: different payload already stored"
+                    )
+            self._conn.commit()
+        return node
+
+    def claim_tool_call(
+        self,
+        step_n: int,
+        payload: dict,
+        trajectory_id: str,
+        tenant_id: str,
+        seq: int,
+    ) -> bool:
+        """Atomically claim a TOOL_CALL slot (single winner under concurrency)."""
+        node = Node(
+            kind="TOOL_CALL",
+            trajectory_id=trajectory_id,
+            tenant_id=tenant_id,
+            step_n=step_n,
+            seq=seq,
+            payload=payload,
+        )
+        with self._lock:
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT 1 FROM nodes
+                        WHERE tenant_id = %s AND trajectory_id = %s
+                          AND step_n = %s AND kind = %s AND seq = %s
+                        LIMIT 1
+                        FOR UPDATE
+                        """,
+                        (tenant_id, trajectory_id, step_n, "TOOL_CALL", seq),
+                    )
+                    if cur.fetchone() is not None:
+                        self._conn.commit()
+                        return False
+                    cur.execute(
+                        """
+                        INSERT INTO nodes
+                        (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            node.id,
+                            node.trajectory_id,
+                            node.tenant_id,
+                            node.step_n,
+                            node.seq,
+                            node.kind,
+                            json.dumps(node.payload),
+                            node.ts,
+                        ),
+                    )
+                self._conn.commit()
+                return True
+            except Exception:
+                self._conn.rollback()
+                # Unique violation: another writer won the slot.
+                return False
+
+    def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
+        sql = "SELECT 1 FROM nodes WHERE trajectory_id = %s AND step_n = %s AND kind = %s"
+        params: list[object] = [trajectory_id, step_n, kind]
+        if seq is not None:
+            sql += " AND seq = %s"
+            params.append(seq)
+        sql += " LIMIT 1"
+        with self._lock:
+            with self._conn.cursor() as cur:
+                cur.execute(sql, params)
+                return cur.fetchone() is not None
+
+    def count(self, node_id: str) -> int:
+        with self._lock:
+            with self._conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM nodes WHERE id = %s", (node_id,))
+                row = cur.fetchone()
+                return int(row[0]) if row else 0
+
+    def list_nodes(
+        self,
+        trajectory_id: str,
+        *,
+        tenant_id: str,
+    ) -> list[dict[str, Any]]:
+        return self._list_nodes(trajectory_id, tenant_id=tenant_id)
+
+    def list_nodes_all_tenants(self, trajectory_id: str) -> list[dict[str, Any]]:
+        return self._list_nodes(trajectory_id, tenant_id=None)
+
+    def _list_nodes(
+        self,
+        trajectory_id: str,
+        *,
+        tenant_id: str | None,
+    ) -> list[dict[str, Any]]:
+        sql = """
+            SELECT id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts
+            FROM nodes
+            WHERE trajectory_id = %s
+            """
+        params: list[object] = [trajectory_id]
+        if tenant_id is not None:
+            sql += " AND tenant_id = %s"
+            params.append(tenant_id)
+        sql += " ORDER BY COALESCE(step_n, -1), seq"
+        with self._lock:
+            with self._conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows: list[dict[str, Any]] = []
+                for row in cur.fetchall():
+                    rows.append(
+                        {
+                            "id": row[0],
+                            "trajectory_id": row[1],
+                            "tenant_id": row[2],
+                            "step_n": row[3],
+                            "seq": row[4],
+                            "kind": row[5],
+                            "payload": json.loads(row[6]),
+                            "ts": row[7],
+                        }
+                    )
+                return rows
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+
+def open_postgres_node_log(dsn: str | None = None) -> PostgresNodeLog:
+    """Open a :class:`PostgresNodeLog` from a DSN or environment.
+
+    Resolution order:
+    1. Explicit ``dsn`` argument
+    2. ``TRAJIR_DATABASE_URL``
+    3. ``DATABASE_URL``
+    """
+    psycopg, _tuple_row = _require_psycopg()
+    resolved = dsn or os.environ.get("TRAJIR_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not resolved:
+        raise ValueError(
+            "PostgreSQL DSN required: pass dsn= or set TRAJIR_DATABASE_URL / DATABASE_URL"
+        )
+    conn = psycopg.connect(resolved)
+    return PostgresNodeLog(conn)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
+postgres = ["psycopg[binary]>=3.1"]
 s3 = ["boto3"]
 
 [build-system]

--- a/test/unit/test_postgres_node_log.py
+++ b/test/unit/test_postgres_node_log.py
@@ -1,0 +1,285 @@
+"""Tests for PostgresNodeLog (in memory fake connection; no live server required)."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any
+
+import pytest
+
+from drivers.postgres.log import PostgresNodeLog, open_postgres_node_log
+from trajectory_ir.runtime.log import SlotConflictError
+
+
+class _FakeCursor:
+    def __init__(self, store: _FakeStore) -> None:
+        self._store = store
+        self._result: list[tuple] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple | list | None = None) -> None:
+        self._result = self._store.execute(sql, params or ())
+
+    def fetchone(self) -> tuple | None:
+        return self._result[0] if self._result else None
+
+    def fetchall(self) -> list[tuple]:
+        return list(self._result)
+
+
+class _FakeStore:
+    """Minimal SQL surface for the PostgresNodeLog methods under test."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, Any]] = {}
+        self.committed = True
+
+    def execute(self, sql: str, params: tuple | list) -> list[tuple]:
+        s = " ".join(sql.split()).lower()
+        if (
+            s.startswith("create table")
+            or s.startswith("create unique index")
+            or s.startswith("create index")
+        ):
+            return []
+        if s.startswith("insert into nodes") and "on conflict" in s:
+            (
+                node_id,
+                trajectory_id,
+                tenant_id,
+                step_n,
+                seq,
+                kind,
+                payload_json,
+                ts,
+            ) = params
+            if node_id not in self.rows:
+                self.rows[node_id] = {
+                    "id": node_id,
+                    "trajectory_id": trajectory_id,
+                    "tenant_id": tenant_id,
+                    "step_n": step_n,
+                    "seq": seq,
+                    "kind": kind,
+                    "payload_json": payload_json,
+                    "ts": ts,
+                }
+            return []
+        if s.startswith("insert into nodes") and "on conflict" not in s:
+            (
+                node_id,
+                trajectory_id,
+                tenant_id,
+                step_n,
+                seq,
+                kind,
+                payload_json,
+                ts,
+            ) = params
+            # Slot unique check
+            for row in self.rows.values():
+                if (
+                    row["tenant_id"] == tenant_id
+                    and row["trajectory_id"] == trajectory_id
+                    and row["step_n"] == step_n
+                    and row["seq"] == seq
+                    and row["kind"] == kind
+                ):
+                    raise RuntimeError("unique_violation")
+            self.rows[node_id] = {
+                "id": node_id,
+                "trajectory_id": trajectory_id,
+                "tenant_id": tenant_id,
+                "step_n": step_n,
+                "seq": seq,
+                "kind": kind,
+                "payload_json": payload_json,
+                "ts": ts,
+            }
+            return []
+        if "select id from nodes" in s and "coalesce" in s:
+            tenant_id, trajectory_id, step_n, seq, kind = params
+            for row in self.rows.values():
+                sn = row["step_n"] if row["step_n"] is not None else -1
+                pn = step_n if step_n is not None else -1
+                if (
+                    row["tenant_id"] == tenant_id
+                    and row["trajectory_id"] == trajectory_id
+                    and sn == pn
+                    and row["seq"] == seq
+                    and row["kind"] == kind
+                ):
+                    return [(row["id"],)]
+            return []
+        if "select 1 from nodes" in s and "for update" in s:
+            tenant_id, trajectory_id, step_n, kind, seq = params
+            for row in self.rows.values():
+                if (
+                    row["tenant_id"] == tenant_id
+                    and row["trajectory_id"] == trajectory_id
+                    and row["step_n"] == step_n
+                    and row["kind"] == kind
+                    and row["seq"] == seq
+                ):
+                    return [(1,)]
+            return []
+        if s.startswith("select 1 from nodes"):
+            # has()
+            if len(params) == 4:
+                trajectory_id, step_n, kind, seq = params
+                for row in self.rows.values():
+                    if (
+                        row["trajectory_id"] == trajectory_id
+                        and row["step_n"] == step_n
+                        and row["kind"] == kind
+                        and row["seq"] == seq
+                    ):
+                        return [(1,)]
+            else:
+                trajectory_id, step_n, kind = params
+                for row in self.rows.values():
+                    if (
+                        row["trajectory_id"] == trajectory_id
+                        and row["step_n"] == step_n
+                        and row["kind"] == kind
+                    ):
+                        return [(1,)]
+            return []
+        if "select count(*)" in s:
+            (node_id,) = params
+            return [(1 if node_id in self.rows else 0,)]
+        if "select id, trajectory_id, tenant_id" in s:
+            trajectory_id = params[0]
+            tenant_id = params[1] if len(params) > 1 else None
+            out = []
+            for row in sorted(
+                self.rows.values(),
+                key=lambda r: (r["step_n"] if r["step_n"] is not None else -1, r["seq"]),
+            ):
+                if row["trajectory_id"] != trajectory_id:
+                    continue
+                if tenant_id is not None and row["tenant_id"] != tenant_id:
+                    continue
+                out.append(
+                    (
+                        row["id"],
+                        row["trajectory_id"],
+                        row["tenant_id"],
+                        row["step_n"],
+                        row["seq"],
+                        row["kind"],
+                        row["payload_json"],
+                        row["ts"],
+                    )
+                )
+            return out
+        return []
+
+
+class FakePgConnection:
+    def __init__(self) -> None:
+        self._store = _FakeStore()
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self._store)
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def log() -> PostgresNodeLog:
+    return PostgresNodeLog(FakePgConnection())
+
+
+def test_append_then_has(log: PostgresNodeLog):
+    log.append(
+        "DECISION",
+        step_n=1,
+        payload={"plan": "x"},
+        trajectory_id="t1",
+        tenant_id="demo",
+        seq=1,
+    )
+    assert log.has("t1", 1, "DECISION")
+    assert not log.has("t1", 1, "TOOL_RESULT")
+
+
+def test_append_idempotent_by_content(log: PostgresNodeLog):
+    n1 = log.append("DECISION", 1, {"plan": "x"}, "t1", "demo", 1)
+    n2 = log.append("DECISION", 1, {"plan": "x"}, "t1", "demo", 1)
+    assert n1.id == n2.id
+    assert log.count(n1.id) == 1
+
+
+def test_slot_conflict(log: PostgresNodeLog):
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "demo", 1)
+    with pytest.raises(SlotConflictError):
+        log.append("DECISION", 1, {"plan": "b"}, "t1", "demo", 1)
+
+
+def test_list_nodes_tenant_filter(log: PostgresNodeLog):
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "tenant-a", 1)
+    log.append("DECISION", 1, {"plan": "b"}, "t1", "tenant-b", 2)
+    only_a = log.list_nodes("t1", tenant_id="tenant-a")
+    assert len(only_a) == 1
+    assert only_a[0]["tenant_id"] == "tenant-a"
+    assert json.loads(json.dumps(only_a[0]["payload"])) == {"plan": "a"}
+
+
+def test_claim_tool_call_single_winner(log: PostgresNodeLog):
+    wins: list[bool] = []
+
+    def worker() -> None:
+        claimed = log.claim_tool_call(
+            1,
+            {"tool": "deploy", "args": {"v": "1"}},
+            "t1",
+            "demo",
+            2,
+        )
+        wins.append(claimed)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(1 for w in wins if w) == 1
+    assert log.has("t1", 1, "TOOL_CALL", seq=2)
+
+
+def test_open_requires_dsn(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TRAJIR_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(ValueError, match="DSN"):
+        open_postgres_node_log(None)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TRAJIR_DATABASE_URL"),
+    reason="Set TRAJIR_DATABASE_URL to run live Postgres integration",
+)
+def test_live_postgres_roundtrip():
+    pytest.importorskip("psycopg")
+    log = open_postgres_node_log()
+    try:
+        n = log.append("DECISION", 1, {"plan": "live"}, "live-t", "demo", 1)
+        assert log.has("live-t", 1, "DECISION")
+        rows = log.list_nodes("live-t", tenant_id="demo")
+        assert rows[0]["id"] == n.id
+    finally:
+        log.close()


### PR DESCRIPTION
## Summary

Adds a PostgreSQL backed IR node log (`drivers.postgres.PostgresNodeLog`) that mirrors the SQLite `NodeLog` public API: append with content addressed idempotency, atomic `claim_tool_call`, `has`, tenant scoped `list_nodes`, and slot conflict detection. Schema follows infrastructure.md (nodes table plus unique slot index). Connection strings come from an explicit DSN or `TRAJIR_DATABASE_URL` / `DATABASE_URL`. Optional `psycopg` install via the `postgres` package extra. Unit tests use an in memory fake so default CI does not need a live database.

## Related issues

Closes #64

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_postgres_node_log.py -q
ruff check drivers/postgres test/unit/test_postgres_node_log.py
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [ ] No
* [x] Yes: persists seals and tool claim slots; keeps tenant isolation on list paths the same as SQLite NodeLog. No change to effect classification or gate policy logic.

## AI assistance (if any)

Assisted with Grok for implementation and tests; human review of schema and claim concurrency behavior.