### PR TITLE
feat: agent host loop example using public client SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Agent host loop example (`examples/host_loop`) using only the public client
+  SDK with a stub model and optional sandbox mode (issue #65).
 - `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
 
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)

--- a/examples/host_loop/README.md
+++ b/examples/host_loop/README.md
@@ -1,0 +1,38 @@
+# Agent host loop example
+
+Minimal **host** that owns the model call, tools, and trajectory step using only
+the public Python client API. This is not an agent framework: it shows how a
+host process should call Trajectory IR.
+
+## What it demonstrates
+
+1. `open_trajectory`
+2. Stub model (no paid API; injectable function)
+3. `project` then `seal_decision` with concrete known args only
+4. `exec_tool` then `commit_step`
+5. Optional sandbox mode (`mode=sandbox`) so non idempotent tools are rejected
+
+## Run
+
+From the repository root (editable install recommended):
+
+```bash
+pip install -e ".[dev]"
+python examples/host_loop/run_host.py
+```
+
+Expected exit code `0` and a short summary of the step.
+
+Sandbox demo (should refuse `deploy_server`):
+
+```bash
+python examples/host_loop/run_host.py --sandbox
+```
+
+## Design notes
+
+1. The model is a pure function that returns a plan dict. Swap it for a real
+   LLM client without changing seal or tool execution.
+2. Tool arguments in the sealed plan are concrete values only (linear known
+   args rule from the master README).
+3. Crash safe durable workflow demos remain under `examples/kill-mid-deploy/`.

--- a/examples/host_loop/run_host.py
+++ b/examples/host_loop/run_host.py
@@ -1,0 +1,163 @@
+"""Minimal agent host loop using the public Trajectory IR client.
+
+Run from the repository root::
+
+    python examples/host_loop/run_host.py
+    python examples/host_loop/run_host.py --sandbox
+
+No paid model API is required: ``stub_model`` is a deterministic stand in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+
+# Allow ``python examples/host_loop/run_host.py`` without a prior editable install.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from client.python.trajectory_client import (  # noqa: E402
+    commit_step,
+    exec_tool,
+    open_trajectory,
+    project,
+    seal_decision,
+)
+from trajectory_ir.effects import EffectClass  # noqa: E402
+from trajectory_ir.runtime.log import NodeLog  # noqa: E402
+from trajectory_ir.runtime.sandbox import SandboxForbidden  # noqa: E402
+from trajectory_ir.runtime.tool import Tool  # noqa: E402
+
+TENANT_ID = "demo"
+TRAJECTORY_ID = "host-loop-demo"
+
+
+def stub_model(context: dict) -> dict:
+    """Stand in for an LLM. Returns a sealed plan with concrete args only."""
+    name = context.get("user_name", "world")
+    return {
+        "tool_calls": [
+            {"name": "greet", "args": {"name": name}},
+            {"name": "deploy_server", "args": {"version": "1.0.0"}},
+        ]
+    }
+
+
+def make_tools() -> dict[str, Tool]:
+    def greet(*, name: str) -> str:
+        return f"hello, {name}"
+
+    def deploy_server(*, version: str) -> str:
+        return f"deployed:{version}"
+
+    return {
+        "greet": Tool(
+            name="greet",
+            fn=greet,
+            effect_class=EffectClass.PURE,
+        ),
+        "deploy_server": Tool(
+            name="deploy_server",
+            fn=deploy_server,
+            effect_class=EffectClass.NON_IDEMPOTENT_WRITE,
+        ),
+    }
+
+
+def run_one_step(
+    *,
+    db_path: str,
+    model_call=stub_model,
+    sandbox: bool = False,
+) -> list[object]:
+    """Execute one host owned step. Returns tool results in seal order."""
+    mode = "sandbox" if sandbox else "live"
+    traj = open_trajectory(
+        TENANT_ID,
+        TRAJECTORY_ID,
+        db_path=db_path,
+        mode=mode,
+    )
+    context = {"user_name": "trajectory", "goal": "greet then deploy"}
+    project(traj, step_n=1, context=context)
+
+    plan = model_call(context)
+    seal_decision(traj, step_n=1, plan=plan)
+
+    tools = make_tools()
+    results: list[object] = []
+    for i, call in enumerate(plan["tool_calls"]):
+        tool = tools[call["name"]]
+        # seq = 2 + 2*i keeps TOOL_CALL and TOOL_RESULT slots non overlapping.
+        seq = 2 + 2 * i
+        result = exec_tool(
+            traj,
+            step_n=1,
+            call={"args": call["args"]},
+            tool=tool,
+            seq=seq,
+        )
+        results.append(result.result)
+
+    # After the last tool pair: seq of last TOOL_RESULT is (2+2*(n-1))+1 = 2*n+1
+    # Commit uses the next free seq: 2 + 2*n
+    commit_seq = 2 + 2 * len(plan["tool_calls"])
+    commit_step(traj, step_n=1, seq=commit_seq)
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Trajectory IR host loop example")
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Open trajectory in sandbox mode (rejects NON_IDEMPOTENT_WRITE)",
+    )
+    parser.add_argument(
+        "--db",
+        default="",
+        help="SQLite path for the IR log (default: temp file)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.db:
+        db_path = args.db
+        cleanup = False
+    else:
+        fd, db_path = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
+        cleanup = True
+
+    try:
+        if args.sandbox:
+            try:
+                run_one_step(db_path=db_path, sandbox=True)
+            except SandboxForbidden as exc:
+                print(f"sandbox correctly rejected non idempotent tool: {exc}")
+                return 0
+            print("error: sandbox should have rejected deploy_server", file=sys.stderr)
+            return 1
+
+        results = run_one_step(db_path=db_path, sandbox=False)
+        log = NodeLog(db_path)
+        kinds = [n["kind"] for n in log.list_nodes(TRAJECTORY_ID, tenant_id=TENANT_ID)]
+        print("host step complete")
+        print(f"  tool results: {results}")
+        print(f"  node kinds:   {kinds}")
+        log.close()
+        return 0
+    finally:
+        if cleanup:
+            try:
+                os.remove(db_path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Fixture agent adjusts sys.path before local imports on purpose.
 "examples/kill-mid-deploy/agent.py" = ["E402"]
+"examples/host_loop/run_host.py" = ["E402"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["trajectory_ir", "drivers", "client", "test"]

--- a/test/unit/test_host_loop_example.py
+++ b/test/unit/test_host_loop_example.py
@@ -1,0 +1,41 @@
+"""Smoke tests for examples/host_loop (public client only)."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_HOST = os.path.join(_REPO, "examples", "host_loop")
+if _HOST not in sys.path:
+    sys.path.insert(0, _HOST)
+
+import run_host  # noqa: E402
+
+
+def test_live_host_step(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "host.sqlite")
+    results = run_host.run_one_step(db_path=db, sandbox=False)
+    assert results == ["hello, trajectory", "deployed:1.0.0"]
+
+
+def test_sandbox_rejects_deploy(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "host-sandbox.sqlite")
+    with pytest.raises(run_host.SandboxForbidden):
+        run_host.run_one_step(db_path=db, sandbox=True)
+
+
+def test_main_live_exit_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    code = run_host.main(["--db", str(tmp_path / "m.sqlite")])
+    assert code == 0
+
+
+def test_main_sandbox_exit_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    code = run_host.main(["--sandbox", "--db", str(tmp_path / "s.sqlite")])
+    assert code == 0


### PR DESCRIPTION
## Summary

Adds a minimal agent host example under `examples/host_loop` that owns the model call, tools, and one trajectory step using only the public client API (`open_trajectory`, `project`, `seal_decision`, `exec_tool`, `commit_step`). The model is a deterministic stub so CI needs no paid LLM. Sandbox mode is demonstrated with `--sandbox` so `NON_IDEMPOTENT_WRITE` is rejected before side effects. This is a host glue sample, not an agent framework.

## Related issues

Closes #65

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_host_loop_example.py -q
python examples/host_loop/run_host.py
python examples/host_loop/run_host.py --sandbox
ruff check examples/host_loop test/unit/test_host_loop_example.py
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [x] No (example only; uses existing client and sandbox paths)
* [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for the example and smoke tests; human review of host loop clarity.