### PR TITLE
fix: fail closed on artifact manifest entries missing content_hash

### DIFF
--- a/pkg/trajectory_ir/storage/artifacts.py
+++ b/pkg/trajectory_ir/storage/artifacts.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 from typing import Any
 
 from trajectory_ir.package.tir import ArtifactRef
-from trajectory_ir.storage.cas import CAS, CASNotFoundError, content_hash, normalize_content_hash
+from trajectory_ir.storage.cas import (
+    CAS,
+    CASError,
+    CASNotFoundError,
+    content_hash,
+    normalize_content_hash,
+)
 
 
 def put_artifact(
@@ -74,7 +80,7 @@ def ensure_artifacts_in_cas(
     for entry in artifacts_manifest:
         raw = entry.get("content_hash")
         if raw is None:
-            continue
+            raise CASError("artifact manifest entry missing content_hash")
         h = normalize_content_hash(str(raw))
         if not store.has(h):
             missing.append(h)

--- a/test/unit/test_ensure_artifacts_fail_closed.py
+++ b/test/unit/test_ensure_artifacts_fail_closed.py
@@ -1,0 +1,39 @@
+"""ensure_artifacts_in_cas must fail closed on a manifest entry missing content_hash."""
+
+from __future__ import annotations
+
+import pytest
+
+from trajectory_ir.storage import CASError, FileSystemCAS, ensure_artifacts_in_cas
+
+
+def test_missing_content_hash_raises_cas_error(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    manifest = [{"logical_path": "out.bin"}]  # no content_hash key
+
+    with pytest.raises(CASError):
+        ensure_artifacts_in_cas(cas, manifest)
+
+
+def test_null_content_hash_raises_cas_error(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    manifest = [{"logical_path": "out.bin", "content_hash": None}]
+
+    with pytest.raises(CASError):
+        ensure_artifacts_in_cas(cas, manifest)
+
+
+def test_missing_content_hash_raises_even_when_require_all_false(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    manifest = [{"logical_path": "out.bin"}]
+
+    with pytest.raises(CASError):
+        ensure_artifacts_in_cas(cas, manifest, require_all=False)
+
+
+def test_present_content_hash_passes(tmp_path):
+    cas = FileSystemCAS(tmp_path / "cas")
+    h = cas.put(b"payload")
+    manifest = [{"logical_path": "out.bin", "content_hash": h}]
+
+    ensure_artifacts_in_cas(cas, manifest)


### PR DESCRIPTION
## Problem

ensure_artifacts_in_cas skipped any manifest entry whose content_hash was None instead of raising. rehydrate_artifacts raises CASError for the exact same shape of entry, so the two functions disagreed.

ensure_artifacts_in_cas is the fail closed pre-check export_tir(mode="thin", cas=...) relies on to guarantee a thin package never claims an artifact the store cannot actually serve. ArtifactRef is a plain dataclass with no field validation, so building one with content_hash=None and passing it through export succeeded silently instead of raising CASNotFoundError. The failure only showed up later, at rehydrate time, on a completely different code path.

## Fix

ensure_artifacts_in_cas now raises CASError the same way rehydrate_artifacts does when content_hash is missing from an entry, regardless of require_all, since a missing content_hash is a manifest shape problem rather than a "hash not found in store" case.

## Testing

Added test/unit/test_ensure_artifacts_fail_closed.py covering a missing key, an explicit None value, the require_all=False case, and the passing case with a real hash. Full test/unit suite passes locally (100 passed, 2 skipped, unrelated to this change).

Closes #93

Some portions of this fix were drafted with AI assistance and reviewed before submission.