### PR TITLE
docs: Go first QUICKSTART path for Phase 1B

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,18 +1,36 @@
 # Quickstart: Trajectory IR
 
-Get a **local** Trajectory IR checkout running. This matches APIs that exist on `main` today (Phase 1A library surface).
+Get a **local** Trajectory IR checkout running. APIs match `main` today.
 
-Trajectory IR is a **semantic layer** for agent runs: content-addressed nodes, effect classes, block-and-gate for non-idempotent tools, portable `.tir` packages, and optional sandbox mode. Crash detection and step memoization are delegated to a durable backend (DBOS for Python Phase 1A).
+Trajectory IR is a **semantic layer** for agent runs: content addressed nodes, effect classes, block and gate for non idempotent tools, portable `.tir` packages, and optional sandbox mode. Crash detection and step memoization are delegated to a durable backend (**Temporal for Go production**, **DBOS for the Python reference port**).
+
+**Phase 1B default path is Go.** Prefer [go/QUICKSTART.md](go/QUICKSTART.md) for first success. Python below is the **reference port** from Phase 1A.
 
 ## Prerequisites
 
-- Python **3.11+**
+- **Go 1.25.x** (primary for Phase 1B)
 - Git
-- Optional: Go **1.25.x** (only if you exercise `go/trajir`)
+- Optional: Python **3.11+** (reference port, parity, DBOS local profile)
 
 ---
 
-## 1. Install from a clone
+## 0. Go first (recommended)
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR/go
+go test ./...
+```
+
+Full Go walkthrough (minimal client snippet, demos, Temporal notes):
+
+**[go/QUICKSTART.md](go/QUICKSTART.md)**
+
+Epic for Go primary work: [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113).
+
+---
+
+## 1. Install Python reference port (optional)
 
 ```bash
 git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
@@ -24,11 +42,11 @@ pip install -U pip
 pip install -e ".[dev]"
 ```
 
-PyPI publish of ``trajectory-ir`` is a maintainer step after the git tag (see ``docs/RELEASE.md``). Until the wheel is on PyPI, **editable install from git** is the supported path.
+PyPI publish of ``trajectory-ir`` is a maintainer step after the git tag (see ``docs/RELEASE.md``). Until the wheel is on PyPI, **editable install from git** is the supported Python path.
 
 ---
 
-## 2. Minimal Python flow (client + NodeLog)
+## 2. Minimal Python flow (client + NodeLog, reference port)
 
 ```python
 from client.python.trajectory_client import (
@@ -258,8 +276,10 @@ Integration recipes and CI parity commands live in
 
 | Doc | Purpose |
 |-----|---------|
+| [go/QUICKSTART.md](go/QUICKSTART.md) | Phase 1B primary Go onboarding |
 | [docs/E2E_POSTGRES_CAS_THIN.md](docs/E2E_POSTGRES_CAS_THIN.md) | Full Postgres + CAS + thin package walkthrough |
-| [docs/PHASE_1A_STATUS.md](docs/PHASE_1A_STATUS.md) | What shipped vs deferred |
+| [docs/PHASE_1A_STATUS.md](docs/PHASE_1A_STATUS.md) | What shipped in Phase 1A |
+| [docs/PHASE_1B_STATUS.md](docs/PHASE_1B_STATUS.md) | Go primary program (when present on branch) |
 | [README.md](README.md) | Master specification |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | DCO, CI, local dev, integration services |
 

--- a/go/QUICKSTART.md
+++ b/go/QUICKSTART.md
@@ -1,0 +1,108 @@
+# Go quickstart (Phase 1B primary path)
+
+First success path without Python. Matches APIs under `go/trajir` on `main`.
+
+## Prerequisites
+
+- Go **1.25.x** (see `go/go.mod`)
+- Git
+
+Optional later: Docker Postgres/MinIO, Temporal for production durable backends.
+
+## 1. Clone and test
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR/go
+go test ./...
+```
+
+## 2. Minimal client step
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/client"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+)
+
+func main() {
+	dir, err := os.MkdirTemp("", "trajir-qs-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	tr, err := client.OpenTrajectory("demo", "qs-1", client.Options{WorkDir: dir})
+	if err != nil {
+		panic(err)
+	}
+	defer tr.Close()
+
+	if _, err := tr.Project(1, map[string]any{"goal": "hello"}); err != nil {
+		panic(err)
+	}
+	plan := map[string]any{
+		"tool_calls": []any{
+			map[string]any{"name": "echo", "args": map[string]any{"msg": "hi"}},
+		},
+	}
+	if _, err := tr.SealDecision(1, plan); err != nil {
+		panic(err)
+	}
+
+	tool := resume.Tool{
+		Name:   "echo",
+		Effect: effects.PURE,
+		Fn: func(args map[string]any) (any, error) {
+			return args["msg"], nil
+		},
+	}
+	res, err := tr.ExecTool(1, 2, tool, map[string]any{"msg": "hi"})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res.Result) // hi
+	if err := tr.CommitStep(1, 4); err != nil {
+		panic(err)
+	}
+}
+```
+
+Run from `go/`:
+
+```bash
+# save as /tmp/qs.go or a small main under examples, then:
+go test ./trajir/client/... -count=1
+```
+
+## 3. Demos
+
+| Demo | Command | Intent |
+|------|---------|--------|
+| Kill mid deploy | `go run ./examples/kill-mid-deploy -workdir ./demo-data` | Crash safety |
+| Adoption host | `go run ./examples/adoption_host` (when merged) | Host seal loop + optional CAS |
+
+## 4. Durable backends
+
+| Backend | Role |
+|---------|------|
+| LocalSQLite / Memory | Coding and tests (test fakes) |
+| Temporal | Production for Go |
+
+```bash
+# optional live Temporal check
+# TEMPORAL_HOSTPORT=localhost:7233
+go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v
+```
+
+## 5. Next
+
+- Package map: [README.md](README.md)
+- Phase 1B epic: [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113)
+- Root docs (includes Python reference path): [../QUICKSTART.md](../QUICKSTART.md)


### PR DESCRIPTION
## Summary

Makes Go the front door in QUICKSTART. Root guide leads with go test and links to a new go/QUICKSTART.md. Python install and client flow stay as the reference port for Phase 1A parity.

## Related issues

Closes #116  
Parent epic: #113

## How I tested

`ash
# Docs only
git diff main -- QUICKSTART.md go/QUICKSTART.md
`

## Checklist

- [x] Commits are DCO signed (git commit -s)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for drafting; I checked API names against go/trajir/client.