### PR TITLE
fix: write .tir packages atomically instead of straight to dest_path

### DIFF
--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import tempfile
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -318,20 +320,33 @@ def export_tir(
     if dest_path.suffix != ".tir":
         dest_path = dest_path.with_suffix(".tir")
 
-    with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True) + "\n")
-        zf.writestr("COMPAT.json", json.dumps(COMPAT, indent=2, sort_keys=True) + "\n")
-        zf.writestr("seals.json", json.dumps(seals, indent=2, sort_keys=True) + "\n")
-        zf.writestr(
-            "artifacts-manifest.json",
-            json.dumps(artifacts_manifest, indent=2, sort_keys=True) + "\n",
-        )
-        ndjson = "".join(json.dumps(n, sort_keys=True) + "\n" for n in nodes)
-        zf.writestr("nodes.ndjson", ndjson)
-        if mode == "fat":
-            for h, data in artifact_bytes.items():
-                shard = h[:2]
-                zf.writestr(f"artifacts/cas/{shard}/{h}", data)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{dest_path.name}.", dir=str(dest_path.parent))
+    try:
+        with os.fdopen(fd, "wb") as raw:
+            with zipfile.ZipFile(raw, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                zf.writestr("manifest.json", json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+                zf.writestr("COMPAT.json", json.dumps(COMPAT, indent=2, sort_keys=True) + "\n")
+                zf.writestr("seals.json", json.dumps(seals, indent=2, sort_keys=True) + "\n")
+                zf.writestr(
+                    "artifacts-manifest.json",
+                    json.dumps(artifacts_manifest, indent=2, sort_keys=True) + "\n",
+                )
+                ndjson = "".join(json.dumps(n, sort_keys=True) + "\n" for n in nodes)
+                zf.writestr("nodes.ndjson", ndjson)
+                if mode == "fat":
+                    for h, data in artifact_bytes.items():
+                        shard = h[:2]
+                        zf.writestr(f"artifacts/cas/{shard}/{h}", data)
+            raw.flush()
+            os.fsync(raw.fileno())
+        os.replace(tmp_name, dest_path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
     return dest_path
 

--- a/test/unit/test_tir_export_atomic_write.py
+++ b/test/unit/test_tir_export_atomic_write.py
@@ -1,0 +1,76 @@
+"""export_tir must never leave a partially written .tir file at dest_path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trajectory_ir.package import export_tir, load_tir
+from trajectory_ir.runtime.log import NodeLog
+
+
+@pytest.fixture
+def sample_log(tmp_path: Path) -> NodeLog:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    log = NodeLog(str(src_dir / "src.sqlite"))
+    log.append(
+        "PROJECT_CONTEXT",
+        1,
+        {"goal": "demo"},
+        trajectory_id="t-atomic",
+        tenant_id="demo",
+        seq=0,
+    )
+    log.append(
+        "DECISION",
+        1,
+        {"plan": {"tool_calls": []}},
+        trajectory_id="t-atomic",
+        tenant_id="demo",
+        seq=1,
+    )
+    return log
+
+
+def test_export_writes_no_temp_file_left_behind(tmp_path, sample_log):
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    dest = export_dir / "run.tir"
+    export_tir(sample_log, "t-atomic", dest, mode="fat", tenant_id="demo")
+
+    assert dest.is_file()
+    leftovers = [p for p in dest.parent.iterdir() if p != dest]
+    assert leftovers == []
+
+
+def test_export_does_not_touch_existing_dest_on_failure(tmp_path, sample_log, monkeypatch):
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    dest = export_dir / "run.tir"
+    export_tir(sample_log, "t-atomic", dest, mode="fat", tenant_id="demo")
+    original_bytes = dest.read_bytes()
+
+    import zipfile
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated crash mid export")
+
+    monkeypatch.setattr(zipfile.ZipFile, "writestr", boom)
+
+    with pytest.raises(RuntimeError):
+        export_tir(sample_log, "t-atomic", dest, mode="fat", tenant_id="demo")
+
+    # dest_path must still hold the last good export, not a truncated file,
+    # and no stray temp file should remain next to it.
+    assert dest.read_bytes() == original_bytes
+    leftovers = [p for p in dest.parent.iterdir() if p != dest]
+    assert leftovers == []
+
+
+def test_exported_package_still_loads(tmp_path, sample_log):
+    dest = tmp_path / "run.tir"
+    export_tir(sample_log, "t-atomic", dest, mode="fat", tenant_id="demo")
+    pkg = load_tir(dest)
+    assert pkg.manifest["mode"] == "fat"


### PR DESCRIPTION
## Problem

export_tir wrote the zip straight to dest_path with zipfile.ZipFile(dest_path, "w", ...), no temp file, no os.replace. The CAS layer in storage/fs.py already does this correctly: write to a temp file, fsync, then atomic rename, specifically so readers never observe a partial object. Package export didn't follow the same pattern.

If the process got killed mid export, dest_path ended up holding a truncated zip. A caller that just checks dest_path.is_file() after calling export_tir would see what looks like a successful export but is actually a broken package. Re-exporting over an existing good package on a failed run could also clobber it with a partial file.

## Fix

export_tir now writes into a temp file created with tempfile.mkstemp in the same directory as dest_path, fsyncs it, and only calls os.replace once the zip is fully written and flushed. On any failure the temp file is cleaned up and dest_path is left untouched, matching what fs.py already does for CAS objects.

## Testing

Added test/unit/test_tir_export_atomic_write.py: one test confirms no temp file is left behind after a normal export, one monkeypatches zipfile.ZipFile.writestr to raise mid write and confirms an existing dest_path is left byte for byte unchanged with no stray temp file, and one confirms the exported package still loads normally. Full test/unit suite passes locally (99 passed, 2 skipped, unrelated to this change).

Closes #95

Some portions of this fix were drafted with AI assistance and reviewed before submission.