### PR TITLE
docs: finalize v0.1.0 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,34 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.1.0] - 2026-08-06
+
+First library-tagged release of the Phase 1A surface: dual-language IR, portable `.tir`, storage drivers, host example, Restate hooks, and CI Phase A gates (R01–R08).
+
+### Added
+
 - CI Phase A quality gates (issue #81): unit coverage floor (Python 80%), Go
   trajir coverage floor (50%), Package smoke (wheel build + import), dedicated
   Security (pip-audit) job; branch protection docs list required checks and
-  “up to date with main”.
+  "up to date with main".
 - Agent host loop example (`examples/host_loop`) using only the public client
   SDK with a stub model and optional sandbox mode (issue #65).
-- `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
+- Restate durable backend adapter package (`drivers.durable_backend.restate`)
+  with process local step memo; injectable durable hooks on `make_run_step`
+  (issue #66).
+- Go filesystem CAS under `go/trajir/cas` (issue #74).
+- File based projector policy loader (YAML subset/JSON) and `policy=` on
+  `project_context` (issue #75).
+- Maintainer PyPI publish steps expanded in `docs/RELEASE.md` (issue #76).
+- `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir`
+  for fail closed rehydrate (issue #73).
 - Local filesystem content addressed store (`trajectory_ir.storage.FileSystemCAS`)
   with sharded `cas/<2-hex>/<hash>` layout, hash verify on get, and
   `rehydrate_artifacts` for thin `.tir` packages (issue #62).
 - S3 compatible CAS driver (`drivers.s3.S3CAS`) with the same sharded key layout
   and injectable client for tests; optional `boto3` extra (issue #63).
-
-### Changed
-
-- Python `pip-audit` CI gate moved from Quality unit suite to the
-  **Security (pip-audit)** job; unit helper remains for local `RUN_PIP_AUDIT=1`.
-
-### Fixed
-
-## [0.1.0] - 2026-08-05
-
-First library-tagged release of the Phase 1A surface: dual-language IR, portable `.tir`, and runnable R01–R08.
-
-### Added
-
-- `put_artifact` helper and optional `cas=` on thin `export_tir` / `import_tir` for fail closed rehydrate (issue #73).
-
+- PostgreSQL NodeLog driver (`drivers.postgres.PostgresNodeLog`) (issue #64).
 - Phase 1A buildable core (nodes, NodeLog, effects, DBOS adapter, seal/resume gate, client SDK, kill-mid-deploy, R01/R02).
 - Issue templates, PR template, DCO CI job, Ruff/Mypy in CI alongside unit/e2e/conformance.
 - Maintainer note for branch protection on `main`.
@@ -56,8 +59,6 @@ First library-tagged release of the Phase 1A surface: dual-language IR, portable
 - Security hardening: `.tir` zip size/path limits, atomic TOOL_CALL claim (Python + Go),
   identity delimiter validation, tenant-scoped list/export, redacted export mode,
   Temporal TLS/API key config, safer import verification API.
-- CI: `pip-audit` gate in Python unit tests under CI (parity with Go `govulncheck`);
-  `pip-audit` added to the `dev` extra.
 - Go `.tir` thin/fat export and import (`trajir/tir`) with Python layout parity,
   hash verification, zip limits/path safety, and cross-language golden fixture.
 - R05 conformance tests for `.tir` thin/fat round-trip and golden fixture load.
@@ -72,8 +73,12 @@ First library-tagged release of the Phase 1A surface: dual-language IR, portable
 
 ### Changed
 
+- Python `pip-audit` CI gate moved to the **Security (pip-audit)** job; unit helper
+  remains for local `RUN_PIP_AUDIT=1`.
 - CONTRIBUTING and infrastructure docs describe the CI gates that actually run.
 - Lint cleanups for Ruff/Mypy on the core package and test harness.
+
+### Fixed
 
 ## [v0.1.0-draft] - 2026-07-27
 

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -1,4 +1,4 @@
-# Phase 1A status (as of 0.1.0 prep)
+# Phase 1A status (as of v0.1.0)
 
 Honest inventory of what is **on `main`** versus what remains **out of scope** or deferred. Normative detail stays in the root `README.md`.
 
@@ -8,15 +8,18 @@ Honest inventory of what is **on `main`** versus what remains **out of scope** o
 |------|------------------|
 | Python IR core | `pkg/trajectory_ir/` — nodes, NodeLog, effects, gate, run_step |
 | DBOS adapter | `drivers/durable_backend/dbos/` |
+| Restate adapter (local memo) | `drivers/durable_backend/restate/` + injectable `make_run_step` hooks |
 | Python client | `client/python/trajectory_client.py` (open/project/seal/exec/commit/resume; sandbox mode) |
 | `.tir` thin/fat | `pkg/trajectory_ir/package/`, Go `go/trajir/tir` |
-| Projector (R04) | `runtime/projector.py`, Go `trajir/projector` (RFC 8785 size metric) |
+| FS CAS + thin rehydrate | `trajectory_ir.storage`, `put_artifact` |
+| S3 CAS | `drivers.s3.S3CAS` |
+| Postgres NodeLog | `drivers.postgres.PostgresNodeLog` |
+| Projector (R04) + policy file | `runtime/projector.py`, `runtime/policy.py`, Go `trajir/projector` |
 | Sandbox (R06) | `runtime/sandbox.py`, Go `trajir/sandbox` |
 | Graft (R07) | `runtime/graft.py`, Go `trajir/graft` |
 | Redaction (R08 + export) | `runtime/redact.py`, Go `trajir/redact` |
-| Local FS CAS | `trajectory_ir.storage.FileSystemCAS`, thin rehydrate helper |
-| Go IR stack | `go/trajir/*` — nodes, log, effects, durable, Temporal, resume, client |
-| Demos | `examples/kill-mid-deploy/`, `go/examples/kill-mid-deploy/` |
+| Go IR stack | `go/trajir/*` — nodes, log, effects, durable, Temporal, resume, client, cas |
+| Demos / host example | `examples/kill-mid-deploy/`, `examples/host_loop/`, Go kill-mid-deploy |
 | CI | DCO, Quality (3.11/3.12: ruff, mypy, unit coverage floor, e2e, conformance), Package smoke, Security (pip-audit), Go (trajir coverage floor + tests + govulncheck) |
 
 ### Conformance (README §10)
@@ -32,25 +35,23 @@ Honest inventory of what is **on `main`** versus what remains **out of scope** o
 | R07 | `conformance/r07_graft_test.py` |
 | R08 | `conformance/r08_projection_redaction_test.py` |
 
-Phase 1A **completion bar** in the master README still treats R01/R02 as the hard product gate; R03–R08 are now implemented and should stay green in CI.
+Phase 1A **completion bar** in the master README still treats R01/R02 as the hard product gate; R03–R08 are implemented and stay green in CI.
 
 ## Explicitly not shipped (do not claim)
 
 | Item | Notes |
 |------|--------|
 | Package digital signatures | `SIGNATURE` reserved / null |
-| Restate adapter | Shipped as optional package + local memo; real cluster is operator wired |
-| Local FS CAS object store product | Shipped: `trajectory_ir.storage.FileSystemCAS` + `rehydrate_artifacts` |
-| Postgres / S3 drivers | Postgres NodeLog shipped (`drivers.postgres`); S3 CAS shipped (`drivers.s3`) |
+| Live Restate cluster product packaging | Adapter + local memo only; operator wires real cluster |
 | Fluid / k8s-fluid profile | Later phase |
-| Full `projector-policy.yaml` DSL | Default built-in policy only |
+| Full projector-policy expression DSL | File/YAML subset for defaults shipped; no plugin language |
 | Multi-tenant SaaS control plane | Library trust model |
-| PyPI publish automation | Prep for 0.1.0 tag; publish is a separate maintainer action |
+| Automated PyPI Trusted Publishing | Manual tag + optional twine; see `docs/RELEASE.md` |
 
 ## Maintainer checklist (after large feature landings)
 
 1. `main` green on latest CI run.
-2. Branch protection requires: `DCO`, `Quality (Python 3.11)`, `Quality (Python 3.12)`, `Go` — see [maintainer-branch-protection.md](maintainer-branch-protection.md).
+2. Branch protection requires: `DCO`, `Quality (Python 3.11)`, `Quality (Python 3.12)`, `Package smoke`, `Security (pip-audit)`, `Go` — see [maintainer-branch-protection.md](maintainer-branch-protection.md). Prefer **require branches to be up to date**.
 3. Prefer org **secret scanning** + **push protection** enabled.
 4. No open issues for work that already merged (close with PR reference).
 5. Quickstart and this status doc match reality (no fictional APIs).

--- a/docs/RELEASE_NOTES_0.1.0.md
+++ b/docs/RELEASE_NOTES_0.1.0.md
@@ -5,11 +5,13 @@ First numbered library release of **Trajectory IR**: a portable, hash-verifiable
 ## Highlights
 
 - **Python IR core** with DBOS-backed durable steps and SQLite NodeLog
-- **Go IR stack** (`go/trajir`) with LocalSQLite/Memory memoization and optional Temporal
-- **Portable `.tir`** thin/fat packages (Python + Go), with verification and resource limits
-- **Conformance R01–R08** runnable under `pytest conformance/` (and Go package tests where noted)
-- **Sandbox mode (R06)**, **graft (R07)**, **projection redaction (R08)**, **projector budget safety (R04)**
-- OSS process: DCO, CI (Ruff/Mypy/pytest/govulncheck/pip-audit gate), Dependabot, SECURITY.md
+- **Optional backends**: Postgres NodeLog, Restate-style durable hooks (local memo + injectable `make_run_step`), S3 and filesystem CAS
+- **Go IR stack** (`go/trajir`) with LocalSQLite/Memory memoization, optional Temporal, and filesystem CAS
+- **Portable `.tir`** thin/fat packages (Python + Go), with verification, resource limits, and thin rehydrate via CAS
+- **Conformance R01–R08** under `pytest conformance/`
+- **Sandbox (R06)**, **graft (R07)**, **projection redaction (R08)**, **projector budget safety (R04)** plus optional projector policy file
+- **Host loop example** (`examples/host_loop`) using only public client APIs
+- **OSS process**: DCO, CI (Ruff/Mypy/pytest coverage floors, Package smoke, Security pip-audit, Go coverage floor + govulncheck), Dependabot, SECURITY.md
 
 ## Install (from source)
 
@@ -17,6 +19,13 @@ First numbered library release of **Trajectory IR**: a portable, hash-verifiable
 git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
 cd Trajectory-IR
 pip install -e ".[dev]"
+# optional: pip install -e ".[s3]" or ".[postgres]"
+```
+
+From the release tag / PyPI (when published):
+
+```bash
+pip install trajectory-ir==0.1.0
 ```
 
 Go:
@@ -29,11 +38,15 @@ See [QUICKSTART.md](../QUICKSTART.md) and [PHASE_1A_STATUS.md](PHASE_1A_STATUS.m
 
 ## Not in 0.1.0
 
-- Package digital signatures  
-- Restate adapter  
-- Full FS/S3 CAS product and Fluid  
-- Multi-tenant SaaS control plane  
-- Automated PyPI publish (optional maintainer follow-up)
+- Package digital signatures (`SIGNATURE` reserved)
+- Live Restate cluster product packaging (adapter + local memo only)
+- Fluid / k8s-fluid profile
+- Full multi-tenant SaaS control plane
+- Automated PyPI Trusted Publishing (manual upload optional)
+
+## Spec note
+
+Master README still names DBOS as the Phase 1A Python default; Go production Temporal is implemented. Tracking residual wording in issue #67.
 
 ## CNCF context
 


### PR DESCRIPTION
## Summary

Finalizes docs for cutting `v0.1.0`: consolidates CHANGELOG into `[0.1.0] - 2026-08-06`, refreshes `RELEASE_NOTES_0.1.0.md` and `PHASE_1A_STATUS.md` so they match shipped CAS, Postgres, host loop, Restate hooks, Go CAS, projector policy, and CI Phase A.

## Related issues

Supports release process in docs/RELEASE.md (after merge: tag + GitHub Release).

## How I tested

Docs only. Local suites already green on main prior to this docs commit.

## Checklist

* [x] Commits are DCO signed
* [x] Docs match reality on main
* [x] No runtime code changes

## Safety areas

* [x] No

## AI assistance (if any)

Assisted with Grok for release note consolidation.