### PR TITLE
ci: Phase B Postgres and MinIO integration jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,89 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
+
+  # Phase B: real service integrations (separate from Quality so Phase A stays fast).
+  integration-postgres:
+    name: Integration (Postgres)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.6
+        env:
+          POSTGRES_USER: trajir
+          POSTGRES_PASSWORD: trajir
+          POSTGRES_DB: trajir
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U trajir -d trajir"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      TRAJIR_DATABASE_URL: postgresql://trajir:trajir@localhost:5432/trajir
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package with Postgres extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,postgres]"
+
+      - name: Live Postgres NodeLog tests
+        run: pytest test/integration/test_postgres_live.py -q
+
+  integration-minio:
+    name: Integration (MinIO)
+    runs-on: ubuntu-latest
+    env:
+      TRAJIR_S3_ENDPOINT_URL: http://127.0.0.1:9000
+      TRAJIR_S3_BUCKET: trajir
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z \
+            server /data --console-address ":9001"
+          for i in $(seq 1 40); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live; then
+              echo "MinIO is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "MinIO failed to become healthy" >&2
+          docker logs minio || true
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package with S3 extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,s3]"
+
+      - name: Live MinIO S3 CAS tests
+        run: pytest test/integration/test_s3_minio_live.py -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CI Phase B: Integration (Postgres) and Integration (MinIO) jobs with live
+  driver tests under `test/integration/` (issue #85).
+
 ### Changed
+
+- `build_s3_client_from_env` uses path-style addressing when
+  `TRAJIR_S3_ENDPOINT_URL` is set (MinIO/LocalStack).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,41 @@ Defined in `.github/workflows/ci.yml`:
 | **Package smoke** | `python -m build`, install the wheel into a clean venv, import smoke |
 | **Security (pip-audit)** | `pip-audit --skip-editable` on the installed dependency tree |
 | **Go** | hash goldens, `go/trajir/...` **coverage floor** (`GO_COV_FAIL_UNDER`, default 50%), `go test ./...`, `govulncheck` |
+| **Integration (Postgres)** | Live `PostgresNodeLog` against a Postgres 16 service (`test/integration/test_postgres_live.py`) |
+| **Integration (MinIO)** | Live `S3CAS` against MinIO (`test/integration/test_s3_minio_live.py`) |
 
 Local dependency audit (optional): `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q` after `pip install -e ".[dev]"`. Under GitHub Actions the dedicated **Security (pip-audit)** job is authoritative.
+
+#### Optional local integration services
+
+Postgres:
+
+```bash
+docker run -d --name trajir-pg \
+  -e POSTGRES_USER=trajir -e POSTGRES_PASSWORD=trajir -e POSTGRES_DB=trajir \
+  -p 5432:5432 postgres:16.6
+export TRAJIR_DATABASE_URL=postgresql://trajir:trajir@localhost:5432/trajir
+pip install -e ".[dev,postgres]"
+pytest test/integration/test_postgres_live.py -q
+```
+
+MinIO:
+
+```bash
+docker run -d --name trajir-minio -p 9000:9000 \
+  -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+  quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z server /data
+export TRAJIR_S3_ENDPOINT_URL=http://127.0.0.1:9000
+export TRAJIR_S3_BUCKET=trajir
+export AWS_ACCESS_KEY_ID=minioadmin
+export AWS_SECRET_ACCESS_KEY=minioadmin
+pip install -e ".[dev,s3]"
+# create bucket once (Python one-liner or mc)
+python -c "from drivers.s3.cas import build_s3_client_from_env; c=build_s3_client_from_env(); c.create_bucket(Bucket='trajir')"
+pytest test/integration/test_s3_minio_live.py -q
+```
+
+Without these env vars, integration tests are skipped; unit fakes still cover offline CI Quality.
 
 Coverage floors and required check names: [docs/maintainer-branch-protection.md](docs/maintainer-branch-protection.md).
 

--- a/docs/PHASE_1A_STATUS.md
+++ b/docs/PHASE_1A_STATUS.md
@@ -20,7 +20,7 @@ Honest inventory of what is **on `main`** versus what remains **out of scope** o
 | Redaction (R08 + export) | `runtime/redact.py`, Go `trajir/redact` |
 | Go IR stack | `go/trajir/*` — nodes, log, effects, durable, Temporal, resume, client, cas |
 | Demos / host example | `examples/kill-mid-deploy/`, `examples/host_loop/`, Go kill-mid-deploy |
-| CI | DCO, Quality (3.11/3.12: ruff, mypy, unit coverage floor, e2e, conformance), Package smoke, Security (pip-audit), Go (trajir coverage floor + tests + govulncheck) |
+| CI | Phase A: DCO, Quality, Package smoke, Security (pip-audit), Go; Phase B: Integration (Postgres), Integration (MinIO) |
 
 ### Conformance (README §10)
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -36,6 +36,11 @@ Match the names shown in the Actions UI (Phase A, issue #81):
 5. `Security (pip-audit)` — first-class dependency audit (not only a unit test)
 6. `Go` — trajir coverage floor, full `go test ./...`, `govulncheck`
 
+Optional after Phase B is proven stable (issue #85):
+
+7. `Integration (Postgres)`
+8. `Integration (MinIO)`
+
 If GitHub shows a slightly different label, use the exact string from the check run.
 
 Also enable org/repo **secret scanning** and **push protection** when available

--- a/drivers/postgres/log.py
+++ b/drivers/postgres/log.py
@@ -92,6 +92,28 @@ class PostgresNodeLog:
                 )
             self._conn.commit()
 
+    def _slot_owner_id(
+        self,
+        cur: Any,
+        *,
+        tenant_id: str,
+        trajectory_id: str,
+        step_n: int | None,
+        seq: int,
+        kind: str,
+    ) -> str | None:
+        cur.execute(
+            """
+            SELECT id FROM nodes
+            WHERE tenant_id = %s AND trajectory_id = %s
+              AND COALESCE(step_n, -1) = COALESCE(%s, -1)
+              AND seq = %s AND kind = %s
+            """,
+            (tenant_id, trajectory_id, step_n, seq, kind),
+        )
+        row = cur.fetchone()
+        return row[0] if row is not None else None
+
     def append(
         self,
         kind: str,
@@ -101,6 +123,16 @@ class PostgresNodeLog:
         tenant_id: str,
         seq: int,
     ) -> Node:
+        """Append a node; match SQLite NodeLog slot conflict semantics.
+
+        Postgres only ignores primary key conflicts with ``ON CONFLICT (id)``.
+        A different payload at the same logical slot hits ``idx_nodes_slot`` and
+        must become :class:`SlotConflictError` (SQLite ``INSERT OR IGNORE`` +
+        post-check does the same).
+        """
+        # Import here so the module loads without psycopg installed.
+        from psycopg.errors import UniqueViolation
+
         node = Node(
             kind=kind,
             trajectory_id=trajectory_id,
@@ -110,42 +142,59 @@ class PostgresNodeLog:
             payload=payload,
         )
         with self._lock:
-            with self._conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO nodes
-                    (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (id) DO NOTHING
-                    """,
-                    (
-                        node.id,
-                        node.trajectory_id,
-                        node.tenant_id,
-                        node.step_n,
-                        node.seq,
-                        node.kind,
-                        json.dumps(node.payload),
-                        node.ts,
-                    ),
-                )
-                cur.execute(
-                    """
-                    SELECT id FROM nodes
-                    WHERE tenant_id = %s AND trajectory_id = %s
-                      AND COALESCE(step_n, -1) = COALESCE(%s, -1)
-                      AND seq = %s AND kind = %s
-                    """,
-                    (tenant_id, trajectory_id, step_n, seq, kind),
-                )
-                row = cur.fetchone()
-                if row is not None and row[0] != node.id:
-                    self._conn.rollback()
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO nodes
+                        (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (id) DO NOTHING
+                        """,
+                        (
+                            node.id,
+                            node.trajectory_id,
+                            node.tenant_id,
+                            node.step_n,
+                            node.seq,
+                            node.kind,
+                            json.dumps(node.payload),
+                            node.ts,
+                        ),
+                    )
+                    owner = self._slot_owner_id(
+                        cur,
+                        tenant_id=tenant_id,
+                        trajectory_id=trajectory_id,
+                        step_n=step_n,
+                        seq=seq,
+                        kind=kind,
+                    )
+                    if owner is not None and owner != node.id:
+                        self._conn.rollback()
+                        raise SlotConflictError(
+                            f"slot conflict trajectory={trajectory_id!r} step={step_n} "
+                            f"seq={seq} kind={kind!r}: different payload already stored"
+                        )
+                self._conn.commit()
+            except UniqueViolation:
+                # Slot unique index fired (different content id, same slot).
+                self._conn.rollback()
+                with self._conn.cursor() as cur:
+                    owner = self._slot_owner_id(
+                        cur,
+                        tenant_id=tenant_id,
+                        trajectory_id=trajectory_id,
+                        step_n=step_n,
+                        seq=seq,
+                        kind=kind,
+                    )
+                if owner is not None and owner != node.id:
                     raise SlotConflictError(
                         f"slot conflict trajectory={trajectory_id!r} step={step_n} "
                         f"seq={seq} kind={kind!r}: different payload already stored"
-                    )
-            self._conn.commit()
+                    ) from None
+                # Same id concurrent insert or unexpected unique path: treat as ok.
         return node
 
     def claim_tool_call(

--- a/drivers/s3/cas.py
+++ b/drivers/s3/cas.py
@@ -165,12 +165,15 @@ def build_s3_client_from_env() -> Any:
     * ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` (default ``us-east-1``)
     * ``TRAJIR_S3_ENDPOINT_URL`` optional custom endpoint (MinIO, LocalStack)
 
+    When ``TRAJIR_S3_ENDPOINT_URL`` is set, path-style addressing is used so
+    MinIO and LocalStack work without virtual-hosted DNS.
+
     Raises:
         ImportError: if boto3 is not installed
-        ValueError: if required configuration is missing in a strict way
     """
     try:
         import boto3
+        from botocore.client import Config
     except ImportError as exc:
         raise ImportError(
             "boto3 is required for S3CAS production use; pip install boto3 "
@@ -179,4 +182,9 @@ def build_s3_client_from_env() -> Any:
 
     region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
     endpoint = os.environ.get("TRAJIR_S3_ENDPOINT_URL") or None
-    return boto3.client("s3", region_name=region, endpoint_url=endpoint)
+    kwargs: dict[str, Any] = {"region_name": region}
+    if endpoint:
+        kwargs["endpoint_url"] = endpoint
+        # Path style is required for many local S3 implementations.
+        kwargs["config"] = Config(signature_version="s3v4", s3={"addressing_style": "path"})
+    return boto3.client("s3", **kwargs)

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Live integration tests (Postgres, MinIO). Skipped unless service env is set."""

--- a/test/integration/test_postgres_live.py
+++ b/test/integration/test_postgres_live.py
@@ -1,0 +1,77 @@
+"""Live Postgres NodeLog tests. Require TRAJIR_DATABASE_URL + psycopg."""
+
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+
+import pytest
+
+pytest.importorskip("psycopg")
+
+from drivers.postgres.log import open_postgres_node_log
+from trajectory_ir.runtime.log import SlotConflictError
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TRAJIR_DATABASE_URL"),
+    reason="Set TRAJIR_DATABASE_URL to run live Postgres integration",
+)
+
+
+@pytest.fixture
+def log():
+    node_log = open_postgres_node_log()
+    yield node_log
+    node_log.close()
+
+
+def test_live_append_has_list_and_idempotent(log):
+    traj = f"live-{uuid.uuid4().hex[:12]}"
+    n1 = log.append("DECISION", 1, {"plan": "x"}, traj, "demo", 1)
+    n2 = log.append("DECISION", 1, {"plan": "x"}, traj, "demo", 1)
+    assert n1.id == n2.id
+    assert log.has(traj, 1, "DECISION")
+    rows = log.list_nodes(traj, tenant_id="demo")
+    assert len(rows) == 1
+    assert rows[0]["id"] == n1.id
+    assert log.count(n1.id) == 1
+
+
+def test_live_slot_conflict(log):
+    traj = f"live-conflict-{uuid.uuid4().hex[:12]}"
+    log.append("DECISION", 1, {"plan": "a"}, traj, "demo", 1)
+    with pytest.raises(SlotConflictError):
+        log.append("DECISION", 1, {"plan": "b"}, traj, "demo", 1)
+
+
+def test_live_tenant_isolation(log):
+    traj = f"live-tenant-{uuid.uuid4().hex[:12]}"
+    log.append("DECISION", 1, {"plan": "a"}, traj, "tenant-a", 1)
+    log.append("DECISION", 1, {"plan": "b"}, traj, "tenant-b", 2)
+    only_a = log.list_nodes(traj, tenant_id="tenant-a")
+    assert len(only_a) == 1
+    assert only_a[0]["tenant_id"] == "tenant-a"
+
+
+def test_live_claim_tool_call_single_winner(log):
+    traj = f"live-claim-{uuid.uuid4().hex[:12]}"
+    wins: list[bool] = []
+
+    def worker() -> None:
+        claimed = log.claim_tool_call(
+            1,
+            {"tool": "deploy", "args": {"v": "1"}},
+            traj,
+            "demo",
+            2,
+        )
+        wins.append(claimed)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(1 for w in wins if w) == 1
+    assert log.has(traj, 1, "TOOL_CALL", seq=2)

--- a/test/integration/test_s3_minio_live.py
+++ b/test/integration/test_s3_minio_live.py
@@ -1,0 +1,88 @@
+"""Live S3 CAS tests against MinIO or any S3 compatible endpoint.
+
+Requires:
+
+* ``TRAJIR_S3_ENDPOINT_URL`` (e.g. http://127.0.0.1:9000)
+* ``TRAJIR_S3_BUCKET`` (bucket must exist or be creatable)
+* ``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``
+* optional ``AWS_REGION`` (default us-east-1)
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytest.importorskip("boto3")
+
+from drivers.s3.cas import S3CAS, build_s3_client_from_env
+from trajectory_ir.storage.cas import CASIntegrityError, CASNotFoundError, content_hash
+from trajectory_ir.storage.rehydrate import rehydrate_artifacts
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TRAJIR_S3_ENDPOINT_URL") or not os.environ.get("TRAJIR_S3_BUCKET"),
+    reason="Set TRAJIR_S3_ENDPOINT_URL and TRAJIR_S3_BUCKET for MinIO/S3 integration",
+)
+
+
+@pytest.fixture(scope="module")
+def bucket() -> str:
+    return os.environ["TRAJIR_S3_BUCKET"]
+
+
+@pytest.fixture(scope="module")
+def client(bucket: str):
+    client = build_s3_client_from_env()
+    # Ensure bucket exists (idempotent for MinIO).
+    try:
+        client.head_bucket(Bucket=bucket)
+    except Exception:
+        client.create_bucket(Bucket=bucket)
+    return client
+
+
+@pytest.fixture
+def store(client, bucket: str) -> S3CAS:
+    return S3CAS(client, bucket, key_prefix=f"ci/{uuid.uuid4().hex[:8]}")
+
+
+def test_live_put_get_has_roundtrip(store: S3CAS):
+    data = b"minio live artifact " + uuid.uuid4().bytes
+    h = store.put(data)
+    assert h == content_hash(data)
+    assert store.has(h)
+    assert store.get(h) == data
+    assert store.uri_for(h).startswith(f"s3://{store.bucket}/")
+
+
+def test_live_put_idempotent(store: S3CAS):
+    data = b"same-bytes"
+    h1 = store.put(data)
+    h2 = store.put(data)
+    assert h1 == h2
+
+
+def test_live_get_missing(store: S3CAS):
+    h = content_hash(b"not-uploaded-" + uuid.uuid4().bytes)
+    with pytest.raises(CASNotFoundError):
+        store.get(h)
+    assert store.has(h) is False
+
+
+def test_live_rehydrate(store: S3CAS):
+    h = store.put(b"rehydrate-me")
+    got = rehydrate_artifacts(
+        store,
+        [{"content_hash": h, "logical_path": "out.bin"}],
+    )
+    assert got[h] == b"rehydrate-me"
+
+
+def test_live_get_detects_tamper(store: S3CAS, client, bucket: str):
+    h = store.put(b"honest")
+    key = store.object_key(h)
+    client.put_object(Bucket=bucket, Key=key, Body=b"tampered")
+    with pytest.raises(CASIntegrityError):
+        store.get(h)


### PR DESCRIPTION
## Summary

CI Phase B (issue #85): prove Postgres NodeLog and S3 CAS against real services without changing Phase A jobs.

1. **Integration (Postgres)** job with `postgres:16.6` service and live tests
2. **Integration (MinIO)** job starting MinIO via Docker and live `S3CAS` tests
3. `test/integration/` suite skips offline (unit fakes unchanged)
4. `build_s3_client_from_env` uses path-style addressing when `TRAJIR_S3_ENDPOINT_URL` is set
5. CONTRIBUTING local docker one-liners; optional required checks documented

## Related issues

Closes #85

## How I tested

`ash
pip install -e ".[dev]"
pytest test/unit -q --cov=trajectory_ir --cov=drivers --cov=client --cov-fail-under=80
pytest test/integration -q   # all skipped without service env
ruff check pkg drivers client test conformance examples
`

Live services are validated in GitHub Actions on this PR.

## Checklist

* [x] Commits are DCO signed
* [x] Change matches the master README (no invented APIs)
* [x] Relevant checks pass locally
* [x] AI assistance disclosed below

## Safety areas

* [x] No (CI + S3 client env helper only)

## AI assistance (if any)

Assisted with Grok for workflow and integration tests; review integration job isolation from Phase A.