### PR TITLE
ci: Phase A quality gates for coverage, wheel smoke, pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  # Coverage floors (Phase A). Raise only after measured green baselines improve.
+  PYTHON_COV_FAIL_UNDER: "80"
+  GO_COV_FAIL_UNDER: "50"
+
 jobs:
   dco:
     name: DCO
@@ -80,14 +85,94 @@ jobs:
       - name: Cross language hash goldens (Python)
         run: pytest test/unit/test_hash_vectors.py test/unit/test_node_identity.py -q
 
-      - name: Unit tests
-        run: pytest test/unit -q
+      - name: Unit tests with coverage floor
+        run: |
+          pytest test/unit -q \
+            --cov=trajectory_ir \
+            --cov=drivers \
+            --cov=client \
+            --cov-report=term \
+            --cov-report=xml:coverage-python.xml \
+            --cov-fail-under=${{ env.PYTHON_COV_FAIL_UNDER }}
+
+      - name: Upload Python coverage (unit)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-python-${{ matrix.python-version }}
+          path: coverage-python.xml
+          if-no-files-found: ignore
 
       - name: E2E crash/resume tests
         run: pytest test/e2e -q
 
-      - name: Conformance R01/R02
+      - name: Conformance R01–R08
         run: pytest conformance/ -q
+
+  package-smoke:
+    name: Package smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Install wheel into clean environment and smoke import
+        run: |
+          python -m venv .venv-smoke
+          .venv-smoke/bin/pip install --upgrade pip
+          .venv-smoke/bin/pip install dist/trajectory_ir-*.whl
+          .venv-smoke/bin/python -c "\
+          import trajectory_ir; \
+          from trajectory_ir.runtime.nodes import Node; \
+          from trajectory_ir.storage import FileSystemCAS, content_hash; \
+          assert content_hash(b'') == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'; \
+          print('package smoke ok', getattr(trajectory_ir, '__file__', 'n/a'))"
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+          if-no-files-found: error
+
+  security-pip-audit:
+    name: Security (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and audit tooling
+        run: |
+          python -m pip install --upgrade pip
+          # Hosted images can ship an older setuptools that pip-audit flags.
+          pip install -U "setuptools>=83"
+          pip install -e ".[dev]"
+          pip install -U pip-audit
+
+      - name: Run pip-audit on installed dependency tree
+        run: |
+          # --skip-editable: local trajectory-ir is not a published PyPI release.
+          pip-audit --skip-editable
 
   go:
     name: Go
@@ -106,9 +191,24 @@ jobs:
         working-directory: go
         run: go test ./trajir/nodes -count=1 -run 'TestHashVectors|TestKeyOrder'
 
-      - name: Test Go IR core
+      - name: Test Go IR core with coverage floor
+        env:
+          GO_COV_FAIL_UNDER: ${{ env.GO_COV_FAIL_UNDER }}
+        run: |
+          chmod +x scripts/check_go_coverage.sh
+          scripts/check_go_coverage.sh
+
+      - name: Full Go test suite
         working-directory: go
         run: go test ./... -count=1
+
+      - name: Upload Go coverage profile
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-go
+          path: go/coverage.out
+          if-no-files-found: ignore
 
       - name: govulncheck
         working-directory: go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CI Phase A quality gates (issue #81): unit coverage floor (Python 80%), Go
+  trajir coverage floor (50%), Package smoke (wheel build + import), dedicated
+  Security (pip-audit) job; branch protection docs list required checks and
+  “up to date with main”.
 - Agent host loop example (`examples/host_loop`) using only the public client
   SDK with a stub model and optional sandbox mode (issue #65).
 - `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
-
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
   with sharded `cas/<2-hex>/<hash>` layout, hash verify on get, and
   `rehydrate_artifacts` for thin `.tir` packages (issue #62).
@@ -20,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and injectable client for tests; optional `boto3` extra (issue #63).
 
 ### Changed
+
+- Python `pip-audit` CI gate moved from Quality unit suite to the
+  **Security (pip-audit)** job; unit helper remains for local `RUN_PIP_AUDIT=1`.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,14 @@ Defined in `.github/workflows/ci.yml`:
 | Check | What it does |
 |-------|----------------|
 | **DCO** | Every commit on the PR has `Signed-off-by` |
-| **Quality** | install, Ruff, Mypy, hash goldens, unit (includes `pip-audit` gate), e2e, full `conformance/` R01–R08 (Python 3.11 and 3.12) |
-| **Go** | hash goldens, `go test ./...`, `govulncheck` |
+| **Quality** | install, Ruff, Mypy, hash goldens, unit tests with **coverage floor** (`PYTHON_COV_FAIL_UNDER`, default 80%), e2e, full `conformance/` R01–R08 (Python 3.11 and 3.12) |
+| **Package smoke** | `python -m build`, install the wheel into a clean venv, import smoke |
+| **Security (pip-audit)** | `pip-audit --skip-editable` on the installed dependency tree |
+| **Go** | hash goldens, `go/trajir/...` **coverage floor** (`GO_COV_FAIL_UNDER`, default 50%), `go test ./...`, `govulncheck` |
 
-Python dependency audit (`pip-audit`) is part of the unit suite under CI (`test/unit/test_pip_audit.py`), so it fails the existing **Quality** checks without a separate job.
+Local dependency audit (optional): `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q` after `pip install -e ".[dev]"`. Under GitHub Actions the dedicated **Security (pip-audit)** job is authoritative.
+
+Coverage floors and required check names: [docs/maintainer-branch-protection.md](docs/maintainer-branch-protection.md).
 
 Phase 1A inventory (shipped vs deferred): [docs/PHASE_1A_STATUS.md](docs/PHASE_1A_STATUS.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 
 ### F. Continuous dependency scanning
 - **Go**: `govulncheck ./...` runs in the CI `Go` job.
-- **Python**: `pip-audit --skip-editable` runs under CI via `test/unit/test_pip_audit.py` (part of the Quality unit suite when `CI=true`). Locally: `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q` in a clean venv after `pip install -e ".[dev]"`.
+- **Python**: `pip-audit --skip-editable` runs in the CI job **Security (pip-audit)**. Locally: `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q` in a clean venv after `pip install -e ".[dev]"`.
 
 ## 4. Security Accountability for Contributors
 

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -17,7 +17,7 @@ Honest inventory of what is **on `main`** versus what remains **out of scope** o
 | Local FS CAS | `trajectory_ir.storage.FileSystemCAS`, thin rehydrate helper |
 | Go IR stack | `go/trajir/*` — nodes, log, effects, durable, Temporal, resume, client |
 | Demos | `examples/kill-mid-deploy/`, `go/examples/kill-mid-deploy/` |
-| CI | DCO, Quality (3.11/3.12: ruff, mypy, unit/e2e/conformance, pip-audit test), Go (tests + govulncheck) |
+| CI | DCO, Quality (3.11/3.12: ruff, mypy, unit coverage floor, e2e, conformance), Package smoke, Security (pip-audit), Go (trajir coverage floor + tests + govulncheck) |
 
 ### Conformance (README §10)
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -9,27 +9,40 @@ GitHub → Settings → Branches → Branch protection rule for `main`:
 1. Require a pull request before merging
 2. Require approvals (at least 1 when more than one maintainer is active; 0 is OK for a solo maintainer if status checks are strict)
 3. Require status checks to pass before merging
-4. Require branches to be up to date before merging (recommended)
+4. **Require branches to be up to date before merging** (strongly recommended; avoids the multi-PR conflict pile after `main` moves)
 5. Do not allow force pushes or deleting `main`
 
 ## Status checks to require
 
-Match the names shown in the Actions UI:
+Match the names shown in the Actions UI (Phase A, issue #81):
 
 1. `DCO` (pull requests only; may appear after the first PR with the DCO job)
-2. `Quality (Python 3.11)` — includes `pip-audit` via unit tests
-3. `Quality (Python 3.12)` — includes `pip-audit` via unit tests
-4. `Go` (includes `govulncheck`)
+2. `Quality (Python 3.11)` — ruff, mypy, unit coverage floor, e2e, conformance
+3. `Quality (Python 3.12)` — same as 3.11
+4. `Package smoke` — `python -m build` + install wheel + import smoke
+5. `Security (pip-audit)` — first-class dependency audit (not only a unit test)
+6. `Go` — trajir coverage floor, full `go test ./...`, `govulncheck`
 
 If GitHub shows a slightly different label, use the exact string from the check run.
 
 Also enable org/repo **secret scanning** and **push protection** when available (Settings → Code security).
 
+## Coverage floors (workflow env)
+
+Set in `.github/workflows/ci.yml` as `env:`:
+
+| Variable | Default | Applies to |
+|----------|---------|------------|
+| `PYTHON_COV_FAIL_UNDER` | `80` | unit suite on `trajectory_ir` + `drivers` + `client` |
+| `GO_COV_FAIL_UNDER` | `50` | `go/trajir/...` via `scripts/check_go_coverage.sh` |
+
+Raise only after a measured green baseline; do not drop floors without a PR.
+
 ## Post-feature landing checklist
 
 After large merges (packages, conformance, security):
 
-1. Latest `main` CI is green.
+1. Latest `main` CI is green (all six check families above).
 2. Required checks still match the names above (rename jobs only with a protection update).
 3. Close GitHub issues that already shipped (link the merge PR).
 4. Skim [QUICKSTART.md](../QUICKSTART.md) and [PHASE_1A_STATUS.md](PHASE_1A_STATUS.md) for fictional APIs.
@@ -38,9 +51,9 @@ After large merges (packages, conformance, security):
 ## Order
 
 1. Merge a PR that defines or updates `.github/workflows/ci.yml`
-2. Confirm a green run so check names exist
-3. Enable the protection rule and select those checks
-4. Confirm a test PR cannot merge with a failing DCO, Quality, or Go job
+2. Confirm a green run so check names exist (including `Package smoke` and `Security (pip-audit)`)
+3. Enable the protection rule, select those checks, enable **up to date with main**
+4. Confirm a test PR cannot merge with a failing DCO, Quality, Package smoke, Security, or Go job
 
 ## CLI (optional)
 
@@ -57,6 +70,8 @@ gh api -X PUT repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection \
       "DCO",
       "Quality (Python 3.11)",
       "Quality (Python 3.12)",
+      "Package smoke",
+      "Security (pip-audit)",
       "Go"
     ]
   },
@@ -71,4 +86,4 @@ gh api -X PUT repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection \
 EOF
 ```
 
-Adjust review count when the team grows.
+`strict: true` is “require branches to be up to date before merging.” Adjust review count when the team grows.

--- a/scripts/check_go_coverage.sh
+++ b/scripts/check_go_coverage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fail if total statement coverage for go/trajir/... is below GO_COV_FAIL_UNDER (percent).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT/go"
+
+MIN="${GO_COV_FAIL_UNDER:-50}"
+PROFILE="${GO_COVERPROFILE:-coverage.out}"
+
+echo "Running go test ./trajir/... with coverage (floor ${MIN}%)"
+go test ./trajir/... -count=1 -coverprofile="$PROFILE"
+
+if [[ ! -f "$PROFILE" ]]; then
+  echo "error: coverprofile $PROFILE was not produced" >&2
+  exit 1
+fi
+
+# last line: total: (statements) XX.X%
+TOTAL_LINE="$(go tool cover -func="$PROFILE" | tail -n 1)"
+echo "$TOTAL_LINE"
+
+PCT="$(echo "$TOTAL_LINE" | awk '{print $3}' | tr -d '%')"
+if [[ -z "$PCT" ]]; then
+  echo "error: could not parse coverage percent from: $TOTAL_LINE" >&2
+  exit 1
+fi
+
+# awk numeric compare (avoids bash float issues)
+awk -v pct="$PCT" -v min="$MIN" 'BEGIN {
+  if (pct + 0 < min + 0) {
+    printf "error: Go trajir coverage %.1f%% is below floor %s%%\n", pct, min > "/dev/stderr"
+    exit 1
+  }
+  printf "Go trajir coverage %.1f%% meets floor %s%%\n", pct, min
+}'

--- a/test/unit/test_pip_audit.py
+++ b/test/unit/test_pip_audit.py
@@ -1,7 +1,12 @@
-"""CI dependency vulnerability gate (Python parity with Go govulncheck).
+"""Local helper for dependency vulnerability scanning (parity with Go govulncheck).
 
-Runs under GitHub Actions (CI=true). Locally: ``RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py``.
-Skip with ``SKIP_PIP_AUDIT=1`` when needed.
+Primary CI gate is the dedicated **Security (pip-audit)** job in
+``.github/workflows/ci.yml``. This unit test remains for local runs:
+
+    RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q
+
+Skip with ``SKIP_PIP_AUDIT=1`` when needed. Under GitHub Actions the dedicated
+job owns the gate so Quality does not double-run audit.
 """
 
 from __future__ import annotations
@@ -17,7 +22,10 @@ def test_installed_dependency_tree_has_no_known_vulns() -> None:
     """Fail when pip-audit reports known vulnerabilities in the installed tree."""
     if os.environ.get("SKIP_PIP_AUDIT") == "1":
         pytest.skip("SKIP_PIP_AUDIT=1")
-    if os.environ.get("CI") != "true" and os.environ.get("RUN_PIP_AUDIT") != "1":
+    # CI uses the Security (pip-audit) job; avoid double-running on every Quality matrix cell.
+    if os.environ.get("CI") == "true":
+        pytest.skip("pip-audit runs in the Security (pip-audit) CI job")
+    if os.environ.get("RUN_PIP_AUDIT") != "1":
         pytest.skip("set RUN_PIP_AUDIT=1 to run pip-audit outside CI")
 
     # Ensure audit tooling and known-vulnerable build backends are current.


### PR DESCRIPTION
## Summary

Implements CI Phase A from issue #81:

1. Python unit coverage floor (80%) on `trajectory_ir` / `drivers` / `client`
2. Go `trajir/...` coverage floor (50%) via `scripts/check_go_coverage.sh`
3. **Package smoke** job: `python -m build`, install wheel, import smoke
4. **Security (pip-audit)** job as a first class check (unit helper still works locally with `RUN_PIP_AUDIT=1`)
5. Branch protection docs updated with new check names and require up to date with `main`

Floors are set from measured green baselines so existing main should stay green.

## Related issues

Closes #81

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit -q --cov=trajectory_ir --cov=drivers --cov=client --cov-fail-under=80
python -m build
# install wheel into clean venv; import trajectory_ir + content_hash smoke
ruff check test/unit/test_pip_audit.py
`

## Checklist

* [x] Commits are DCO signed (`git commit -s`)
* [x] Change matches the master README (no invented APIs)
* [x] Relevant CI checks pass locally
* [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block and gate, seals, or secret handling?

* [x] No
* [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for CI workflow and docs; floors chosen from local coverage baselines to avoid flaky CI.