### PR TITLE
fix: propagate real errors from claim_tool_call instead of swallowing them

### DIFF
--- a/drivers/postgres/log.py
+++ b/drivers/postgres/log.py
@@ -206,6 +206,9 @@ class PostgresNodeLog:
         seq: int,
     ) -> bool:
         """Atomically claim a TOOL_CALL slot (single winner under concurrency)."""
+        # Import here so the module loads without psycopg installed.
+        from psycopg.errors import UniqueViolation
+
         node = Node(
             kind="TOOL_CALL",
             trajectory_id=trajectory_id,
@@ -249,10 +252,13 @@ class PostgresNodeLog:
                     )
                 self._conn.commit()
                 return True
+            except UniqueViolation:
+                self._conn.rollback()
+                # Another writer won the slot between our SELECT and INSERT.
+                return False
             except Exception:
                 self._conn.rollback()
-                # Unique violation: another writer won the slot.
-                return False
+                raise
 
     def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
         sql = "SELECT 1 FROM nodes WHERE trajectory_id = %s AND step_n = %s AND kind = %s"

--- a/test/unit/test_postgres_claim_tool_call_exception_narrowing.py
+++ b/test/unit/test_postgres_claim_tool_call_exception_narrowing.py
@@ -1,0 +1,110 @@
+"""Regression test for issue #96: claim_tool_call must not swallow non-conflict errors.
+
+Uses minimal purpose-built fakes (not test_postgres_node_log.py's _FakeStore)
+so this file stays self-contained and independently mergeable.
+"""
+
+from __future__ import annotations
+
+import pytest
+from psycopg.errors import UniqueViolation
+
+from drivers.postgres.log import PostgresNodeLog
+
+
+class _RaisingCursor:
+    def __init__(self, exc_to_raise: Exception) -> None:
+        self._exc_to_raise = exc_to_raise
+        self._select_done = False
+
+    def __enter__(self) -> _RaisingCursor:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, sql: str, params=None) -> None:
+        normalized = " ".join(sql.lower().split())
+        if (
+            normalized.startswith("create table")
+            or normalized.startswith("create unique index")
+            or normalized.startswith("create index")
+        ):
+            # PostgresNodeLog._ensure_schema DDL; no-op for this fake.
+            return
+        if normalized.startswith("select 1 from nodes"):
+            # No existing claimant: fall through to the INSERT attempt.
+            self._select_done = True
+            return
+        if normalized.startswith("insert into nodes"):
+            raise self._exc_to_raise
+        raise AssertionError(f"unexpected SQL in fake cursor: {sql!r}")
+
+    def fetchone(self):
+        return None
+
+
+class _RaisingConnection:
+    """Fake psycopg connection whose INSERT step raises a chosen exception."""
+
+    def __init__(self, exc_to_raise: Exception) -> None:
+        self._exc_to_raise = exc_to_raise
+        self.committed = 0
+        self.rolled_back = 0
+
+    def cursor(self):
+        return _RaisingCursor(self._exc_to_raise)
+
+    def commit(self) -> None:
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+    def close(self) -> None:
+        return None
+
+
+def _make_log(exc_to_raise: Exception) -> tuple[PostgresNodeLog, _RaisingConnection]:
+    conn = _RaisingConnection(exc_to_raise)
+    log = PostgresNodeLog(conn)
+    # _ensure_schema's DDL calls happened against the same fake cursor above,
+    # which only special-cases SELECT/INSERT INTO nodes; reset counters so
+    # assertions below only reflect claim_tool_call's own commit/rollback.
+    conn.committed = 0
+    conn.rolled_back = 0
+    return log, conn
+
+
+def test_claim_tool_call_returns_false_on_unique_violation():
+    """A genuine lost race (UniqueViolation) still returns False, not an exception."""
+    log, conn = _make_log(UniqueViolation("duplicate key"))
+
+    claimed = log.claim_tool_call(
+        step_n=1,
+        payload={"tool": "x"},
+        trajectory_id="t1",
+        tenant_id="demo",
+        seq=1,
+    )
+
+    assert claimed is False
+    assert conn.rolled_back == 1
+    assert conn.committed == 0
+
+
+def test_claim_tool_call_propagates_unrelated_exception():
+    """A dropped connection or other real error must not be silently swallowed as False."""
+    log, conn = _make_log(RuntimeError("connection dropped"))
+
+    with pytest.raises(RuntimeError, match="connection dropped"):
+        log.claim_tool_call(
+            step_n=1,
+            payload={"tool": "x"},
+            trajectory_id="t1",
+            tenant_id="demo",
+            seq=1,
+        )
+
+    assert conn.rolled_back == 1
+    assert conn.committed == 0


### PR DESCRIPTION
## Problem

`PostgresNodeLog.claim_tool_call` wrapped its SELECT-then-INSERT claim attempt in a bare `except Exception: rollback(); return False`. That means a genuine slot conflict (another worker already claimed the `TOOL_CALL` slot) and a real failure such as a dropped connection or a deadlock both produce the exact same observable result: `False`.

A caller receiving `False` reasonably concludes "another worker already claimed this, skip it." If the `False` actually came from a dropped connection mid-claim, the step gets silently skipped instead of the failure being surfaced, which is the opposite of the fail-closed behavior the rest of the node log relies on.

## Fix

Narrow the except clause in `drivers/postgres/log.py`'s `claim_tool_call` to catch only `psycopg.errors.UniqueViolation`, the actual signal for "lost the race" (mirrors the local-import pattern already used in `append()`). Any other exception now rolls back and re-raises, so real failures propagate instead of being reinterpreted as a lost claim.

## Testing

Added `test/unit/test_postgres_claim_tool_call_exception_narrowing.py` with minimal, self-contained fake connection/cursor objects (does not touch the existing `_FakeStore`/`_FakeCursor` in `test_postgres_node_log.py`):
- `test_claim_tool_call_returns_false_on_unique_violation`: a genuine `UniqueViolation` on the INSERT still returns `False`, preserving existing "lost the race" semantics.
- `test_claim_tool_call_propagates_unrelated_exception`: an unrelated exception (simulating a dropped connection) now propagates instead of being swallowed as `False`.

Full `test/unit` suite passes (98 passed, 2 skipped — the skips are pre-existing, gated on live Postgres/pip-audit).

Closes #96

---
This fix was developed with AI assistance (Claude Code) and reviewed by the author before submission.