### PR TITLE
chore: stabilize branch settings notes and PyPI package metadata

### DIFF
--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -2,9 +2,22 @@
 
 Do this after CI has produced green check names on `main` or on a PR.
 
+## GitHub plan note (important)
+
+This repository is currently **private**. On GitHub’s free plan for private
+repos, **classic branch protection** and **repository rulesets** return HTTP
+403 (“Upgrade to GitHub Pro or make this repository public”).
+
+To enable step 1 of post-v0.1.0 stabilization, pick one:
+
+1. **Make the repo public** (free branch protection + free secret scanning for public repos), or  
+2. **Upgrade the org/user to a plan that includes branch protection on private repos** (GitHub Pro / Team / Enterprise as applicable).
+
+Until then, enforce process by policy: only merge green PRs, prefer squash, and use **Update branch** (repo setting `allow_update_branch` is enabled).
+
 ## Recommended settings
 
-GitHub → Settings → Branches → Branch protection rule for `main`:
+GitHub → Settings → Branches → Branch protection rule for `main` (after plan allows it):
 
 1. Require a pull request before merging
 2. Require approvals (at least 1 when more than one maintainer is active; 0 is OK for a solo maintainer if status checks are strict)
@@ -25,7 +38,11 @@ Match the names shown in the Actions UI (Phase A, issue #81):
 
 If GitHub shows a slightly different label, use the exact string from the check run.
 
-Also enable org/repo **secret scanning** and **push protection** when available (Settings → Code security).
+Also enable org/repo **secret scanning** and **push protection** when available
+(Settings → Code security). On **private** free-tier repos, secret scanning is
+often unavailable without GitHub Advanced Security; **Dependabot alerts** and
+**Dependabot security updates** can still be enabled (and were enabled for this
+repo where the API allows).
 
 ## Coverage floors (workflow env)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,29 @@
 [project]
 name = "trajectory-ir"
 version = "0.1.0"
+description = "Portable, hash-verifiable intermediate representation for agent runs (seals, effects, .tir packages)"
+readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [
+    { name = "Coder-s-OG-s contributors" },
+]
+keywords = [
+    "agent",
+    "trajectory",
+    "intermediate-representation",
+    "durable-execution",
+    "tir",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "dbos",
     "rfc8785",
@@ -11,6 +33,13 @@ dependencies = [
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
 postgres = ["psycopg[binary]>=3.1"]
 s3 = ["boto3"]
+
+[project.urls]
+Homepage = "https://github.com/Coder-s-OG-s/Trajectory-IR"
+Repository = "https://github.com/Coder-s-OG-s/Trajectory-IR"
+Issues = "https://github.com/Coder-s-OG-s/Trajectory-IR/issues"
+Changelog = "https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/CHANGELOG.md"
+Release = "https://github.com/Coder-s-OG-s/Trajectory-IR/releases/tag/v0.1.0"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

Post v0.1.0 stabilization follow through:

1. Documents that classic branch protection / rulesets need a public repo or paid plan while this repo is private free tier.
2. Records security posture: Dependabot security updates enabled via API; secret scanning not available on this private free plan.
3. Hardens `pyproject.toml` for PyPI (description, readme, license, urls, classifiers) so `twine check` is clean for a future upload.

Does not announce anything and does not upload to PyPI (no token in environment).

## How I tested

`ash
python -m build
python -m twine check dist/*
`

## Checklist

* [x] Commits are DCO signed
* [x] Docs match reality
* [x] Twine check PASSED

## Safety areas

* [x] No

## AI assistance (if any)

Assisted with Grok for metadata and API probes.