### PR TITLE
fix: Go effect classifier fails closed on openWorldHint

### DIFF
--- a/go/trajir/effects/effects.go
+++ b/go/trajir/effects/effects.go
@@ -34,11 +34,13 @@ func ClassifyFromMCP(annotations map[string]any) EffectClass {
 	readOnly, hasReadOnly := asBool(annotations["readOnlyHint"])
 	destructive, hasDestructive := asBool(annotations["destructiveHint"])
 	idempotent, hasIdempotent := asBool(annotations["idempotentHint"])
+	openWorld, hasOpenWorld := asBool(annotations["openWorldHint"])
 
 	if hasReadOnly && readOnly && !(hasDestructive && destructive) {
 		return READ_ONLY
 	}
-	if hasReadOnly && !readOnly && hasIdempotent && idempotent && hasDestructive && !destructive {
+	// openWorldHint=true without a clear safe profile stays fail-closed below.
+	if hasReadOnly && !readOnly && hasIdempotent && idempotent && hasDestructive && !destructive && !(hasOpenWorld && openWorld) {
 		return IDEMPOTENT_WRITE
 	}
 	return NON_IDEMPOTENT_WRITE

--- a/go/trajir/effects/effects_test.go
+++ b/go/trajir/effects/effects_test.go
@@ -57,6 +57,30 @@ func TestExplicitIdempotentWrite(t *testing.T) {
 	}
 }
 
+func TestOpenWorldFailsClosedEvenIfIdempotent(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{
+		"readOnlyHint":    false,
+		"idempotentHint":  true,
+		"destructiveHint": false,
+		"openWorldHint":   true,
+	})
+	if got != effects.NON_IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)
+	}
+}
+
+func TestOpenWorldFalseStillAllowsIdempotentWrite(t *testing.T) {
+	got := effects.ClassifyFromMCP(map[string]any{
+		"readOnlyHint":    false,
+		"idempotentHint":  true,
+		"destructiveHint": false,
+		"openWorldHint":   false,
+	})
+	if got != effects.IDEMPOTENT_WRITE {
+		t.Fatalf("got %s, want IDEMPOTENT_WRITE", got)
+	}
+}
+
 func TestDestructiveFailsClosedEvenIfIdempotent(t *testing.T) {
 	got := effects.ClassifyFromMCP(map[string]any{
 		"readOnlyHint":    false,


### PR DESCRIPTION
## Summary

Fixes #98.

`ClassifyFromMCP` in `go/trajir/effects/effects.go` was missing the `openWorldHint` check that `classify.py` has. An open world tool that self-reports `idempotentHint: true` could get classified `IDEMPOTENT_WRITE` in Go, skipping the block-and-gate NodeLog claim on resume, while the same annotations correctly stay `NON_IDEMPOTENT_WRITE` in Python.

## Change

- Added the `openWorldHint` conjunct to the `IDEMPOTENT_WRITE` branch so it matches the Python rule: `openWorldHint` must not be `true` for a tool to qualify as `IDEMPOTENT_WRITE`.
- Added two tests: one confirming `openWorldHint: true` fails closed to `NON_IDEMPOTENT_WRITE` even with idempotent/non-destructive/non-readonly hints set, and one confirming `openWorldHint: false` still allows `IDEMPOTENT_WRITE` as before.

## Test plan

- [x] `go test ./trajir/effects/...` passes, including the two new cases
- [x] Existing classifier tests still pass, no behavior change for inputs that don't set `openWorldHint`