### PR TITLE
feat: adoption host demo with public client seal loop and optional CAS export

### DIFF
--- a/examples/adoption_host/README.md
+++ b/examples/adoption_host/README.md
@@ -1,0 +1,70 @@
+# Adoption host demo
+
+Host owned seal loop that a newcomer can run after an editable install. Uses
+**only public Python APIs**: client open / project / seal / exec / commit, plus
+optional filesystem CAS and thin `.tir` export.
+
+This is not an agent framework. The model is a stub function. Swap it for a
+real LLM client without changing seal or tool execution.
+
+## What it proves
+
+1. `open_trajectory` → `project` → stub model → `seal_decision`
+2. `exec_tool` for a **PURE** tool (`build_manifest`) and a **gated**
+   `NON_IDEMPOTENT_WRITE` tool (`ship_release`)
+3. `commit_step` finalizes the step
+4. Optional `--with-package`: `put_artifact` into `FileSystemCAS`, thin
+   `export_tir(..., cas=...)`, `load_tir` + `rehydrate_artifacts` with a
+   byte match check
+5. Optional `--sandbox`: non idempotent tools are rejected before the body runs
+
+## How this differs from other examples
+
+| Example | Intent |
+|---------|--------|
+| `examples/adoption_host/` (this) | Adoption: full host loop + optional CAS / thin package |
+| `examples/host_loop/` | Minimal public client step (no packaging) |
+| `examples/kill-mid-deploy/` | Crash safety / durable workflow resume |
+
+## Run
+
+From the repository root:
+
+```bash
+pip install -e ".[dev]"
+python examples/adoption_host/run_demo.py
+```
+
+Expected exit code `0` and a short summary of tool results and node kinds.
+
+Sandbox (should refuse `ship_release`):
+
+```bash
+python examples/adoption_host/run_demo.py --sandbox
+```
+
+Live step plus thin package + CAS rehydrate:
+
+```bash
+python examples/adoption_host/run_demo.py --with-package
+```
+
+Persist artifacts somewhere stable:
+
+```bash
+python examples/adoption_host/run_demo.py \
+  --db ./adoption.sqlite \
+  --with-package \
+  --cas-root ./cas_root \
+  --tir-out ./adoption-run.tir
+```
+
+## Design notes
+
+1. Tool arguments in the sealed plan are **concrete known values** only
+   (linear known args rule from the master README).
+2. Seq allocation is `seq = 2 + 2*i` for the i-th tool call so `TOOL_CALL` /
+   `TOOL_RESULT` slots do not overlap.
+3. The host owns the artifact payload. CAS stores bytes; the IR log stores
+   content addressed nodes. Thin packages carry hashes, not embedded blobs.
+4. CI covers this example via `test/unit/test_adoption_host_example.py`.

--- a/examples/adoption_host/run_demo.py
+++ b/examples/adoption_host/run_demo.py
@@ -1,0 +1,382 @@
+"""Adoption oriented host demo using only the public Trajectory IR APIs.
+
+This is the example a newcomer should run after ``pip install -e ".[dev]"``
+to see how a real host process wires the public client, tools, optional CAS,
+and a thin ``.tir`` package. It is not an agent framework and does not call
+paid model APIs.
+
+Run from the repository root::
+
+    python examples/adoption_host/run_demo.py
+    python examples/adoption_host/run_demo.py --sandbox
+    python examples/adoption_host/run_demo.py --with-package
+
+Compared with ``examples/host_loop``: same public client surface, but this
+demo also shows optional ``FileSystemCAS`` + thin ``export_tir`` + rehydrate.
+Crash safe durable workflow demos remain under ``examples/kill-mid-deploy/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Allow ``python examples/adoption_host/run_demo.py`` without a prior editable install.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from client.python.trajectory_client import (  # noqa: E402
+    commit_step,
+    exec_tool,
+    open_trajectory,
+    project,
+    seal_decision,
+)
+from trajectory_ir.effects import EffectClass  # noqa: E402
+from trajectory_ir.package import export_tir, load_tir  # noqa: E402
+from trajectory_ir.runtime.log import NodeLog  # noqa: E402
+from trajectory_ir.runtime.sandbox import SandboxForbidden  # noqa: E402
+from trajectory_ir.runtime.tool import Tool  # noqa: E402
+from trajectory_ir.storage import FileSystemCAS, put_artifact, rehydrate_artifacts  # noqa: E402
+
+TENANT_ID = "demo"
+TRAJECTORY_ID = "adoption-host-demo"
+STEP_N = 1
+
+ModelFn = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class HostStepResult:
+    """Outcome of one host owned seal / tool / commit cycle."""
+
+    tool_results: tuple[Any, ...]
+    node_kinds: tuple[str, ...]
+    trajectory_id: str
+    tenant_id: str
+    db_path: str
+
+
+@dataclass(frozen=True)
+class PackageResult:
+    """Outcome of optional thin package + CAS rehydrate check."""
+
+    tir_path: str
+    content_hash: str
+    logical_path: str
+    rehydrated_bytes: bytes
+    node_count: int
+
+
+def stub_model(context: Mapping[str, Any]) -> dict[str, Any]:
+    """Deterministic stand in for an LLM. Returns concrete known args only."""
+    release = str(context.get("release", "1.0.0"))
+    service = str(context.get("service", "api"))
+    return {
+        "tool_calls": [
+            {
+                "name": "build_manifest",
+                "args": {"service": service, "release": release},
+            },
+            {
+                "name": "ship_release",
+                "args": {"service": service, "version": release},
+            },
+        ]
+    }
+
+
+def make_tools() -> dict[str, Tool]:
+    """Tools used by the demo: one PURE path and one gated write path."""
+
+    def build_manifest(*, service: str, release: str) -> dict[str, str]:
+        return {
+            "service": service,
+            "release": release,
+            "status": "ready",
+        }
+
+    def ship_release(*, service: str, version: str) -> dict[str, str]:
+        # Side effect stand in (deploy). Gated as NON_IDEMPOTENT_WRITE.
+        return {"shipped": f"{service}:{version}"}
+
+    return {
+        "build_manifest": Tool(
+            name="build_manifest",
+            fn=build_manifest,
+            effect_class=EffectClass.PURE,
+        ),
+        "ship_release": Tool(
+            name="ship_release",
+            fn=ship_release,
+            effect_class=EffectClass.NON_IDEMPOTENT_WRITE,
+        ),
+    }
+
+
+def _list_kinds(db_path: str, *, trajectory_id: str, tenant_id: str) -> tuple[str, ...]:
+    log = NodeLog(db_path)
+    try:
+        nodes = log.list_nodes(trajectory_id, tenant_id=tenant_id)
+        return tuple(n["kind"] for n in nodes)
+    finally:
+        log.close()
+
+
+def run_host_step(
+    *,
+    db_path: str,
+    model_call: ModelFn = stub_model,
+    sandbox: bool = False,
+    context: Mapping[str, Any] | None = None,
+    tools: Mapping[str, Tool] | None = None,
+    trajectory_id: str = TRAJECTORY_ID,
+    tenant_id: str = TENANT_ID,
+    step_n: int = STEP_N,
+) -> HostStepResult:
+    """Run one host owned step with the public client API only.
+
+    Sequence matches the master README host loop:
+    open → project → model → seal_decision → exec_tool* → commit_step.
+    """
+    mode = "sandbox" if sandbox else "live"
+    ctx: dict[str, Any] = {
+        "goal": "build a release manifest then ship it",
+        "service": "api",
+        "release": "1.0.0",
+    }
+    if context:
+        ctx.update(dict(context))
+
+    traj = open_trajectory(
+        tenant_id,
+        trajectory_id,
+        db_path=db_path,
+        mode=mode,
+    )
+    project(traj, step_n=step_n, context=ctx)
+
+    plan = model_call(ctx)
+    if "tool_calls" not in plan or not isinstance(plan["tool_calls"], Sequence):
+        raise ValueError("model plan must include a tool_calls sequence")
+    seal_decision(traj, step_n=step_n, plan=plan)
+
+    registry = dict(tools) if tools is not None else make_tools()
+    results: list[Any] = []
+    for i, call in enumerate(plan["tool_calls"]):
+        name = call["name"]
+        if name not in registry:
+            raise KeyError(f"unknown tool in sealed plan: {name!r}")
+        tool = registry[name]
+        # seq = 2 + 2*i keeps TOOL_CALL and TOOL_RESULT slots non overlapping.
+        seq = 2 + 2 * i
+        tool_result = exec_tool(
+            traj,
+            step_n=step_n,
+            call={"args": call["args"]},
+            tool=tool,
+            seq=seq,
+        )
+        results.append(tool_result.result)
+
+    commit_seq = 2 + 2 * len(plan["tool_calls"])
+    commit_step(traj, step_n=step_n, seq=commit_seq)
+
+    kinds = _list_kinds(db_path, trajectory_id=trajectory_id, tenant_id=tenant_id)
+    return HostStepResult(
+        tool_results=tuple(results),
+        node_kinds=kinds,
+        trajectory_id=trajectory_id,
+        tenant_id=tenant_id,
+        db_path=db_path,
+    )
+
+
+def export_thin_package(
+    db_path: str,
+    cas_root: str | Path,
+    dest: str | Path,
+    payload: bytes,
+    *,
+    trajectory_id: str = TRAJECTORY_ID,
+    tenant_id: str = TENANT_ID,
+    logical_path: str = "outputs/release-report.json",
+) -> PackageResult:
+    """Put ``payload`` into a filesystem CAS, export a thin ``.tir``, rehydrate.
+
+    Uses only public storage and package APIs. The host owns artifact bytes;
+    the IR log stays content addressed and independent of the CAS backend.
+    """
+    if not payload:
+        raise ValueError("payload must be non empty")
+
+    store = FileSystemCAS(cas_root)
+    ref = put_artifact(store, payload, logical_path=logical_path)
+
+    log = NodeLog(db_path)
+    try:
+        tir_path = export_tir(
+            log,
+            trajectory_id,
+            dest,
+            mode="thin",
+            artifacts=[ref],
+            tenant_id=tenant_id,
+            cas=store,
+        )
+    finally:
+        log.close()
+
+    pkg = load_tir(tir_path)
+    rehydrated = rehydrate_artifacts(store, pkg.artifacts_manifest)
+    if ref.content_hash not in rehydrated:
+        raise RuntimeError(f"rehydrate missed content_hash={ref.content_hash}")
+    if rehydrated[ref.content_hash] != payload:
+        raise RuntimeError("rehydrated bytes do not match original payload")
+
+    return PackageResult(
+        tir_path=str(tir_path),
+        content_hash=ref.content_hash,
+        logical_path=logical_path,
+        rehydrated_bytes=rehydrated[ref.content_hash],
+        node_count=int(pkg.manifest["node_count"]),
+    )
+
+
+def report_bytes_from_step(step: HostStepResult) -> bytes:
+    """Serialize tool results into a small host owned artifact payload."""
+    body = {
+        "trajectory_id": step.trajectory_id,
+        "tenant_id": step.tenant_id,
+        "tool_results": list(step.tool_results),
+        "node_kinds": list(step.node_kinds),
+    }
+    return (json.dumps(body, sort_keys=True, indent=2) + "\n").encode("utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Adoption host demo for Trajectory IR (public client + optional CAS)"
+    )
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Open trajectory in sandbox mode (rejects NON_IDEMPOTENT_WRITE)",
+    )
+    parser.add_argument(
+        "--with-package",
+        action="store_true",
+        help="After a live step, put a report in FileSystemCAS and export a thin .tir",
+    )
+    parser.add_argument(
+        "--db",
+        default="",
+        help="SQLite path for the IR log (default: temp file)",
+    )
+    parser.add_argument(
+        "--cas-root",
+        default="",
+        help="Filesystem CAS root when using --with-package (default: temp dir)",
+    )
+    parser.add_argument(
+        "--tir-out",
+        default="",
+        help="Destination .tir path when using --with-package (default: temp file)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.sandbox and args.with_package:
+        print(
+            "error: --sandbox and --with-package cannot be combined "
+            "(sandbox never finishes a live gated step)",
+            file=sys.stderr,
+        )
+        return 2
+
+    cleanup_db = False
+    if args.db:
+        db_path = args.db
+    else:
+        fd, db_path = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
+        cleanup_db = True
+
+    cleanup_cas = False
+    cleanup_tir = False
+    cas_root = args.cas_root
+    tir_out = args.tir_out
+
+    try:
+        if args.sandbox:
+            try:
+                run_host_step(db_path=db_path, sandbox=True)
+            except SandboxForbidden as exc:
+                print(f"sandbox correctly rejected non idempotent tool: {exc}")
+                return 0
+            print("error: sandbox should have rejected ship_release", file=sys.stderr)
+            return 1
+
+        step = run_host_step(db_path=db_path, sandbox=False)
+        print("adoption host step complete")
+        print(f"  tool results: {list(step.tool_results)}")
+        print(f"  node kinds:   {list(step.node_kinds)}")
+
+        if args.with_package:
+            if not cas_root:
+                cas_root = tempfile.mkdtemp(prefix="trajir-cas-")
+                cleanup_cas = True
+            if not tir_out:
+                fd, tir_out = tempfile.mkstemp(suffix=".tir")
+                os.close(fd)
+                cleanup_tir = True
+            package = export_thin_package(
+                db_path=db_path,
+                cas_root=cas_root,
+                dest=tir_out,
+                payload=report_bytes_from_step(step),
+                trajectory_id=step.trajectory_id,
+                tenant_id=step.tenant_id,
+            )
+            print("thin package path complete")
+            print(f"  tir:          {package.tir_path}")
+            print(f"  content_hash: {package.content_hash}")
+            print(f"  logical_path: {package.logical_path}")
+            print(f"  node_count:   {package.node_count}")
+            print(f"  rehydrate:    {len(package.rehydrated_bytes)} bytes ok")
+
+        return 0
+    finally:
+        if cleanup_db:
+            try:
+                os.remove(db_path)
+            except OSError:
+                pass
+        if cleanup_tir and tir_out:
+            try:
+                os.remove(tir_out)
+            except OSError:
+                pass
+        if cleanup_cas and cas_root:
+            # Best effort: leave CAS contents if remove fails mid walk.
+            try:
+                for root, dirs, files in os.walk(cas_root, topdown=False):
+                    for name in files:
+                        os.remove(os.path.join(root, name))
+                    for name in dirs:
+                        os.rmdir(os.path.join(root, name))
+                os.rmdir(cas_root)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/unit/test_adoption_host_example.py
+++ b/test/unit/test_adoption_host_example.py
@@ -1,0 +1,207 @@
+"""Smoke and path coverage for examples/adoption_host (public APIs only)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_EXAMPLE = os.path.join(_REPO, "examples", "adoption_host")
+if _EXAMPLE not in sys.path:
+    sys.path.insert(0, _EXAMPLE)
+
+import run_demo  # noqa: E402
+
+from trajectory_ir.effects import EffectClass  # noqa: E402
+from trajectory_ir.package import load_tir  # noqa: E402
+from trajectory_ir.runtime.tool import Tool  # noqa: E402
+from trajectory_ir.storage import FileSystemCAS  # noqa: E402
+
+
+def test_live_host_step_pure_and_gated(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "adoption.sqlite")
+    step = run_demo.run_host_step(db_path=db, sandbox=False)
+
+    assert step.tool_results == (
+        {"service": "api", "release": "1.0.0", "status": "ready"},
+        {"shipped": "api:1.0.0"},
+    )
+    assert "PROJECT_CONTEXT" in step.node_kinds
+    assert "DECISION" in step.node_kinds
+    assert "TOOL_CALL" in step.node_kinds
+    assert "TOOL_RESULT" in step.node_kinds
+    assert "COMMIT_STEP" in step.node_kinds
+    # PURE tool + gated tool each contribute a TOOL_CALL (2) and TOOL_RESULT (2).
+    assert step.node_kinds.count("TOOL_CALL") == 2
+    assert step.node_kinds.count("TOOL_RESULT") == 2
+
+
+def test_sandbox_rejects_non_idempotent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "sandbox.sqlite")
+    with pytest.raises(run_demo.SandboxForbidden):
+        run_demo.run_host_step(db_path=db, sandbox=True)
+
+
+def test_custom_context_and_model(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "custom.sqlite")
+
+    def model(ctx):
+        return {
+            "tool_calls": [
+                {
+                    "name": "build_manifest",
+                    "args": {
+                        "service": ctx["service"],
+                        "release": ctx["release"],
+                    },
+                }
+            ]
+        }
+
+    step = run_demo.run_host_step(
+        db_path=db,
+        model_call=model,
+        context={"service": "worker", "release": "2.1.0"},
+        tools={
+            "build_manifest": run_demo.make_tools()["build_manifest"],
+        },
+    )
+    assert step.tool_results == ({"service": "worker", "release": "2.1.0", "status": "ready"},)
+    assert step.node_kinds.count("TOOL_CALL") == 1
+
+
+def test_unknown_tool_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "bad-tool.sqlite")
+
+    def model(_ctx):
+        return {"tool_calls": [{"name": "does_not_exist", "args": {}}]}
+
+    with pytest.raises(KeyError, match="unknown tool"):
+        run_demo.run_host_step(db_path=db, model_call=model)
+
+
+def test_invalid_plan_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "bad-plan.sqlite")
+
+    def model(_ctx):
+        return {"not_tool_calls": []}
+
+    with pytest.raises(ValueError, match="tool_calls"):
+        run_demo.run_host_step(db_path=db, model_call=model)
+
+
+def test_export_thin_package_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "pkg.sqlite")
+    step = run_demo.run_host_step(db_path=db, sandbox=False)
+    payload = run_demo.report_bytes_from_step(step)
+    assert b"adoption-host-demo" in payload
+
+    cas_root = tmp_path / "cas"
+    dest = tmp_path / "run.tir"
+    package = run_demo.export_thin_package(
+        db_path=db,
+        cas_root=cas_root,
+        dest=dest,
+        payload=payload,
+        trajectory_id=step.trajectory_id,
+        tenant_id=step.tenant_id,
+    )
+
+    assert Path(package.tir_path).is_file()
+    assert package.rehydrated_bytes == payload
+    assert package.node_count >= 1
+    assert package.logical_path == "outputs/release-report.json"
+
+    pkg = load_tir(package.tir_path)
+    assert pkg.manifest["mode"] == "thin"
+    assert pkg.artifact_bytes == {}
+    assert pkg.artifacts_manifest[0]["content_hash"] == package.content_hash
+    assert FileSystemCAS(cas_root).has(package.content_hash)
+
+
+def test_export_rejects_empty_payload(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = str(tmp_path / "empty.sqlite")
+    run_demo.run_host_step(db_path=db, sandbox=False)
+    with pytest.raises(ValueError, match="non empty"):
+        run_demo.export_thin_package(
+            db_path=db,
+            cas_root=tmp_path / "cas",
+            dest=tmp_path / "x.tir",
+            payload=b"",
+        )
+
+
+def test_main_live_exit_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    code = run_demo.main(["--db", str(tmp_path / "m.sqlite")])
+    assert code == 0
+
+
+def test_main_sandbox_exit_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    code = run_demo.main(["--sandbox", "--db", str(tmp_path / "s.sqlite")])
+    assert code == 0
+
+
+def test_main_with_package_exit_zero(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = tmp_path / "p.sqlite"
+    cas = tmp_path / "cas"
+    tir = tmp_path / "out.tir"
+    code = run_demo.main(
+        [
+            "--db",
+            str(db),
+            "--with-package",
+            "--cas-root",
+            str(cas),
+            "--tir-out",
+            str(tir),
+        ]
+    )
+    assert code == 0
+    assert tir.is_file()
+    assert cas.is_dir()
+    # CAS root should contain at least one object shard.
+    assert any(cas.rglob("*")), "expected CAS objects under cas root"
+
+
+def test_main_rejects_sandbox_with_package(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    code = run_demo.main(["--sandbox", "--with-package", "--db", str(tmp_path / "x.sqlite")])
+    assert code == 2
+
+
+def test_main_temp_db_and_package_cleanup(tmp_path, monkeypatch):
+    """Default paths use temp files; process must still exit 0."""
+    monkeypatch.chdir(tmp_path)
+    code = run_demo.main(["--with-package"])
+    assert code == 0
+
+
+def test_report_bytes_is_stable_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    step = run_demo.run_host_step(db_path=str(tmp_path / "r.sqlite"))
+    raw = run_demo.report_bytes_from_step(step)
+    parsed = json.loads(raw.decode("utf-8"))
+    assert parsed["trajectory_id"] == run_demo.TRAJECTORY_ID
+    assert isinstance(parsed["tool_results"], list)
+    assert isinstance(parsed["node_kinds"], list)
+
+
+def test_make_tools_effect_classes():
+    tools = run_demo.make_tools()
+    assert tools["build_manifest"].effect_class is EffectClass.PURE
+    assert tools["ship_release"].effect_class is EffectClass.NON_IDEMPOTENT_WRITE
+    assert isinstance(tools["build_manifest"], Tool)


### PR DESCRIPTION
## Summary

Adds `examples/adoption_host/`: a newcomer-friendly host owned seal loop that uses only public client APIs, plus an optional filesystem CAS + thin `.tir` export and rehydrate path. Smoke tests under `test/unit/test_adoption_host_example.py` keep the example from rotting.

## Related issues

Closes #87

## How I tested

```bash
pip install -e ".[dev]"
pytest test/unit/test_adoption_host_example.py -q
pytest test/unit -q --cov=trajectory_ir --cov=drivers --cov=client --cov-fail-under=80
python examples/adoption_host/run_demo.py
python examples/adoption_host/run_demo.py --sandbox
python examples/adoption_host/run_demo.py --with-package
ruff check examples/adoption_host test/unit/test_adoption_host_example.py
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes

## AI assistance (if any)

Assisted with Grok for scaffolding and tests; I reviewed all diffs against public APIs on main.