### PR TITLE
fix: close NodeLog's SQLite connection on garbage collection

### DIFF
--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -253,3 +253,16 @@ class NodeLog:
     def close(self):
         with self._lock:
             self._conn.close()
+
+    def __del__(self):
+        # Client SDK call sites construct a fresh NodeLog per function call
+        # and never close it explicitly. Without this, connections only get
+        # released whenever the garbage collector happens to get to them,
+        # which over a long running agent session means an unbounded number
+        # of open SQLite connections. This is a best-effort backstop, not a
+        # substitute for callers using close()/a context manager when they
+        # can.
+        try:
+            self._conn.close()
+        except Exception:
+            pass

--- a/test/unit/test_node_log_connection_cleanup.py
+++ b/test/unit/test_node_log_connection_cleanup.py
@@ -1,0 +1,32 @@
+"""NodeLog must release its SQLite connection when garbage collected."""
+
+from __future__ import annotations
+
+import gc
+import sqlite3
+
+import pytest
+
+from trajectory_ir.runtime.log import NodeLog
+
+
+def test_del_closes_connection_when_log_goes_out_of_scope(tmp_path):
+    db_path = str(tmp_path / "cleanup.sqlite")
+    log = NodeLog(db_path)
+    log.append("DECISION", 1, {"plan": {}}, "t1", "demo", seq=1)
+    conn = log._conn
+
+    del log
+    gc.collect()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+def test_del_after_explicit_close_does_not_raise(tmp_path):
+    db_path = str(tmp_path / "cleanup_explicit.sqlite")
+    log = NodeLog(db_path)
+    log.close()
+
+    del log
+    gc.collect()


### PR DESCRIPTION
## Problem

project(), seal_decision(), exec_tool(), and commit_step() in client/python/trajectory_client.py each construct a fresh NodeLog(trajectory.db_path) inline and never close it. NodeLog.__init__ opens a raw sqlite3.connect(db_path, check_same_thread=False). NodeLog has no __enter__/__exit__ and no __del__, so there is no deterministic cleanup, connections just sit around until the garbage collector gets to them.

A long running agent driving many steps through the client SDK ends up opening a brand new SQLite connection on basically every call with nothing ever closing them. Over a long session that risks file descriptor exhaustion or stray SQLite lock state.

## Fix

Added __del__ to NodeLog so CPython's reference counting closes the connection promptly whenever a NodeLog object goes out of scope, wrapped in a try/except since __del__ running during interpreter shutdown can hit already finalized state. This is a backstop that fixes the leak without needing every client SDK call site to be rewritten to reuse a single NodeLog instance. Callers that already call close() explicitly are unaffected, closing twice is safe.

## Testing

Added test/unit/test_node_log_connection_cleanup.py: one test drops the last reference to a NodeLog, forces gc.collect(), and asserts the underlying connection raises sqlite3.ProgrammingError on further use; another confirms __del__ after an explicit close() doesn't raise. Full test/unit suite passes locally (98 passed, 2 skipped, unrelated to this change).

Closes #94

Some portions of this fix were drafted with AI assistance and reviewed before submission.