### PR TITLE
feat: load default projector policy from a YAML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- File based projector policy loader (YAML subset/JSON) and `policy=` on `project_context` (issue #75).
 - PostgreSQL NodeLog driver (`drivers.postgres.PostgresNodeLog`) matching SQLite
   append, claim, list, and tenant isolation semantics; optional `psycopg` extra
   (issue #64).

--- a/pkg/trajectory_ir/runtime/__init__.py
+++ b/pkg/trajectory_ir/runtime/__init__.py
@@ -1,6 +1,7 @@
 """Runtime primitives: nodes, log, tools, projector, sandbox, graft, redaction."""
 
 from trajectory_ir.runtime.graft import GraftError, graft_artifact_ref
+from trajectory_ir.runtime.policy import PolicyError, ProjectorPolicy, load_projector_policy
 from trajectory_ir.runtime.projector import BudgetImpossible, ProjectResult, project_context
 from trajectory_ir.runtime.redact import redact_payload, redact_projection_context
 from trajectory_ir.runtime.sandbox import RunMode, SandboxForbidden, assert_tool_allowed_in_mode
@@ -8,11 +9,14 @@ from trajectory_ir.runtime.sandbox import RunMode, SandboxForbidden, assert_tool
 __all__ = [
     "BudgetImpossible",
     "GraftError",
+    "PolicyError",
     "ProjectResult",
+    "ProjectorPolicy",
     "RunMode",
     "SandboxForbidden",
     "assert_tool_allowed_in_mode",
     "graft_artifact_ref",
+    "load_projector_policy",
     "project_context",
     "redact_payload",
     "redact_projection_context",

--- a/pkg/trajectory_ir/runtime/policy.py
+++ b/pkg/trajectory_ir/runtime/policy.py
@@ -1,0 +1,170 @@
+"""File based projector policy (narrow config, not a full DSL).
+
+Default behavior without a file matches the built in R04 policy: always
+include CONSTRAINT nodes; size metric is ``rfc8785_bytes``.
+
+Supported file shape (YAML subset or JSON)::
+
+    default_budget: 50000          # optional; callers may still pass budget=
+    always_include_kinds:
+      - CONSTRAINT
+    size_metric: rfc8785_bytes     # must match the only supported metric today
+
+Unknown top level keys fail closed. Nested expression languages are out of
+scope (see issue #75).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trajectory_ir.runtime.projector import SIZE_METRIC
+
+_ENV_POLICY = "TRAJIR_PROJECTOR_POLICY"
+
+_ALLOWED_KEYS = frozenset({"default_budget", "always_include_kinds", "size_metric"})
+
+
+class PolicyError(ValueError):
+    """Raised when a policy file is missing required shape or has unknown keys."""
+
+
+@dataclass(frozen=True)
+class ProjectorPolicy:
+    """Resolved projector policy used by :func:`project_context`."""
+
+    always_include_kinds: frozenset[str] = frozenset({"CONSTRAINT"})
+    default_budget: int | None = None
+    size_metric: str = SIZE_METRIC
+
+    def __post_init__(self) -> None:
+        if self.size_metric != SIZE_METRIC:
+            raise PolicyError(
+                f"unsupported size_metric {self.size_metric!r}; only {SIZE_METRIC!r} is implemented"
+            )
+        if self.default_budget is not None and self.default_budget < 0:
+            raise PolicyError("default_budget must be non-negative")
+        if not self.always_include_kinds:
+            raise PolicyError("always_include_kinds must be non-empty")
+
+
+def default_projector_policy() -> ProjectorPolicy:
+    """Built in policy (same as pre file behavior)."""
+    return ProjectorPolicy()
+
+
+def policy_from_mapping(data: dict[str, Any]) -> ProjectorPolicy:
+    """Build a policy from a plain dict (JSON/YAML load result)."""
+    if not isinstance(data, dict):
+        raise PolicyError("policy root must be a mapping")
+    unknown = set(data) - _ALLOWED_KEYS
+    if unknown:
+        raise PolicyError(f"unknown policy keys: {sorted(unknown)}")
+
+    kinds = data.get("always_include_kinds", ["CONSTRAINT"])
+    if not isinstance(kinds, list) or not all(isinstance(k, str) and k for k in kinds):
+        raise PolicyError("always_include_kinds must be a list of non-empty strings")
+
+    budget = data.get("default_budget")
+    if budget is not None and not isinstance(budget, int):
+        raise PolicyError("default_budget must be an integer when set")
+
+    metric = data.get("size_metric", SIZE_METRIC)
+    if not isinstance(metric, str):
+        raise PolicyError("size_metric must be a string")
+
+    return ProjectorPolicy(
+        always_include_kinds=frozenset(kinds),
+        default_budget=budget,
+        size_metric=metric,
+    )
+
+
+def _parse_scalar(raw: str) -> Any:
+    s = raw.strip()
+    if not s or s in {"null", "Null", "NULL", "~"}:
+        return None
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
+        return s[1:-1]
+    if re.fullmatch(r"-?\d+", s):
+        return int(s)
+    if s in {"true", "True", "false", "False"}:
+        return s.lower() == "true"
+    return s
+
+
+def _load_simple_yaml(text: str) -> dict[str, Any]:
+    """Parse the tiny YAML subset we document (mappings + string lists only)."""
+    data: dict[str, Any] = {}
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        i += 1
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("-"):
+            raise PolicyError("list item outside a key is not supported")
+        if ":" not in stripped:
+            raise PolicyError(f"expected key: value, got {stripped!r}")
+        key, _, rest = stripped.partition(":")
+        key = key.strip()
+        rest = rest.strip()
+        if rest:
+            data[key] = _parse_scalar(rest)
+            continue
+        # block list
+        items: list[Any] = []
+        while i < len(lines):
+            nxt = lines[i]
+            ns = nxt.strip()
+            if not ns or ns.startswith("#"):
+                i += 1
+                continue
+            if not nxt.startswith((" ", "\t")):
+                break
+            if not ns.startswith("-"):
+                raise PolicyError(f"expected list item under {key!r}, got {ns!r}")
+            items.append(_parse_scalar(ns[1:].strip()))
+            i += 1
+        data[key] = items
+    return data
+
+
+def load_projector_policy(path: str | Path) -> ProjectorPolicy:
+    """Load policy from a JSON or YAML subset file."""
+    p = Path(path)
+    if not p.is_file():
+        raise PolicyError(f"policy file not found: {p}")
+    text = p.read_text(encoding="utf-8")
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise PolicyError(f"invalid JSON policy: {exc}") from exc
+    else:
+        # .yaml / .yml / unknown: try JSON first, then simple YAML subset
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError:
+            raw = _load_simple_yaml(text)
+    if not isinstance(raw, dict):
+        raise PolicyError("policy root must be a mapping")
+    return policy_from_mapping(raw)
+
+
+def load_projector_policy_from_env(
+    env_var: str = _ENV_POLICY,
+) -> ProjectorPolicy | None:
+    """Load policy from ``TRAJIR_PROJECTOR_POLICY`` path if set; else None."""
+    path = os.environ.get(env_var)
+    if not path:
+        return None
+    return load_projector_policy(path)

--- a/pkg/trajectory_ir/runtime/projector.py
+++ b/pkg/trajectory_ir/runtime/projector.py
@@ -5,13 +5,15 @@ Metric: ``rfc8785_bytes`` — byte length of the RFC 8785 (JCS) canonical form o
 as node identity hashing (``rfc8785`` / Go ``jcs``), so Python and Go agree on
 budget thresholds. This is deliberately not a model-specific tokenizer.
 
-Default policy (no projector-policy.yaml):
-- Always include every CONSTRAINT node
+Default policy (no file, or always_include_kinds: [CONSTRAINT]):
+- Always include every always_include_kinds node (default: CONSTRAINT)
 - Always include explicitly pinned node ids
 - If must-include set alone exceeds budget → ``BudgetImpossible`` (never
-  silent drop of a CONSTRAINT or pinned node)
+  silent drop of a must-include or pinned node)
 - Other kinds fill remaining budget in deterministic order
   (step_n ascending, null last; then seq; then id)
+
+Optional file/env policy: see ``trajectory_ir.runtime.policy``.
 """
 
 from __future__ import annotations
@@ -70,35 +72,48 @@ def _sort_key(node: dict[str, Any]) -> tuple[int, int, str]:
 def project_context(
     nodes: list[dict[str, Any]],
     *,
-    budget: int,
+    budget: int | None = None,
     pinned_ids: set[str] | frozenset[str] | None = None,
+    policy: Any | None = None,
 ) -> ProjectResult:
-    """Project nodes into a budgeted context under the default policy.
+    """Project nodes into a budgeted context under the default (or file) policy.
 
     Args:
         nodes: Node records (must include ``id``, ``kind``, ``payload``; optionally
             ``step_n``, ``seq`` for ordering).
-        budget: Maximum total ``json_chars`` size units.
+        budget: Maximum total size units. When None, uses ``policy.default_budget``
+            if set, otherwise raises ValueError.
         pinned_ids: Node ids that must always appear when present in ``nodes``.
+        policy: Optional ``ProjectorPolicy``. When None, built in defaults apply
+            (always include CONSTRAINT).
 
     Returns:
         ProjectResult with included/dropped ids and an assembled context payload
         suitable for recording as PROJECT_CONTEXT.
 
     Raises:
-        BudgetImpossible: if CONSTRAINT + pinned nodes alone exceed ``budget``.
-        ValueError: if ``budget`` is negative.
+        BudgetImpossible: if always_include + pinned nodes alone exceed ``budget``.
+        ValueError: if ``budget`` is negative or cannot be resolved.
     """
+    if policy is None:
+        from trajectory_ir.runtime.policy import default_projector_policy
+
+        policy = default_projector_policy()
+    if budget is None:
+        budget = policy.default_budget
+    if budget is None:
+        raise ValueError("budget is required when policy.default_budget is unset")
     if budget < 0:
         raise ValueError("budget must be non-negative")
 
+    always_kinds = policy.always_include_kinds
     pinned = set(pinned_ids or ())
 
     must: list[dict[str, Any]] = []
     seen: set[str] = set()
     for n in nodes:
         nid = str(n.get("id") or "")
-        if n.get("kind") == "CONSTRAINT" or nid in pinned:
+        if n.get("kind") in always_kinds or nid in pinned:
             if nid and nid not in seen:
                 must.append(n)
                 seen.add(nid)
@@ -107,7 +122,7 @@ def project_context(
     must_size = sum(node_size_units(n) for n in must_sorted)
     if must_size > budget:
         raise BudgetImpossible(
-            f"BUDGET_IMPOSSIBLE: CONSTRAINT/pinned size {must_size} exceeds budget {budget}",
+            f"BUDGET_IMPOSSIBLE: always-include/pinned size {must_size} exceeds budget {budget}",
             required_size=must_size,
             budget=budget,
         )

--- a/test/unit/test_projector_policy.py
+++ b/test/unit/test_projector_policy.py
@@ -1,0 +1,93 @@
+"""Tests for file based projector policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trajectory_ir.runtime.policy import (
+    PolicyError,
+    ProjectorPolicy,
+    load_projector_policy,
+    policy_from_mapping,
+)
+from trajectory_ir.runtime.projector import project_context
+
+
+def _node(nid: str, kind: str, payload: dict, *, seq: int = 0) -> dict:
+    return {
+        "id": nid,
+        "kind": kind,
+        "payload": payload,
+        "step_n": 1,
+        "seq": seq,
+    }
+
+
+def test_load_yaml_subset(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        "default_budget: 1000\n"
+        "always_include_kinds:\n"
+        "  - CONSTRAINT\n"
+        "  - DECISION\n"
+        "size_metric: rfc8785_bytes\n",
+        encoding="utf-8",
+    )
+    pol = load_projector_policy(p)
+    assert pol.default_budget == 1000
+    assert pol.always_include_kinds == frozenset({"CONSTRAINT", "DECISION"})
+
+
+def test_load_json(tmp_path: Path) -> None:
+    p = tmp_path / "policy.json"
+    p.write_text(
+        '{"default_budget": 200, "always_include_kinds": ["CONSTRAINT"]}',
+        encoding="utf-8",
+    )
+    pol = load_projector_policy(p)
+    assert pol.default_budget == 200
+
+
+def test_unknown_key_fails(tmp_path: Path) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("default_budget: 1\nexotic_plugin: true\n", encoding="utf-8")
+    with pytest.raises(PolicyError, match="unknown"):
+        load_projector_policy(p)
+
+
+def test_bad_metric_fails() -> None:
+    with pytest.raises(PolicyError, match="size_metric"):
+        policy_from_mapping({"size_metric": "tokens", "always_include_kinds": ["CONSTRAINT"]})
+
+
+def test_project_uses_policy_kinds() -> None:
+    nodes = [
+        _node("d1", "DECISION", {"plan": {}}, seq=0),
+        _node("t1", "THOUGHT", {"text": "x" * 20}, seq=1),
+    ]
+    pol = ProjectorPolicy(always_include_kinds=frozenset({"DECISION"}), default_budget=10_000)
+    result = project_context(nodes, policy=pol)
+    assert "d1" in result.included_ids
+
+
+def test_budget_from_policy_when_arg_omitted() -> None:
+    nodes = [_node("c1", "CONSTRAINT", {"rule": "a"}, seq=0)]
+    pol = ProjectorPolicy(default_budget=50_000)
+    result = project_context(nodes, policy=pol)
+    assert result.budget == 50_000
+    assert "c1" in result.included_ids
+
+
+def test_missing_budget_errors() -> None:
+    nodes = [_node("c1", "CONSTRAINT", {"rule": "a"}, seq=0)]
+    with pytest.raises(ValueError, match="budget"):
+        project_context(nodes, policy=ProjectorPolicy())
+
+
+def test_repo_example_policy_loads() -> None:
+    root = Path(__file__).resolve().parents[2]
+    pol = load_projector_policy(root / "testdata" / "projector_policy_default.yaml")
+    assert pol.default_budget == 50000
+    assert "CONSTRAINT" in pol.always_include_kinds

--- a/testdata/projector_policy_default.yaml
+++ b/testdata/projector_policy_default.yaml
@@ -1,0 +1,5 @@
+# Minimal projector policy (issue #75). Unknown keys are rejected.
+default_budget: 50000
+always_include_kinds:
+  - CONSTRAINT
+size_metric: rfc8785_bytes


### PR DESCRIPTION
## Summary

Adds a narrow file based projector policy loader (JSON or a small YAML subset) so operators can set `default_budget`, `always_include_kinds`, and `size_metric` without editing source. Unknown keys fail closed. `project_context` accepts optional `policy=`; with no policy the built in R04 behavior (always include CONSTRAINT) is unchanged. Includes `testdata/projector_policy_default.yaml` and unit tests. Not a full policy expression language.

## Related issues

Closes #75

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit/test_projector_policy.py test/unit/test_projector.py -q
ruff check pkg/trajectory_ir/runtime test/unit/test_projector_policy.py
ruff format --check pkg drivers client test conformance examples
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [ ] No
* [x] Yes: projector policy only. Default always include set remains CONSTRAINT unless a policy file changes it. No change to seals, effects, or gate.

## AI assistance (if any)

Assisted with Grok for policy loader and tests; human review of fail closed unknown keys and default compatibility.