### PR TITLE
docs: label Memory and LocalSQLite as durable backend test fakes

### DIFF
--- a/go/trajir/durable/doc.go
+++ b/go/trajir/durable/doc.go
@@ -2,10 +2,14 @@
 //
 // Decision (issue #16)
 //
-//	Coding default: LocalSQLite (and Memory for pure unit tests).
-//	It memoizes step results by workflow id and step key so re-entry skips
-//	re-running model inference and tools. No separate Temporal or Restate
-//	server is required for Phase 1B Go development.
+//	Coding default: LocalSQLite (and Memory for pure unit tests). Both are
+//	test fakes: a hand rolled first writer wins memoization store, not an
+//	integration with a real durable execution engine. They memoize step
+//	results by workflow id and step key so re-entry skips re-running model
+//	inference and tools, which is enough for Phase 1B Go development and
+//	the current conformance suite, but neither should be treated as a
+//	production backend. See issue #92 for the open question on wiring
+//	trajir/durable into a real DBOS or Restate client, tracked alongside #67.
 //
 //	Production target: Temporal as the first full Go adapter
 //	(go/trajir/durable/temporal, issue #24). Restate remains a welcome

--- a/go/trajir/durable/memory.go
+++ b/go/trajir/durable/memory.go
@@ -5,7 +5,8 @@ import (
 	"sync"
 )
 
-// Memory is an in process Backend. Fine for unit tests. Does not survive process exit.
+// Memory is a test fake Backend, not a durable execution engine integration.
+// Fine for unit tests. Does not survive process exit. See issue #92.
 type Memory struct {
 	mu   sync.Mutex
 	data map[string][]byte

--- a/go/trajir/durable/sqlite.go
+++ b/go/trajir/durable/sqlite.go
@@ -9,9 +9,11 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// LocalSQLite is the Phase 1B coding default Backend. Step memos survive
-// process restart when the same database path is reopened (needed for crash
-// style tests later).
+// LocalSQLite is the Phase 1B coding default Backend. It is a test fake, a
+// hand rolled first writer wins memoization store, not an integration with a
+// real durable execution engine; see issue #92. Step memos survive process
+// restart when the same database path is reopened (needed for crash style
+// tests later).
 type LocalSQLite struct {
 	db *sql.DB
 	mu sync.Mutex


### PR DESCRIPTION
## Problem

go/trajir/durable/backend.go, memory.go, and sqlite.go implement a first writer wins step memoization engine from scratch, backed by an in process map or a SQLite table. Neither DBOS nor Restate shows up anywhere in that package, but the package doc only described the coding default without saying plainly that Memory and LocalSQLite are test fakes rather than a real durable execution backend integration. crashagent, kill-mid-deploy, and the Go R01/R02 conformance tests all run against this hand rolled store through durable.OpenLocal, and that isn't obvious without reading the implementation.

This issue itself doesn't propose a specific code fix, it flags the backend strategy decision for triage alongside #67. Wiring trajir/durable into a real DBOS or Restate client is a separate, larger decision that shouldn't happen inside a documentation PR.

## Fix

Documentation only change. doc.go, memory.go, and sqlite.go now say explicitly that Memory and LocalSQLite are test fakes, not a production backend, and point at this issue for the open wiring question. No functional code changed.

## Testing

go build ./... and go test ./trajir/durable/... both pass locally with no behavior change.

Closes #92

Some portions of this fix were drafted with AI assistance and reviewed before submission.