### PR TITLE
fix: force CONSTRAINT into always_include_kinds on every policy

### DIFF
--- a/pkg/trajectory_ir/runtime/policy.py
+++ b/pkg/trajectory_ir/runtime/policy.py
@@ -51,6 +51,12 @@ class ProjectorPolicy:
             raise PolicyError("default_budget must be non-negative")
         if not self.always_include_kinds:
             raise PolicyError("always_include_kinds must be non-empty")
+        if "CONSTRAINT" not in self.always_include_kinds:
+            # CONSTRAINT must always survive projection (README §4); a
+            # policy that omits it is a footgun, not a real customization.
+            object.__setattr__(
+                self, "always_include_kinds", self.always_include_kinds | {"CONSTRAINT"}
+            )
 
 
 def default_projector_policy() -> ProjectorPolicy:

--- a/test/unit/test_projector_policy_constraint_guard.py
+++ b/test/unit/test_projector_policy_constraint_guard.py
@@ -1,0 +1,18 @@
+from trajectory_ir.runtime.policy import ProjectorPolicy, policy_from_mapping
+
+
+def test_direct_construction_without_constraint_still_includes_it():
+    policy = ProjectorPolicy(always_include_kinds=frozenset({"DECISION"}))
+    assert "CONSTRAINT" in policy.always_include_kinds
+    assert "DECISION" in policy.always_include_kinds
+
+
+def test_policy_from_mapping_without_constraint_still_includes_it():
+    policy = policy_from_mapping({"always_include_kinds": ["DECISION"]})
+    assert "CONSTRAINT" in policy.always_include_kinds
+    assert "DECISION" in policy.always_include_kinds
+
+
+def test_policy_from_mapping_explicit_constraint_unaffected():
+    policy = policy_from_mapping({"always_include_kinds": ["CONSTRAINT", "DECISION"]})
+    assert policy.always_include_kinds == frozenset({"CONSTRAINT", "DECISION"})


### PR DESCRIPTION
## Problem

ProjectorPolicy checked that always_include_kinds was non-empty but never checked that CONSTRAINT was actually in it. A policy built with, say, always_include_kinds=frozenset({"DECISION"}), whether constructed directly or loaded through policy_from_mapping from a file that lists other kinds and omits CONSTRAINT, gets accepted unchanged. project_context then silently drops CONSTRAINT nodes for that policy instead of raising BudgetImpossible.

## Fix

__post_init__ now adds CONSTRAINT to always_include_kinds whenever it's missing, using object.__setattr__ since the dataclass is frozen. This covers both direct construction and policy_from_mapping, since the latter always goes through the ProjectorPolicy constructor.

## Testing

Added test/unit/test_projector_policy_constraint_guard.py covering direct construction without CONSTRAINT, policy_from_mapping without CONSTRAINT, and the explicit-CONSTRAINT case staying unaffected. Full test/unit suite passes locally (99 passed, 2 skipped, unrelated to this change).

Closes #90

Some portions of this fix were drafted with AI assistance and reviewed before submission.