### PR TITLE
feat: Restate durable backend adapter as second implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Restate durable backend adapter package (`drivers.durable_backend.restate`)
+  with process local step memo for tests/dev, injectable into `make_run_step`
+  via `durable_infer_fn` / `durable_tool_fn` / `durable_workflow_fn` (issue #66).
 - `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
 
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
@@ -19,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `make_run_step` accepts optional durable hook functions; default remains DBOS.
 ### Fixed
 
 ## [0.1.0] - 2026-08-05

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -39,7 +39,7 @@ Phase 1A **completion bar** in the master README still treats R01/R02 as the har
 | Item | Notes |
 |------|--------|
 | Package digital signatures | `SIGNATURE` reserved / null |
-| Restate adapter | Spec: after DBOS is solid |
+| Restate adapter | Shipped as optional package + local memo; real cluster is operator wired |
 | Local FS CAS object store product | Shipped: `trajectory_ir.storage.FileSystemCAS` + `rehydrate_artifacts` |
 | Postgres / S3 drivers | S3 CAS shipped (`drivers.s3`); Postgres NodeLog still deferred |
 | Fluid / k8s-fluid profile | Later phase |

--- a/drivers/durable_backend/restate/README.md
+++ b/drivers/durable_backend/restate/README.md
@@ -1,0 +1,72 @@
+# Restate durable backend adapter
+
+Optional second durable execution backend for Trajectory IR (issue #66).
+
+## Why this exists
+
+The master README names DBOS as the Phase 1A default and welcomes Restate
+once the adapter interface is stable. This package provides:
+
+1. The **same call surface** as `drivers.durable_backend.dbos.adapter`
+   (`init_backend`, `durable_infer`, `durable_tool`, `durable_workflow`)
+2. A **process local memo** implementation for development and unit tests
+3. Injection into `make_run_step` without hardcoding Restate into the IR core
+
+Production Restate SDK wiring is intentionally thin here: operators should use
+Restate's own durable handlers for crash detection and lease/heartbeat. Trajectory
+IR only needs step memoization for model and tool calls.
+
+## Local memo (default in this package)
+
+```python
+from drivers.durable_backend.restate import (
+    durable_infer,
+    durable_tool,
+    durable_workflow,
+    init_backend,
+    workflow_scope,
+)
+from trajectory_ir.resume.step import make_run_step
+
+init_backend()
+run_step = make_run_step(
+    node_log,
+    tenant_id,
+    trajectory_id,
+    tool_registry,
+    durable_infer_fn=durable_infer,
+    durable_tool_fn=durable_tool,
+    durable_workflow_fn=durable_workflow,
+)
+
+with workflow_scope(trajectory_id):
+    run_step(step_n=1, model_call=model, context={})
+```
+
+On a second call with the same workflow id, memoized infer/tool steps return
+prior results without re-executing the function body (R01 spirit).
+
+## Real Restate cluster (operator sketch)
+
+1. Run Restate server (`restate-server` / Docker image from Restate docs).
+2. Implement a Restate service whose handlers wrap your tool and model
+   functions with Restate's durable promise / journal semantics.
+3. Keep using `make_run_step` with injectable `durable_*` callables that
+   invoke those handlers, **or** call Restate from a thin host and only use
+   Trajectory IR for NodeLog seals and `.tir` export.
+4. Never add custom crash loops in `pkg/resume`.
+
+Environment variables (suggested for hosts that dial Restate):
+
+| Variable | Purpose |
+|----------|---------|
+| `RESTATE_URL` | Ingress URL (example: `http://localhost:8080`) |
+| `RESTATE_ADMIN_URL` | Admin API if you register services from tooling |
+
+Secrets for managed Restate stay in the environment or a secret manager.
+
+## What this package does not do
+
+1. Ship a full multi service Restate application layout
+2. Replace DBOS as the default for `make_run_step` (DBOS remains default)
+3. Implement package signatures, Fluid, or CAS

--- a/drivers/durable_backend/restate/__init__.py
+++ b/drivers/durable_backend/restate/__init__.py
@@ -1,0 +1,26 @@
+"""Restate durable backend adapter (optional second implementation).
+
+Phase 1A still defaults to DBOS via ``make_run_step``. This package exposes
+the same call surface so a host can inject Restate style durability without
+reimplementing crash detection inside Trajectory IR.
+
+Development and unit tests use :mod:`drivers.durable_backend.restate.local_memo`
+(process local step memoization). A real Restate cluster is optional and
+documented in ``README.md`` in this directory.
+"""
+
+from drivers.durable_backend.restate import local_memo as local_memo
+from drivers.durable_backend.restate.adapter import (
+    durable_infer,
+    durable_tool,
+    durable_workflow,
+    init_backend,
+)
+
+__all__ = [
+    "durable_infer",
+    "durable_tool",
+    "durable_workflow",
+    "init_backend",
+    "local_memo",
+]

--- a/drivers/durable_backend/restate/adapter.py
+++ b/drivers/durable_backend/restate/adapter.py
@@ -1,0 +1,36 @@
+"""Restate adapter public surface (same names as the DBOS adapter).
+
+Default implementation for this package is the process local memo backend
+(:mod:`drivers.durable_backend.restate.local_memo`). That keeps unit tests and
+contributors free of a Restate server while still exercising the injectable
+durable hooks on ``make_run_step``.
+
+When you run against a real Restate cluster, replace these wrappers with the
+Restate SDK bindings documented in ``drivers/durable_backend/restate/README.md``.
+Do not reimplement crash detection, retry, or lease logic inside
+``pkg/trajectory_ir`` (master README rule 2).
+"""
+
+from __future__ import annotations
+
+from drivers.durable_backend.restate.local_memo import (
+    clear_memo,
+    durable_infer,
+    durable_tool,
+    durable_workflow,
+    get_workflow_id,
+    init_backend,
+    set_workflow_id,
+    workflow_scope,
+)
+
+__all__ = [
+    "clear_memo",
+    "durable_infer",
+    "durable_tool",
+    "durable_workflow",
+    "get_workflow_id",
+    "init_backend",
+    "set_workflow_id",
+    "workflow_scope",
+]

--- a/drivers/durable_backend/restate/local_memo.py
+++ b/drivers/durable_backend/restate/local_memo.py
@@ -1,0 +1,117 @@
+"""Process local durable step memoization (dev / test stand in for Restate).
+
+Mirrors the DBOS adapter contract used by ``make_run_step``:
+
+* ``durable_workflow`` marks the host entrypoint (no special behavior here)
+* ``durable_infer`` / ``durable_tool`` run the body once per
+  (workflow id, step name, args) and return the memoized result on replay
+
+This is **not** a production Restate deployment. It exists so:
+
+1. The Restate adapter package is testable without a Restate server
+2. Hosts can prove R01 style "do not re invoke model" semantics with the
+   same ``make_run_step(..., durable_*=...)`` injection path
+
+Set the workflow id with :func:`set_workflow_id` (or the context manager
+:func:`workflow_scope`) before invoking a workflow, analogous to DBOS
+``SetWorkflowID``.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_workflow_id: ContextVar[str] = ContextVar("restate_local_workflow_id", default="")
+_lock = threading.RLock()
+# key: (workflow_id, step_kind, step_name, args_json) -> result
+_memo: dict[tuple[str, str, str, str], Any] = {}
+
+
+def set_workflow_id(workflow_id: str) -> None:
+    """Bind the current context to a durable workflow id."""
+    if not workflow_id:
+        raise ValueError("workflow_id is required")
+    _workflow_id.set(workflow_id)
+
+
+def get_workflow_id() -> str:
+    return _workflow_id.get()
+
+
+@contextmanager
+def workflow_scope(workflow_id: str) -> Iterator[None]:
+    """Context manager equivalent of DBOS ``SetWorkflowID``."""
+    token = _workflow_id.set(workflow_id)
+    try:
+        yield
+    finally:
+        _workflow_id.reset(token)
+
+
+def clear_memo() -> None:
+    """Drop all memoized steps (tests only)."""
+    with _lock:
+        _memo.clear()
+
+
+def init_backend(app_name: str = "trajectory-ir-restate-local") -> None:
+    """Initialize the local memo backend.
+
+    ``app_name`` is accepted for API parity with the DBOS adapter; the local
+    backend does not open network connections.
+    """
+    del app_name  # API parity; unused for process local storage.
+    # Intentionally do not clear memo on every init: resume scenarios need it.
+
+
+def _args_key(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    payload = {"args": list(args), "kwargs": kwargs}
+    return json.dumps(payload, sort_keys=True, default=str)
+
+
+def _memoize(step_kind: str, fn: F) -> F:
+    step_name = getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        wid = get_workflow_id()
+        if not wid:
+            raise RuntimeError(
+                "restate local_memo: workflow id not set; "
+                "call set_workflow_id() or use workflow_scope() before durable steps"
+            )
+        key = (wid, step_kind, step_name, _args_key(args, kwargs))
+        with _lock:
+            if key in _memo:
+                return _memo[key]
+        result = fn(*args, **kwargs)
+        with _lock:
+            # First writer wins if two threads race the miss path.
+            if key not in _memo:
+                _memo[key] = result
+            return _memo[key]
+
+    wrapper.__name__ = getattr(fn, "__name__", "wrapped")
+    wrapper.__qualname__ = step_name
+    return wrapper  # type: ignore[return-value]
+
+
+def durable_infer(fn: F) -> F:
+    """Wrap model inference as a memoized durable step."""
+    return _memoize("infer", fn)
+
+
+def durable_tool(fn: F) -> F:
+    """Wrap a tool body as a memoized durable step."""
+    return _memoize("tool", fn)
+
+
+def durable_workflow(fn: F) -> F:
+    """Mark a function as a durable workflow entrypoint (passthrough locally)."""
+    return fn

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -6,6 +6,61 @@ from trajectory_ir.resume.gate import make_gated_tool_call
 from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
 
 
+def _resolve_durable_hooks(
+    durable_infer_fn: Callable[[Callable[..., Any]], Callable[..., Any]] | None,
+    durable_tool_fn: Callable[[Callable[..., Any]], Callable[..., Any]] | None,
+    durable_workflow_fn: Callable[[Callable[..., Any]], Callable[..., Any]] | None,
+) -> tuple[
+    Callable[[Callable[..., Any]], Callable[..., Any]],
+    Callable[[Callable[..., Any]], Callable[..., Any]],
+    Callable[[Callable[..., Any]], Callable[..., Any]],
+]:
+    """Resolve durable wrappers; refuse silent DBOS/Restate (or other) mixes.
+
+    Rules:
+    1. All three None → default DBOS adapter hooks.
+    2. All three set → use the injected set as a single backend.
+    3. Any other combination → ValueError (fail loud).
+    """
+    provided = (
+        durable_infer_fn is not None,
+        durable_tool_fn is not None,
+        durable_workflow_fn is not None,
+    )
+    if any(provided) and not all(provided):
+        missing = [
+            name
+            for name, set_ in (
+                ("durable_infer_fn", durable_infer_fn is not None),
+                ("durable_tool_fn", durable_tool_fn is not None),
+                ("durable_workflow_fn", durable_workflow_fn is not None),
+            )
+            if not set_
+        ]
+        raise ValueError(
+            "make_run_step durable hooks must be injected together "
+            f"(all three or none); missing: {', '.join(missing)}. "
+            "Partial injection would silently mix durable backends."
+        )
+    if all(provided):
+        assert durable_infer_fn is not None
+        assert durable_tool_fn is not None
+        assert durable_workflow_fn is not None
+        return durable_infer_fn, durable_tool_fn, durable_workflow_fn
+
+    from drivers.durable_backend.dbos.adapter import (
+        durable_infer as dbos_infer,
+    )
+    from drivers.durable_backend.dbos.adapter import (
+        durable_tool as dbos_tool,
+    )
+    from drivers.durable_backend.dbos.adapter import (
+        durable_workflow as dbos_workflow,
+    )
+
+    return dbos_infer, dbos_tool, dbos_workflow
+
+
 def make_run_step(
     node_log,
     tenant_id,
@@ -30,27 +85,14 @@ def make_run_step(
 
     Durable backend hooks default to the DBOS adapter. Pass Restate (or local
     memo) wrappers via ``durable_infer_fn`` / ``durable_tool_fn`` /
-    ``durable_workflow_fn`` for a second backend without forking this module.
+    ``durable_workflow_fn`` together for a second backend. Partial injection
+    raises ``ValueError`` so backends are never mixed silently.
     """
-    if durable_infer_fn is None or durable_tool_fn is None or durable_workflow_fn is None:
-        from drivers.durable_backend.dbos.adapter import (
-            durable_infer as dbos_infer,
-        )
-        from drivers.durable_backend.dbos.adapter import (
-            durable_tool as dbos_tool,
-        )
-        from drivers.durable_backend.dbos.adapter import (
-            durable_workflow as dbos_workflow,
-        )
-
-        durable_infer = durable_infer_fn or dbos_infer
-        durable_tool = durable_tool_fn or dbos_tool
-        durable_workflow = durable_workflow_fn or dbos_workflow
-    else:
-        durable_infer = durable_infer_fn
-        durable_tool = durable_tool_fn
-        durable_workflow = durable_workflow_fn
-
+    durable_infer, durable_tool, durable_workflow = _resolve_durable_hooks(
+        durable_infer_fn,
+        durable_tool_fn,
+        durable_workflow_fn,
+    )
     run_mode = normalize_run_mode(mode)
 
     @durable_workflow

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -1,8 +1,6 @@
-from drivers.durable_backend.dbos.adapter import (
-    durable_infer,
-    durable_tool,
-    durable_workflow,
-)
+from collections.abc import Callable
+from typing import Any
+
 from trajectory_ir.effects import requires_block_and_gate
 from trajectory_ir.resume.gate import make_gated_tool_call
 from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
@@ -16,6 +14,9 @@ def make_run_step(
     on_decision_sealed=None,
     *,
     mode: RunMode | str = RunMode.LIVE,
+    durable_infer_fn: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
+    durable_tool_fn: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
+    durable_workflow_fn: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
 ):
     """Build a durable run_step workflow for one agent step.
 
@@ -26,7 +27,30 @@ def make_run_step(
       must not raise ``BlockedNeedsGate`` for these classes.
 
     Sandbox mode (R06): rejects NON_IDEMPOTENT_WRITE before the tool body runs.
+
+    Durable backend hooks default to the DBOS adapter. Pass Restate (or local
+    memo) wrappers via ``durable_infer_fn`` / ``durable_tool_fn`` /
+    ``durable_workflow_fn`` for a second backend without forking this module.
     """
+    if durable_infer_fn is None or durable_tool_fn is None or durable_workflow_fn is None:
+        from drivers.durable_backend.dbos.adapter import (
+            durable_infer as dbos_infer,
+        )
+        from drivers.durable_backend.dbos.adapter import (
+            durable_tool as dbos_tool,
+        )
+        from drivers.durable_backend.dbos.adapter import (
+            durable_workflow as dbos_workflow,
+        )
+
+        durable_infer = durable_infer_fn or dbos_infer
+        durable_tool = durable_tool_fn or dbos_tool
+        durable_workflow = durable_workflow_fn or dbos_workflow
+    else:
+        durable_infer = durable_infer_fn
+        durable_tool = durable_tool_fn
+        durable_workflow = durable_workflow_fn
+
     run_mode = normalize_run_mode(mode)
 
     @durable_workflow
@@ -35,7 +59,7 @@ def make_run_step(
 
         # Model inference wrapped as a durable step -- fix from spec §1. Without
         # durable_infer here, a crash after this line but before the DECISION
-        # is sealed would cause DBOS to re-invoke model_call on resume even
+        # is sealed would cause the backend to re-invoke model_call on resume even
         # though its output would be discarded once replay reaches DECISION.
         infer = durable_infer(model_call)
         plan = infer(context)

--- a/test/unit/test_restate_adapter.py
+++ b/test/unit/test_restate_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from drivers.durable_backend.restate import (
     durable_infer,
     durable_tool,
@@ -91,3 +93,36 @@ def test_make_run_step_with_restate_local_memo(tmp_path):
     assert node_log.has(TRAJECTORY_ID, 1, "DECISION")
     assert node_log.has(TRAJECTORY_ID, 1, "TOOL_CALL", seq=2)
     assert node_log.has(TRAJECTORY_ID, 1, "COMMIT_STEP")
+
+
+def test_partial_durable_injection_fails_loud(tmp_path):
+    """Partial hooks would mix backends; refuse instead of filling from DBOS."""
+    node_log = NodeLog(str(tmp_path / "nodes.sqlite"))
+    tools = {
+        "echo": Tool(name="echo", fn=lambda *, msg: msg, effect_class=EffectClass.PURE),
+    }
+    with pytest.raises(ValueError, match="must be injected together"):
+        make_run_step(
+            node_log,
+            TENANT_ID,
+            TRAJECTORY_ID,
+            tools,
+            durable_infer_fn=durable_infer,
+            # durable_tool_fn / durable_workflow_fn omitted on purpose
+        )
+
+
+def test_partial_durable_injection_lists_missing_names(tmp_path):
+    node_log = NodeLog(str(tmp_path / "nodes.sqlite"))
+    tools = {
+        "echo": Tool(name="echo", fn=lambda *, msg: msg, effect_class=EffectClass.PURE),
+    }
+    with pytest.raises(ValueError, match="durable_workflow_fn"):
+        make_run_step(
+            node_log,
+            TENANT_ID,
+            "partial-2",
+            tools,
+            durable_infer_fn=durable_infer,
+            durable_tool_fn=durable_tool,
+        )

--- a/test/unit/test_restate_adapter.py
+++ b/test/unit/test_restate_adapter.py
@@ -1,0 +1,93 @@
+"""Tests for Restate adapter local memo and make_run_step injection."""
+
+from __future__ import annotations
+
+from drivers.durable_backend.restate import (
+    durable_infer,
+    durable_tool,
+    durable_workflow,
+    init_backend,
+)
+from drivers.durable_backend.restate.local_memo import clear_memo, workflow_scope
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.resume.step import make_run_step
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.tool import Tool
+
+TRAJECTORY_ID = "restate-local-demo"
+TENANT_ID = "demo"
+
+
+def test_local_memo_infer_runs_once():
+    clear_memo()
+    init_backend()
+    calls = {"n": 0}
+
+    def model(context: dict) -> dict:
+        calls["n"] += 1
+        return {"tool_calls": [], "v": context.get("v")}
+
+    wrapped = durable_infer(model)
+    with workflow_scope("wf-1"):
+        a = wrapped({"v": 1})
+        b = wrapped({"v": 1})
+    assert a == b
+    assert calls["n"] == 1
+
+
+def test_local_memo_tool_runs_once():
+    clear_memo()
+    init_backend()
+    calls = {"n": 0}
+
+    def add(*, x: int) -> int:
+        calls["n"] += 1
+        return x + 1
+
+    wrapped = durable_tool(add)
+    with workflow_scope("wf-2"):
+        assert wrapped(x=1) == 2
+        assert wrapped(x=1) == 2
+    assert calls["n"] == 1
+
+
+def test_make_run_step_with_restate_local_memo(tmp_path):
+    clear_memo()
+    init_backend()
+    model_calls = {"n": 0}
+    tool_calls = {"n": 0}
+
+    def model_call(context: dict) -> dict:
+        model_calls["n"] += 1
+        return {"tool_calls": [{"name": "echo", "args": {"msg": "hi"}}]}
+
+    def echo(*, msg: str) -> str:
+        tool_calls["n"] += 1
+        return msg
+
+    node_log = NodeLog(str(tmp_path / "nodes.sqlite"))
+    tools = {
+        "echo": Tool(name="echo", fn=echo, effect_class=EffectClass.PURE),
+    }
+    run_step = make_run_step(
+        node_log,
+        TENANT_ID,
+        TRAJECTORY_ID,
+        tools,
+        durable_infer_fn=durable_infer,
+        durable_tool_fn=durable_tool,
+        durable_workflow_fn=durable_workflow,
+    )
+
+    with workflow_scope(TRAJECTORY_ID):
+        r1 = run_step(step_n=1, model_call=model_call, context={})
+        r2 = run_step(step_n=1, model_call=model_call, context={})
+
+    assert r1 == ["hi"]
+    assert r2 == ["hi"]
+    # Durable memo: model and tool body run once across replay.
+    assert model_calls["n"] == 1
+    assert tool_calls["n"] == 1
+    assert node_log.has(TRAJECTORY_ID, 1, "DECISION")
+    assert node_log.has(TRAJECTORY_ID, 1, "TOOL_CALL", seq=2)
+    assert node_log.has(TRAJECTORY_ID, 1, "COMMIT_STEP")


### PR DESCRIPTION
## Summary

Adds an optional Restate durable backend package that matches the DBOS adapter call surface (`init_backend`, `durable_infer`, `durable_tool`, `durable_workflow`). The default implementation in tree is process local step memoization so unit tests prove R01 style replay without a Restate server. `make_run_step` now accepts optional durable hook functions; when omitted, behavior stays on DBOS. Operator notes for a real Restate cluster live in `drivers/durable_backend/restate/README.md`. Crash detection stays outside Trajectory IR core.

## Related issues

Closes #66

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_restate_adapter.py test/unit/test_step.py -q
ruff check drivers/durable_backend/restate pkg/trajectory_ir/resume/step.py test/unit/test_restate_adapter.py
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [ ] No
* [x] Yes: `make_run_step` gains injectable durable hooks (default still DBOS). Resume and gate policy logic are unchanged. No custom crash detection was added inside `pkg/`.

## AI assistance (if any)

Assisted with Grok for adapter layout and tests; human review of injection design and scope vs DBOS default.