### PR TITLE
docs: prepare 0.1.1 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Post-`v0.1.0` work intended for **0.1.1**. Do not tag until this section is
+moved under `## [0.1.1]` and `pyproject.toml` `project.version` is bumped.
+Open PRs that may still fold in before the tag: adoption host demo (#87 / PR
+#108), QUICKSTART E2E Postgres+CAS+thin walkthrough (#88 / PR #109). Spec
+backend wording for Go Temporal remains tracked in #67 (not a 0.1.1 blocker).
+
 ### Added
 
 - CI Phase B: Integration (Postgres) and Integration (MinIO) jobs with live
-  driver tests under `test/integration/` (issue #85).
+  driver tests under `test/integration/` (issue #85, PR #86).
+- Maintainer branch protection and free-plan notes expanded in
+  `docs/maintainer-branch-protection.md`; richer PyPI package metadata in
+  `pyproject.toml` (PR #84).
 
 ### Changed
 
 - `build_s3_client_from_env` uses path-style addressing when
-  `TRAJIR_S3_ENDPOINT_URL` is set (MinIO/LocalStack).
+  `TRAJIR_S3_ENDPOINT_URL` is set (MinIO/LocalStack) (PR #86).
+- Go `trajir/durable` docs label `Memory` and `LocalSQLite` as durable backend
+  **test fakes**, not production engines (issue #92 context, PR #102).
+- Client SDK `resume()` is a documented reattach: requires existing node log
+  history and fails loudly on empty trajectories instead of silently matching
+  `open_trajectory` (issue #97, PR #107).
+- Projector policy construction always keeps `CONSTRAINT` in
+  `always_include_kinds` so policies cannot drop constraints by omission
+  (PR #101).
 
 ### Fixed
+
+- Go effect classifier fails closed on `openWorldHint=true` (parity with Python
+  `classify.py`) so open-world tools do not classify as `IDEMPOTENT_WRITE`
+  (issue #98, PR #99).
+- Client `exec_tool` appends `TOOL_CALL` / `TOOL_RESULT` for non-gated tools
+  (PURE / READ_ONLY / IDEMPOTENT_WRITE), not only the block-and-gate path
+  (issue #89, PR #100).
+- `ensure_artifacts_in_cas` fails closed when a manifest entry is missing
+  `content_hash` instead of skipping the row (PR #103).
+- `NodeLog` closes its SQLite connection in `__del__` as a best-effort backstop
+  for long-running client SDK sessions that never call `close()` (PR #104).
+- `export_tir` writes packages atomically (temp file + fsync + `os.replace`) so
+  a crash mid-export cannot leave a truncated `.tir` at the destination
+  (PR #105).
+- Postgres `claim_tool_call` propagates non-conflict errors; only
+  `UniqueViolation` returns `False` for a lost race (issue #96, PR #106).
 
 ## [0.1.0] - 2026-08-06
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,35 +14,47 @@ from unreviewed automation. Package owner credentials never belong in the repo.
 
 | Surface | Where | Notes |
 |---------|--------|--------|
-| Python package | `pyproject.toml` → `project.version` | Currently `0.1.0` |
-| Git tag | `v0.1.0` | Prefer `v` prefix |
+| Python package | `pyproject.toml` → `project.version` | `0.1.0` on main until 0.1.1 bump at tag time |
+| Git tag | `v0.1.0` (shipped); next `v0.1.1` | Prefer `v` prefix |
 | Go module | `go/go.mod` | No separate semver tag yet; consumers use commit or a later policy |
 
 ### Choosing 0.1.0 vs 0.1.1
 
-Open storage and host PRs may land after the first release prep. Pick one:
+`v0.1.0` is already tagged. Prefer **`v0.1.1`** for everything that landed after
+that tag (Phase B CI, reliability fixes, optional adoption demo / E2E docs).
 
-1. **Tag `v0.1.0` from current `main`** (R01–R08 library surface, docs release prep only), then ship **`0.1.1`** after CAS / Postgres / host PRs merge with CHANGELOG updated.
-2. **Wait** until the storage PRs you want in the first public wheel are on `main`, bump `pyproject.toml` if needed, and tag once.
+1. Keep `v0.1.0` as the first library surface snapshot.
+2. Ship **`0.1.1`** when CHANGELOG `[Unreleased]` is accurate, optional fold-in
+   PRs are merged or deferred, `pyproject.toml` version is bumped, and CI is green.
+3. Draft notes: [RELEASE_NOTES_0.1.1.md](RELEASE_NOTES_0.1.1.md).
 
 Do not move an already pushed tag. Prefer a new patch version.
 
-## Steps for a GitHub release (example v0.1.0)
+## Steps for a GitHub release (example v0.1.1)
 
 ```bash
 git checkout main
 git pull origin main
 
-git tag -a v0.1.0 -m "Trajectory IR v0.1.0 — Phase 1A library surface (R01–R08, dual .tir)"
+# After version bump in pyproject.toml and CHANGELOG [0.1.1] section:
+git tag -a v0.1.1 -m "Trajectory IR v0.1.1 — post-0.1.0 reliability and Phase B CI"
 
-git push origin v0.1.0
+git push origin v0.1.1
 ```
 
 Create a **GitHub Release** for the tag:
 
-1. Title: `v0.1.0`
-2. Body: paste or adapt [RELEASE_NOTES_0.1.0.md](RELEASE_NOTES_0.1.0.md) (or a 0.1.1 notes file if that is the tag)
+1. Title: `v0.1.1`
+2. Body: paste or adapt [RELEASE_NOTES_0.1.1.md](RELEASE_NOTES_0.1.1.md)
+   (for the first tag, [RELEASE_NOTES_0.1.0.md](RELEASE_NOTES_0.1.0.md) remains historical)
 3. Attach nothing required (source zip is automatic)
+
+### Historical: v0.1.0
+
+```bash
+git tag -a v0.1.0 -m "Trajectory IR v0.1.0 — Phase 1A library surface (R01–R08, dual .tir)"
+git push origin v0.1.0
+```
 
 ## Publish to PyPI (optional but tracked)
 

--- a/docs/RELEASE_NOTES_0.1.1.md
+++ b/docs/RELEASE_NOTES_0.1.1.md
@@ -1,0 +1,98 @@
+# Trajectory IR v0.1.1 (draft)
+
+Patch release after **v0.1.0**: reliability and honesty fixes for the Phase 1A
+library surface, plus CI Phase B live driver jobs. No new Phase 2 scope.
+
+**Status:** changelog and notes prepared on `main` (or the prep PR). Tag only
+after `pyproject.toml` version is `0.1.1`, CHANGELOG section is renamed from
+`[Unreleased]` to `[0.1.1] - YYYY-MM-DD`, and `main` is green.
+
+## Highlights
+
+- **CI Phase B**: live Postgres NodeLog and MinIO S3 CAS integration jobs
+- **Fail closed storage**: missing artifact `content_hash` raises; thin export
+  can verify CAS presence (already on 0.1.0 path, tightened here)
+- **Atomic `.tir` export**: no half-written package at the destination path
+- **Postgres claim honesty**: real DB errors are not misread as “lost the race”
+- **Client IR history**: plain (non-gated) tools leave `TOOL_CALL` / `TOOL_RESULT`
+- **Client `resume()`**: real reattach with history check, not a silent alias
+- **Go / Python effect parity**: `openWorldHint` fails closed in Go
+- **Projector safety**: `CONSTRAINT` always survives policy construction
+- **Docs**: Go durable Memory / LocalSQLite called out as test fakes
+
+## Install (from source)
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR
+git checkout v0.1.1   # after the tag exists
+pip install -e ".[dev]"
+# optional: pip install -e ".[s3]" or ".[postgres]"
+```
+
+When PyPI is published:
+
+```bash
+pip install trajectory-ir==0.1.1
+```
+
+## What landed since v0.1.0 (on main)
+
+| Area | PRs (approx.) |
+|------|----------------|
+| Phase B CI (Postgres + MinIO) | #86 |
+| Package / branch metadata | #84 |
+| Go `openWorldHint` fail closed | #99 |
+| Plain tool logging in client | #100 |
+| CONSTRAINT always in projector policy | #101 |
+| Durable test-fake docs (Go) | #102 |
+| Missing `content_hash` fail closed | #103 |
+| NodeLog connection GC close | #104 |
+| Atomic `.tir` write | #105 |
+| Postgres `claim_tool_call` error propagation | #106 |
+| Client `resume()` reattach | #107 |
+
+## Optional fold-ins before the tag
+
+Merge these if you want them in the same patch (recommended for adopters):
+
+| PR | Issue | Topic |
+|----|-------|--------|
+| #108 | #87 | Adoption host demo (public client + optional CAS thin package) |
+| #109 | #88 | QUICKSTART / docs E2E: Postgres NodeLog, CAS, thin `.tir` |
+
+After merge: add CHANGELOG lines under Added, re-run CI on `main`, then tag.
+
+## Not in 0.1.1
+
+Same non-goals as 0.1.0:
+
+- Package digital signatures (`SIGNATURE` reserved)
+- Live Restate cluster product packaging
+- Fluid / k8s-fluid profile
+- Multi-tenant SaaS control plane
+- Automated PyPI Trusted Publishing (manual upload still optional)
+
+## Spec note
+
+Master README still names DBOS as the Phase 1A Python default; Go production
+Temporal is implemented. Residual wording tracked in **issue #67** (owned
+separately; not required to close for 0.1.1).
+
+## How to cut the tag (maintainers)
+
+See [RELEASE.md](RELEASE.md). Short form:
+
+1. Merge any remaining fold-ins (#108 / #109 if desired).
+2. Bump `pyproject.toml` → `version = "0.1.1"`.
+3. Move CHANGELOG `[Unreleased]` body under `## [0.1.1] - <date>` and leave a
+   fresh empty `[Unreleased]`.
+4. Ensure CI is green on the release commit.
+5. `git tag -a v0.1.1 -m "Trajectory IR v0.1.1 — post-0.1.0 reliability and Phase B CI"`
+6. `git push origin v0.1.1` and publish a GitHub Release with this file as body.
+7. Optional: build + `twine upload` for PyPI.
+
+## Full changelog
+
+See [CHANGELOG.md](../CHANGELOG.md) section `[Unreleased]` until the tag, then
+`[0.1.1]`.


### PR DESCRIPTION
## Summary

Starts the **0.1.1 release track** without tagging:

1. Fills `CHANGELOG` `[Unreleased]` for everything on main since `v0.1.0` (Phase B CI, reliability fixes, client/Go honesty).
2. Adds draft `docs/RELEASE_NOTES_0.1.1.md` with highlights, fold-in list for open PRs #108 / #109, and cut steps.
3. Updates `docs/RELEASE.md` so the next cut is documented as **0.1.1**.

Does **not** bump `pyproject.toml` version and does **not** create a git tag. That happens when you are ready to ship.

## Related issues

Release hygiene after v0.1.0. Does not close #67 (Monika). Fold-ins for #87 / #88 remain optional until PRs #108 / #109 merge.

## How I tested

- Reviewed `git log v0.1.0..HEAD` against CHANGELOG lines
- Docs only; no runtime change

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

- [x] No
- [ ] Yes

## AI assistance (if any)

Assisted with Grok for draft structure; I cross-checked each bullet against merged PRs on main.