### PR TITLE
feat: Go filesystem CAS with thin package rehydrate parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Go filesystem CAS under `go/trajir/cas` with sharded layout and Rehydrate helper (issue #74).
 - `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
 
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)

--- a/go/README.md
+++ b/go/README.md
@@ -13,6 +13,7 @@ Second language implementation of Trajectory IR primitives. Python remains the P
 | `trajir/durable/temporal` | Temporal Backend + worker registration |
 | `trajir/resume` | Block and gate, and RunStep seal path for one agent step |
 | `trajir/client` | Thin SDK: open, project, seal, exec, commit, resume, RunStep |
+| `trajir/cas` | Filesystem CAS (sharded layout; thin rehydrate) |
 | `trajir/tir` | Portable `.tir` package export / import (thin and fat) |
 | `trajir/projector` | Default context projector (R04; size metric = RFC 8785 / JCS bytes) |
 
@@ -127,3 +128,4 @@ Crash resume conformance (R01/R02 style) lives under `conformance/`.
 cd go
 go test ./conformance -count=1 -v
 ```
+

--- a/go/trajir/cas/cas.go
+++ b/go/trajir/cas/cas.go
@@ -1,0 +1,218 @@
+// Package cas implements content addressed artifact storage for the local
+// profile (README section 11.2).
+//
+// Key layout matches the Python reference (trajectory_ir.storage):
+//
+//	cas/<first-2-hex-of-sha256>/<full-sha256-hex>
+//
+// Objects are identified solely by SHA-256 of their bytes. Get always
+// re-hashes stored data and fails closed on mismatch.
+package cas
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Sentinel errors.
+var (
+	ErrCAS       = errors.New("cas")
+	ErrNotFound  = errors.New("cas not found")
+	ErrIntegrity = errors.New("cas integrity")
+	ErrInvalid   = errors.New("cas invalid hash")
+)
+
+var hex64 = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// Store is the minimal CAS surface used by thin package rehydrate.
+type Store interface {
+	Put(data []byte) (contentHash string, err error)
+	Get(contentHash string) ([]byte, error)
+	Has(contentHash string) bool
+}
+
+// ContentHash returns lowercase hex SHA-256 of data.
+func ContentHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// NormalizeHash validates and lowercases a 64 hex content hash.
+func NormalizeHash(h string) (string, error) {
+	h = strings.ToLower(strings.TrimSpace(h))
+	if !hex64.MatchString(h) {
+		return "", fmt.Errorf("%w: need 64 lowercase hex digits, got %q", ErrInvalid, h)
+	}
+	return h, nil
+}
+
+// ShardKey returns the relative object key cas/<2hex>/<fullhash>.
+func ShardKey(contentHash string) (string, error) {
+	h, err := NormalizeHash(contentHash)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(filepath.Join("cas", h[:2], h)), nil
+}
+
+// FileSystem is a directory rooted CAS for the local deployment profile.
+type FileSystem struct {
+	Root string
+}
+
+// NewFileSystem creates root if needed and returns a FileSystem store.
+func NewFileSystem(root string) (*FileSystem, error) {
+	if root == "" {
+		return nil, fmt.Errorf("%w: root is required", ErrCAS)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, fmt.Errorf("%w: mkdir root: %v", ErrCAS, err)
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	return &FileSystem{Root: abs}, nil
+}
+
+// PathFor returns the absolute path for a content hash under this store.
+func (fs *FileSystem) PathFor(contentHash string) (string, error) {
+	rel, err := ShardKey(contentHash)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(fs.Root, filepath.FromSlash(rel)), nil
+}
+
+// URIFor returns a portable cas://<hash> URI (store context is external).
+func (fs *FileSystem) URIFor(contentHash string) (string, error) {
+	h, err := NormalizeHash(contentHash)
+	if err != nil {
+		return "", err
+	}
+	return "cas://" + h, nil
+}
+
+// Put stores data under its content hash. Idempotent when the object exists.
+func (fs *FileSystem) Put(data []byte) (string, error) {
+	h := ContentHash(data)
+	path, err := fs.PathFor(h)
+	if err != nil {
+		return "", err
+	}
+	if st, err := os.Stat(path); err == nil && !st.IsDir() {
+		existing, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		if ContentHash(existing) != h {
+			return "", fmt.Errorf("%w: corrupt object at %s", ErrIntegrity, path)
+		}
+		return h, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+h+".*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	ok := false
+	defer func() {
+		_ = tmp.Close()
+		if !ok {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return "", err
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return "", err
+	}
+	ok = true
+	return h, nil
+}
+
+// Get loads bytes and verifies the content hash.
+func (fs *FileSystem) Get(contentHash string) ([]byte, error) {
+	h, err := NormalizeHash(contentHash)
+	if err != nil {
+		return nil, err
+	}
+	path, err := fs.PathFor(h)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, h)
+		}
+		return nil, err
+	}
+	actual := ContentHash(data)
+	if actual != h {
+		return nil, fmt.Errorf("%w: expected %s got %s at %s", ErrIntegrity, h, actual, path)
+	}
+	return data, nil
+}
+
+// Has reports whether an object path exists (does not full verify).
+func (fs *FileSystem) Has(contentHash string) bool {
+	h, err := NormalizeHash(contentHash)
+	if err != nil {
+		return false
+	}
+	path, err := fs.PathFor(h)
+	if err != nil {
+		return false
+	}
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}
+
+// ArtifactEntry is one row from a .tir artifacts-manifest.json.
+type ArtifactEntry struct {
+	LogicalPath string `json:"logical_path"`
+	ContentHash string `json:"content_hash"`
+	URI         string `json:"uri,omitempty"`
+	Size        *int   `json:"size,omitempty"`
+}
+
+// Rehydrate loads bytes for each manifest entry from store.
+// When requireAll is true, missing hashes return ErrNotFound.
+func Rehydrate(store Store, entries []ArtifactEntry, requireAll bool) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(entries))
+	for _, e := range entries {
+		h, err := NormalizeHash(e.ContentHash)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := out[h]; ok {
+			continue
+		}
+		data, err := store.Get(h)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) && !requireAll {
+				continue
+			}
+			return nil, err
+		}
+		out[h] = data
+	}
+	return out, nil
+}

--- a/go/trajir/cas/cas_test.go
+++ b/go/trajir/cas/cas_test.go
@@ -1,0 +1,164 @@
+package cas
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestContentHashEmpty(t *testing.T) {
+	// Public SHA-256 empty string vector.
+	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got := ContentHash(nil); got != want {
+		t.Fatalf("ContentHash(nil)=%s want %s", got, want)
+	}
+	if got := ContentHash([]byte{}); got != want {
+		t.Fatalf("ContentHash(empty)=%s want %s", got, want)
+	}
+}
+
+func TestShardKey(t *testing.T) {
+	h := ContentHash([]byte("hello"))
+	key, err := ShardKey(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cas/" + h[:2] + "/" + h
+	if key != want {
+		t.Fatalf("ShardKey=%s want %s", key, want)
+	}
+}
+
+func TestPutGetRoundTrip(t *testing.T) {
+	fs, err := NewFileSystem(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("trajectory artifact")
+	h, err := fs.Put(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h != ContentHash(data) {
+		t.Fatalf("hash mismatch")
+	}
+	if !fs.Has(h) {
+		t.Fatal("Has=false after Put")
+	}
+	got, err := fs.Get(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("Get bytes mismatch")
+	}
+	uri, err := fs.URIFor(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uri != "cas://"+h {
+		t.Fatalf("URI=%s", uri)
+	}
+	// sharded path exists
+	path, err := fs.PathFor(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(filepath.Dir(path)) != h[:2] {
+		t.Fatalf("shard dir = %s", filepath.Base(filepath.Dir(path)))
+	}
+}
+
+func TestPutIdempotent(t *testing.T) {
+	fs, err := NewFileSystem(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("same")
+	h1, err := fs.Put(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := fs.Put(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Fatal("idempotent put changed hash")
+	}
+}
+
+func TestGetMissing(t *testing.T) {
+	fs, err := NewFileSystem(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := ContentHash([]byte("absent"))
+	_, err = fs.Get(h)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err=%v want ErrNotFound", err)
+	}
+	if fs.Has(h) {
+		t.Fatal("Has should be false")
+	}
+}
+
+func TestGetDetectsTamper(t *testing.T) {
+	fs, err := NewFileSystem(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := fs.Put([]byte("honest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := fs.PathFor(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("tampered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = fs.Get(h)
+	if !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("err=%v want ErrIntegrity", err)
+	}
+}
+
+func TestRehydrate(t *testing.T) {
+	fs, err := NewFileSystem(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1, err := fs.Put([]byte("one"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2 := ContentHash([]byte("missing"))
+	entries := []ArtifactEntry{
+		{LogicalPath: "a", ContentHash: h1},
+		{LogicalPath: "b", ContentHash: h2},
+	}
+	_, err = Rehydrate(fs, entries, true)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("requireAll err=%v", err)
+	}
+	partial, err := Rehydrate(fs, entries, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(partial) != 1 || !bytes.Equal(partial[h1], []byte("one")) {
+		t.Fatalf("partial=%v", partial)
+	}
+}
+
+func TestNormalizeHashRejectsBad(t *testing.T) {
+	if _, err := NormalizeHash("nope"); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Go content addressed store under `go/trajir/cas` aligned with README section 11.2 and the Python CAS layout: sharded paths, SHA 256 identity, hash verify on get, portable `cas://` URIs, and a `Rehydrate` helper for thin package artifact manifests. Unit tests cover put/get, missing objects, tamper detection, and partial rehydrate. Independent of the Python CAS PRs (same contract, separate tree).

## Related issues

Closes #74

## How I tested

`ash
cd go
go test ./trajir/cas/ -count=1
go test ./... -count=1
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [x] No
* [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for Go package and tests; human review of layout parity with README section 11.2.