### PR TITLE
fix: make resume() a tested, documented reattach instead of a silent stub

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -143,7 +143,27 @@ def resume(
     *,
     mode: RunMode | str = RunMode.LIVE,
 ) -> Trajectory:
+    """Reattach to a trajectory that already has node log history.
+
+    This SDK does not wrap steps in a durable workflow decorator the way
+    ``trajectory_ir.resume.step.make_run_step`` does; crash safety here comes
+    entirely from ``NodeLog`` being idempotent by content and from
+    ``exec_tool``'s block-and-gate claim on NON_IDEMPOTENT_WRITE tools
+    (README S8, R02). Re-driving the same step_n/seq calls against the same
+    db_path is what "resume" means at this layer, so there is no separate
+    replay step to run here beyond reconnecting to the log.
+
+    Unlike ``open_trajectory``, this raises if ``trajectory_id`` has no prior
+    nodes: resuming a trajectory with nothing to resume is almost always a
+    caller bug (wrong db_path or trajectory_id), and should fail loudly
+    rather than silently behave like ``open_trajectory``.
+    """
     init_backend(app_name=trajectory_id)
+    if not NodeLog(db_path).list_nodes_all_tenants(trajectory_id):
+        raise ValueError(
+            f"cannot resume trajectory_id={trajectory_id!r}: no existing nodes "
+            f"found in {db_path!r}; use open_trajectory() to start a new one"
+        )
     return Trajectory(
         trajectory_id=trajectory_id,
         tenant_id=tenant_id,

--- a/test/unit/test_client_sdk_resume_alias.py
+++ b/test/unit/test_client_sdk_resume_alias.py
@@ -1,0 +1,74 @@
+"""Regression test for issue #97: client SDK resume() must be a real, tested alias.
+
+resume() is a thin wrapper around the same Trajectory construction
+open_trajectory() does, by design (see its docstring for why). This test
+covers what actually distinguishes it: rejecting resume of a trajectory with
+no prior history, and reattaching correctly to continue a step across a
+simulated crash/restart without re-running an already-claimed gated tool call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from client.python.trajectory_client import exec_tool, open_trajectory, resume, seal_decision
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.resume.gate import BlockedNeedsGate
+from trajectory_ir.runtime.tool import Tool
+
+
+def _deploy_tool(calls: list[str]) -> Tool:
+    def deploy_server(version: str) -> dict:
+        calls.append(version)
+        return {"deployed": version}
+
+    return Tool(
+        name="deploy_server", fn=deploy_server, effect_class=EffectClass.NON_IDEMPOTENT_WRITE
+    )
+
+
+def test_resume_raises_on_trajectory_with_no_history(tmp_path):
+    db_path = str(tmp_path / "trajectory.sqlite")
+
+    with pytest.raises(ValueError, match="no existing nodes"):
+        resume("brand-new-trajectory", db_path=db_path)
+
+
+def test_resume_reattaches_after_history_exists(tmp_path):
+    db_path = str(tmp_path / "trajectory.sqlite")
+    trajectory = open_trajectory("demo", "t1", db_path=db_path)
+    seal_decision(trajectory, step_n=1, plan={"tool_calls": []})
+
+    resumed = resume("t1", db_path=db_path)
+
+    assert resumed.trajectory_id == "t1"
+    assert resumed.tenant_id == "demo"
+    assert resumed.db_path == db_path
+
+
+def test_resume_does_not_replay_already_claimed_gated_tool_call(tmp_path):
+    """Simulates a crash/restart mid-step: resume() reattaches, and re-driving
+    the same exec_tool call for a NON_IDEMPOTENT_WRITE tool blocks instead of
+    re-running the side effect (README S8, R02)."""
+    db_path = str(tmp_path / "trajectory.sqlite")
+    calls: list[str] = []
+    tool = _deploy_tool(calls)
+
+    trajectory = open_trajectory("demo", "t1", db_path=db_path)
+    seal_decision(
+        trajectory,
+        step_n=1,
+        plan={"tool_calls": [{"name": "deploy_server", "args": {"version": "1.0.0"}}]},
+    )
+    exec_tool(trajectory, step_n=1, call={"args": {"version": "1.0.0"}}, tool=tool, seq=2)
+    assert calls == ["1.0.0"]
+
+    # Simulate crash/restart: drop the in-process trajectory and reattach.
+    del trajectory
+    resumed = resume("t1", db_path=db_path)
+
+    with pytest.raises(BlockedNeedsGate):
+        exec_tool(resumed, step_n=1, call={"args": {"version": "1.0.0"}}, tool=tool, seq=2)
+
+    # The already-claimed slot blocks retry; the tool body must not re-run.
+    assert calls == ["1.0.0"]


### PR DESCRIPTION
## Problem

`resume()` in `client/python/trajectory_client.py` (one of the six SDK functions named in README §12.1) was byte-for-byte identical to `open_trajectory()`: it never inspected any prior `DECISION`/`TOOL_RESULT` state and did no replay of its own. Nothing in the codebase calls it. The one example built specifically to demonstrate resume, `examples/kill-mid-deploy/agent.py`, bypasses the client SDK entirely and re-invokes `resume/step.py`'s `make_run_step` machinery directly under the same durable workflow id. So `resume()` looked like a real SDK entry point but was an untested, unused stub that happened to work by accident.

## Fix

This SDK layer does not wrap steps in a durable workflow decorator the way `make_run_step` does. Its crash safety comes entirely from `NodeLog` being idempotent by content and from `exec_tool`'s block-and-gate claim on `NON_IDEMPOTENT_WRITE` tools (README §8, R02). Re-driving the same `step_n`/`seq` calls against the same `db_path` is what "resume" means at this layer, so there genuinely is no separate replay step to wire in.

Rather than leave that implicit, `resume()`:
- Now has a docstring explaining why it's a thin wrapper and what actually makes resumption safe.
- Raises `ValueError` if the trajectory has no existing nodes in the log, since resuming something with no history is almost always a caller bug (wrong `db_path` or `trajectory_id`) rather than a legitimate resume.

## Testing

Added `test/unit/test_client_sdk_resume_alias.py`:
- `test_resume_raises_on_trajectory_with_no_history`: resuming a trajectory with an empty log raises `ValueError`.
- `test_resume_reattaches_after_history_exists`: resuming after some history exists returns a `Trajectory` with the correct fields.
- `test_resume_does_not_replay_already_claimed_gated_tool_call`: an actual crash/restart scenario, mirroring `kill-mid-deploy`'s approach. Execs a gated `NON_IDEMPOTENT_WRITE` tool, drops the in-process `Trajectory`, calls `resume()`, then re-drives the same `exec_tool` call and asserts it blocks with `BlockedNeedsGate` instead of re-running the tool body.

Full `test/unit` suite passes (99 passed, 2 skipped — pre-existing skips gated on live Postgres/pip-audit).

Closes #97

---
This fix was developed with AI assistance (Claude Code) and reviewed by the author before submission.