### PR TITLE
fix: log TOOL_CALL and TOOL_RESULT nodes for non-gated tool calls

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -112,9 +112,27 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool, seq: 
             tool_name=tool.name,
             tool_fn=tool.fn,
         )
+        result = fn(**call["args"])
     else:
-        fn = tool.fn
-    result = fn(**call["args"])
+        # Not claim-gated, but still needs IR history audit; gate path
+        # already logs its own TOOL_CALL/TOOL_RESULT nodes.
+        result = tool.fn(**call["args"])
+        log.append(
+            "TOOL_CALL",
+            step_n,
+            {"tool": tool.name, "args": call["args"]},
+            trajectory.trajectory_id,
+            trajectory.tenant_id,
+            seq=seq,
+        )
+        log.append(
+            "TOOL_RESULT",
+            step_n,
+            {"result": result},
+            trajectory.trajectory_id,
+            trajectory.tenant_id,
+            seq=seq + 1,
+        )
     return ToolResult(step_n=step_n, result=result)
 
 

--- a/test/unit/test_client_sdk_plain_tool_logging.py
+++ b/test/unit/test_client_sdk_plain_tool_logging.py
@@ -1,0 +1,36 @@
+from client.python.trajectory_client import exec_tool, open_trajectory
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.tool import Tool
+
+
+def test_exec_tool_logs_tool_call_and_result_for_non_gated_tool(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db_path = str(tmp_path / "test_plain_tool_logging.sqlite")
+    traj = open_trajectory(tenant_id="demo", trajectory_id="plain-1", db_path=db_path)
+
+    tool = Tool(name="double", fn=lambda x: x * 2, effect_class=EffectClass.IDEMPOTENT_WRITE)
+    result = exec_tool(traj, step_n=1, call={"args": {"x": 5}}, tool=tool, seq=2)
+
+    assert result.result == 10
+    log = NodeLog(db_path)
+    assert log.has("plain-1", 1, "TOOL_CALL", seq=2)
+    assert log.has("plain-1", 1, "TOOL_RESULT", seq=3)
+
+
+def test_exec_tool_logs_two_plain_tools_same_step_distinct_seq(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db_path = str(tmp_path / "test_plain_tool_logging_multi.sqlite")
+    traj = open_trajectory(tenant_id="demo", trajectory_id="plain-2", db_path=db_path)
+
+    tool_a = Tool(name="incr", fn=lambda x: x + 1, effect_class=EffectClass.PURE)
+    tool_b = Tool(name="square", fn=lambda x: x * x, effect_class=EffectClass.PURE)
+
+    exec_tool(traj, step_n=1, call={"args": {"x": 1}}, tool=tool_a, seq=2)
+    exec_tool(traj, step_n=1, call={"args": {"x": 3}}, tool=tool_b, seq=4)
+
+    log = NodeLog(db_path)
+    assert log.has("plain-2", 1, "TOOL_CALL", seq=2)
+    assert log.has("plain-2", 1, "TOOL_RESULT", seq=3)
+    assert log.has("plain-2", 1, "TOOL_CALL", seq=4)
+    assert log.has("plain-2", 1, "TOOL_RESULT", seq=5)


### PR DESCRIPTION
## Problem

`exec_tool` in `client/python/trajectory_client.py` only appended TOOL_CALL and TOOL_RESULT nodes on the block-and-gate path, which only covers NON_IDEMPOTENT_WRITE calls. Anything classified PURE, READ_ONLY, or IDEMPOTENT_WRITE ran through `fn(**call["args"])` directly with no node log write at all, so those calls left no trace in the IR history.

## Fix

The non-gated branch now appends TOOL_CALL at `seq` and TOOL_RESULT at `seq + 1`, mirroring the slot layout the gated path already uses in `resume/step.py`. Every tool call is now represented in the log regardless of effect class.

## Testing

Added `test/unit/test_client_sdk_plain_tool_logging.py` covering a single non-gated call and two non-gated calls in the same step with distinct seq slots. Full `test/unit` suite passes locally (98 passed, 2 skipped, unrelated to this change).

Closes #89

Some portions of this fix were drafted with AI assistance and reviewed before submission.