### PR TITLE
feat: put artifacts into CAS on thin package export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
+
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
   with sharded `cas/<2-hex>/<hash>` layout, hash verify on get, and
   `rehydrate_artifacts` for thin `.tir` packages (issue #62).
@@ -24,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 First library-tagged release of the Phase 1A surface: dual-language IR, portable `.tir`, and runnable R01–R08.
 
 ### Added
+
+- `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
 
 - Phase 1A buildable core (nodes, NodeLog, effects, DBOS adapter, seal/resume gate, client SDK, kill-mid-deploy, R01/R02).
 - Issue templates, PR template, DCO CI job, Ruff/Mypy in CI alongside unit/e2e/conformance.
@@ -66,6 +70,8 @@ First library-tagged release of the Phase 1A surface: dual-language IR, portable
 ## [v0.1.0-draft] - 2026-07-27
 
 ### Added
+
+- `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
 
 - **Master Specification (`README.md`)**: The authoritative definition of Trajectory IR (Spec v0.2-draft).
 - **Infrastructure Blueprint (`infrastructure.md`)**: Detailed DevOps rules targeting `local`, `server-s3`, and `k8s-fluid` profiles. Outlines the sharded CAS layout and fallback mechanisms.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -155,6 +155,22 @@ go test ./...
 
 ---
 
+## 8. Thin package + local CAS
+
+```python
+from trajectory_ir.package import export_tir, load_tir
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.storage import FileSystemCAS, put_artifact, rehydrate_artifacts
+
+store = FileSystemCAS("./cas_root")
+log = NodeLog("traj.sqlite")
+# ... append nodes as usual ...
+ref = put_artifact(store, b"bytes from a tool", logical_path="out.bin")
+export_tir(log, "my-traj", "run.tir", mode="thin", artifacts=[ref], tenant_id="demo", cas=store)
+pkg = load_tir("run.tir")
+rehydrated = rehydrate_artifacts(store, pkg.artifacts_manifest)
+```
+
 ## What's next
 
 | Doc | Purpose |

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -218,6 +218,7 @@ def export_tir(
     artifact_bytes: dict[str, bytes] | None = None,
     tenant_id: str | None = None,
     redacted: bool = False,
+    cas: Any | None = None,
 ) -> Path:
     """Export a trajectory from ``node_log`` to a ``.tir`` zip at ``dest``.
 
@@ -228,6 +229,9 @@ def export_tir(
             heuristic, not a general secret scanner: it will not catch every
             secret, so ``redacted=True`` output still needs a human review
             pass before being shared outside the tenant.
+        cas: Optional content addressed store. When set and ``mode`` is thin,
+            every artifact content hash must already exist in the store
+            (fail closed). Fat mode ignores this check (bytes are embedded).
     """
     if mode not in ("thin", "fat"):
         raise TirError(f"unsupported mode {mode!r}; use thin or fat")
@@ -270,6 +274,20 @@ def export_tir(
             raise TirLimitError(f"too many artifacts: {len(artifacts)} > {MAX_ARTIFACTS}")
     else:
         artifact_bytes = {}
+
+    if cas is not None and mode == "thin" and artifacts:
+        from trajectory_ir.storage.artifacts import ensure_artifacts_in_cas
+
+        ensure_artifacts_in_cas(
+            cas,
+            [
+                {
+                    "content_hash": a.content_hash,
+                    "logical_path": a.logical_path,
+                }
+                for a in artifacts
+            ],
+        )
 
     seals = _seals_from_nodes(nodes)
     manifest = {
@@ -428,18 +446,37 @@ def import_tir(
     node_log: NodeLog,
     *,
     verify: bool = True,
+    cas: Any | None = None,
+    rehydrate: bool = False,
 ) -> TirPackage:
     """Verify a package and append its nodes into ``node_log`` (idempotent by id).
 
-    Does not acquire a writer lease (README §9). Verification cannot be disabled
-    on import — forged packages must not enter a durable log.
+    Does not acquire a writer lease (README section 9). Verification cannot be
+    disabled on import; forged packages must not enter a durable log.
+
+    Args:
+        cas: Optional CAS. When set, thin package artifact hashes must exist in
+            the store. When ``rehydrate`` is True, resolved bytes are placed on
+            ``pkg.artifact_bytes`` (useful for hosts that want fat in memory
+            after thin transport).
+        rehydrate: Load artifact bytes from ``cas`` into the returned package.
+            Requires ``cas``.
     """
     if not verify:
         raise TirError(
             "import_tir refuses verify=False; forged packages must not enter a NodeLog. "
             "Use load_tir_unverified() only for inspection, never for durable import."
         )
+    if rehydrate and cas is None:
+        raise TirError("import_tir(rehydrate=True) requires cas=")
     pkg = load_tir(path, verify=True)
+    if cas is not None and pkg.manifest.get("mode", "thin") == "thin" and pkg.artifacts_manifest:
+        from trajectory_ir.storage.artifacts import ensure_artifacts_in_cas
+        from trajectory_ir.storage.rehydrate import rehydrate_artifacts
+
+        ensure_artifacts_in_cas(cas, list(pkg.artifacts_manifest))
+        if rehydrate:
+            pkg.artifact_bytes = rehydrate_artifacts(cas, list(pkg.artifacts_manifest))
     for n in pkg.nodes:
         node = Node(
             kind=n["kind"],

--- a/pkg/trajectory_ir/storage/__init__.py
+++ b/pkg/trajectory_ir/storage/__init__.py
@@ -10,6 +10,7 @@ S3 and other remote drivers live under ``drivers/`` and implement the same
 rehydrate from any store that verifies hashes on put and get.
 """
 
+from trajectory_ir.storage.artifacts import ensure_artifacts_in_cas, put_artifact
 from trajectory_ir.storage.cas import (
     CAS,
     CASError,
@@ -28,6 +29,8 @@ __all__ = [
     "CASNotFoundError",
     "FileSystemCAS",
     "content_hash",
+    "ensure_artifacts_in_cas",
+    "put_artifact",
     "rehydrate_artifacts",
     "shard_key",
 ]

--- a/pkg/trajectory_ir/storage/artifacts.py
+++ b/pkg/trajectory_ir/storage/artifacts.py
@@ -1,0 +1,84 @@
+"""Helpers that connect tool output bytes to CAS and ArtifactRef.
+
+Typical host pattern::
+
+    store = FileSystemCAS(root)
+    ref = put_artifact(store, data, logical_path="out.bin")
+    export_tir(log, traj_id, "run.tir", mode="thin", artifacts=[ref])
+    # later, on another machine with the same CAS root or an S3 store:
+    pkg = load_tir("run.tir")
+    bytes_by_hash = rehydrate_artifacts(store, pkg.artifacts_manifest)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from trajectory_ir.package.tir import ArtifactRef
+from trajectory_ir.storage.cas import CAS, CASNotFoundError, content_hash, normalize_content_hash
+
+
+def put_artifact(
+    store: CAS,
+    data: bytes,
+    *,
+    logical_path: str,
+    uri: str | None = None,
+) -> ArtifactRef:
+    """Store ``data`` in ``store`` and return a thin package artifact ref.
+
+    Args:
+        store: Any CAS implementation (filesystem, S3, ...).
+        data: Raw artifact bytes.
+        logical_path: Path shown in the package manifest (not used as a store key).
+        uri: Optional override. When omitted, uses ``store.uri_for(hash)`` if the
+            store exposes that method, otherwise ``cas://<hash>``.
+
+    Returns:
+        ArtifactRef ready for ``export_tir(..., mode="thin", artifacts=[...])``.
+    """
+    if not logical_path or not isinstance(logical_path, str):
+        raise ValueError("logical_path is required")
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError("data must be bytes")
+    data_b = bytes(data)
+    h = store.put(data_b)
+    if content_hash(data_b) != h:
+        raise RuntimeError(f"CAS put returned hash {h} that does not match content")
+    if uri is None:
+        uri_fn = getattr(store, "uri_for", None)
+        if callable(uri_fn):
+            uri = str(uri_fn(h))
+        else:
+            uri = f"cas://{h}"
+    return ArtifactRef(
+        logical_path=logical_path,
+        content_hash=h,
+        uri=uri,
+        size=len(data_b),
+    )
+
+
+def ensure_artifacts_in_cas(
+    store: CAS,
+    artifacts_manifest: list[dict[str, Any]],
+    *,
+    require_all: bool = True,
+) -> None:
+    """Fail closed if thin package hashes are missing from ``store``.
+
+    Used by ``export_tir`` / ``import_tir`` when a CAS is supplied so packages
+    do not claim rehydratable artifacts that the store cannot serve.
+    """
+    missing: list[str] = []
+    for entry in artifacts_manifest:
+        raw = entry.get("content_hash")
+        if raw is None:
+            continue
+        h = normalize_content_hash(str(raw))
+        if not store.has(h):
+            missing.append(h)
+    if missing and require_all:
+        raise CASNotFoundError(
+            "CAS missing content hashes required by package: " + ", ".join(missing)
+        )

--- a/test/unit/test_cas_artifact_export.py
+++ b/test/unit/test_cas_artifact_export.py
@@ -1,0 +1,90 @@
+"""put_artifact -> thin export -> rehydrate end to end."""
+
+from __future__ import annotations
+
+from trajectory_ir.package.tir import export_tir, import_tir, load_tir
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.storage import (
+    CASNotFoundError,
+    FileSystemCAS,
+    put_artifact,
+    rehydrate_artifacts,
+)
+
+
+def test_put_export_thin_rehydrate_roundtrip(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    db = str(tmp_path / "nodes.sqlite")
+    log = NodeLog(db)
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+
+    data = b"portable artifact payload"
+    ref = put_artifact(cas, data, logical_path="outputs/result.bin")
+    assert ref.content_hash == cas.put(data)  # idempotent
+    assert ref.uri == f"cas://{ref.content_hash}"
+    assert ref.size == len(data)
+
+    dest = tmp_path / "run.tir"
+    export_tir(
+        log,
+        "t1",
+        dest,
+        mode="thin",
+        artifacts=[ref],
+        tenant_id="demo",
+        cas=cas,
+    )
+
+    pkg = load_tir(dest)
+    assert pkg.manifest["mode"] == "thin"
+    assert pkg.artifact_bytes == {}
+    assert len(pkg.artifacts_manifest) == 1
+    assert pkg.artifacts_manifest[0]["content_hash"] == ref.content_hash
+
+    got = rehydrate_artifacts(cas, pkg.artifacts_manifest)
+    assert got[ref.content_hash] == data
+
+    # import with rehydrate fills package bytes for host convenience
+    db2 = str(tmp_path / "nodes2.sqlite")
+    log2 = NodeLog(db2)
+    pkg2 = import_tir(dest, log2, cas=cas, rehydrate=True)
+    assert pkg2.artifact_bytes[ref.content_hash] == data
+    assert log2.has("t1", 1, "DECISION")
+    log.close()
+    log2.close()
+
+
+def test_export_thin_with_cas_fails_if_missing(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    db = str(tmp_path / "nodes.sqlite")
+    log = NodeLog(db)
+    log.append("DECISION", 1, {"plan": {}}, "t1", "demo", 1)
+    # Ref claims a hash that was never put
+    from trajectory_ir.package.tir import ArtifactRef
+    from trajectory_ir.storage.cas import content_hash
+
+    fake = content_hash(b"not-in-store")
+    ref = ArtifactRef(logical_path="x.bin", content_hash=fake, uri=f"cas://{fake}", size=1)
+    try:
+        export_tir(
+            log,
+            "t1",
+            tmp_path / "bad.tir",
+            mode="thin",
+            artifacts=[ref],
+            tenant_id="demo",
+            cas=cas,
+        )
+        raise AssertionError("expected CASNotFoundError")
+    except CASNotFoundError:
+        pass
+    log.close()
+
+
+def test_put_artifact_requires_path(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    try:
+        put_artifact(cas, b"x", logical_path="")
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass


### PR DESCRIPTION
## Summary

Connects the local CAS to real package flows. Adds `put_artifact` so hosts store tool output bytes and get an `ArtifactRef` for thin export. `export_tir` and `import_tir` accept optional `cas=`: thin export fails closed if listed hashes are missing from the store; import can rehydrate bytes into the package. Includes a round trip unit test and a short QUICKSTART example.

**Depends on** PR #68 (local FS CAS). This branch is based on `feat/local-fs-cas-62`. Prefer merging #68 first, then this PR.

## Related issues

Closes #73

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_cas_artifact_export.py test/unit/test_fs_cas.py -q
ruff check pkg/trajectory_ir/storage pkg/trajectory_ir/package/tir.py test/unit/test_cas_artifact_export.py
ruff format --check pkg drivers client test conformance examples
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [x] No
* [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for implementation and tests; human review of CAS fail closed paths.