### PR TITLE
feat: Go adoption host demo with optional CAS thin package

### DIFF
--- a/go/examples/adoption_host/README.md
+++ b/go/examples/adoption_host/README.md
@@ -1,0 +1,35 @@
+# Go adoption host demo
+
+Host owned seal loop using only the public Go client. Stub model (no paid API).
+Optional filesystem CAS and thin `.tir` export with rehydrate check.
+
+## What it proves
+
+1. `OpenTrajectory` → `Project` → stub model → `SealDecision`
+2. `ExecTool` for PURE (`build_manifest`) and gated NON_IDEMPOTENT_WRITE (`ship_release`)
+3. `CommitStep`
+4. Optional `-with-package`: CAS put, thin export, rehydrate
+5. Optional `-sandbox`: non idempotent tools rejected
+
+## How this differs
+
+| Example | Intent |
+|---------|--------|
+| `examples/adoption_host` (this) | Adoption: host loop + optional package |
+| `examples/kill-mid-deploy` | Crash safety / durable resume |
+
+## Run
+
+From `go/`:
+
+```bash
+go run ./examples/adoption_host
+go run ./examples/adoption_host -sandbox
+go run ./examples/adoption_host -with-package
+```
+
+Tests:
+
+```bash
+go test ./examples/adoption_host -count=1
+```

--- a/go/examples/adoption_host/demo.go
+++ b/go/examples/adoption_host/demo.go
@@ -1,0 +1,281 @@
+// Package main is the Go adoption host demo (public client APIs only).
+//
+//	go run ./examples/adoption_host
+//	go run ./examples/adoption_host -sandbox
+//	go run ./examples/adoption_host -with-package
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/cas"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/client"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/effects"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/resume"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/sandbox"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/tir"
+)
+
+const (
+	tenantID     = "demo"
+	trajectoryID = "go-adoption-host"
+	stepN        = 1
+)
+
+// HostStepResult is the outcome of one host owned seal cycle.
+type HostStepResult struct {
+	ToolResults  []any
+	NodeKinds    []string
+	TrajectoryID string
+	TenantID     string
+	WorkDir      string
+}
+
+// PackageResult is the outcome of thin export + rehydrate.
+type PackageResult struct {
+	TirPath      string
+	ContentHash  string
+	LogicalPath  string
+	Rehydrated   []byte
+	NodeCount    int
+}
+
+func stubModel(ctx map[string]any) map[string]any {
+	release := "1.0.0"
+	if v, ok := ctx["release"].(string); ok && v != "" {
+		release = v
+	}
+	service := "api"
+	if v, ok := ctx["service"].(string); ok && v != "" {
+		service = v
+	}
+	return map[string]any{
+		"tool_calls": []any{
+			map[string]any{
+				"name": "build_manifest",
+				"args": map[string]any{"service": service, "release": release},
+			},
+			map[string]any{
+				"name": "ship_release",
+				"args": map[string]any{"service": service, "version": release},
+			},
+		},
+	}
+}
+
+func makeTools() map[string]resume.Tool {
+	return map[string]resume.Tool{
+		"build_manifest": {
+			Name:   "build_manifest",
+			Effect: effects.PURE,
+			Fn: func(args map[string]any) (any, error) {
+				return map[string]any{
+					"service": args["service"],
+					"release": args["release"],
+					"status":  "ready",
+				}, nil
+			},
+		},
+		"ship_release": {
+			Name:   "ship_release",
+			Effect: effects.NON_IDEMPOTENT_WRITE,
+			Fn: func(args map[string]any) (any, error) {
+				return map[string]any{
+					"shipped": fmt.Sprintf("%v:%v", args["service"], args["version"]),
+				}, nil
+			},
+		},
+	}
+}
+
+func runHostStep(workDir string, sandboxMode bool, model func(map[string]any) map[string]any) (*HostStepResult, error) {
+	if model == nil {
+		model = stubModel
+	}
+	mode := sandbox.ModeLive
+	if sandboxMode {
+		mode = sandbox.ModeSandbox
+	}
+	tr, err := client.OpenTrajectory(tenantID, trajectoryID, client.Options{
+		WorkDir: workDir,
+		Mode:    mode,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer tr.Close()
+
+	ctx := map[string]any{
+		"goal":    "build a release manifest then ship it",
+		"service": "api",
+		"release": "1.0.0",
+	}
+	if _, err := tr.Project(stepN, ctx); err != nil {
+		return nil, err
+	}
+	plan := model(ctx)
+	if _, err := tr.SealDecision(stepN, plan); err != nil {
+		return nil, err
+	}
+
+	tools := makeTools()
+	rawCalls, ok := plan["tool_calls"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("model plan must include tool_calls")
+	}
+	results := make([]any, 0, len(rawCalls))
+	for i, raw := range rawCalls {
+		call, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("tool call %d is not an object", i)
+		}
+		name, _ := call["name"].(string)
+		tool, ok := tools[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown tool in sealed plan: %q", name)
+		}
+		args, _ := call["args"].(map[string]any)
+		if args == nil {
+			args = map[string]any{}
+		}
+		seq := 2 + 2*i
+		trRes, err := tr.ExecTool(stepN, seq, tool, args)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, trRes.Result)
+	}
+	commitSeq := 2 + 2*len(rawCalls)
+	if err := tr.CommitStep(stepN, commitSeq); err != nil {
+		return nil, err
+	}
+
+	kinds, err := listKinds(tr, trajectoryID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return &HostStepResult{
+		ToolResults:  results,
+		NodeKinds:    kinds,
+		TrajectoryID: trajectoryID,
+		TenantID:     tenantID,
+		WorkDir:      workDir,
+	}, nil
+}
+
+func listKinds(tr *client.Trajectory, trajID, tenant string) ([]string, error) {
+	rows, err := tr.Log().ListNodes(trajID, tenant)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if k, ok := r["kind"].(string); ok {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+func reportBytes(step *HostStepResult) ([]byte, error) {
+	body := map[string]any{
+		"trajectory_id": step.TrajectoryID,
+		"tenant_id":     step.TenantID,
+		"tool_results":  step.ToolResults,
+		"node_kinds":    step.NodeKinds,
+	}
+	return json.MarshalIndent(body, "", "  ")
+}
+
+func exportThinPackage(workDir, casRoot, dest string, payload []byte) (*PackageResult, error) {
+	if len(payload) == 0 {
+		return nil, errors.New("payload must be non empty")
+	}
+	store, err := cas.NewFileSystem(casRoot)
+	if err != nil {
+		return nil, err
+	}
+	h, err := store.Put(payload)
+	if err != nil {
+		return nil, err
+	}
+	uri, err := store.URIFor(h)
+	if err != nil {
+		return nil, err
+	}
+	size := len(payload)
+	logical := "outputs/release-report.json"
+	ref := tir.ArtifactRef{
+		LogicalPath: logical,
+		ContentHash: h,
+		URI:         &uri,
+		Size:        &size,
+	}
+
+	tr, err := client.OpenTrajectory(tenantID, trajectoryID, client.Options{WorkDir: workDir})
+	if err != nil {
+		return nil, err
+	}
+	defer tr.Close()
+	tenant := tenantID
+	path, err := tir.Export(tr.Log(), trajectoryID, dest, tir.ExportOptions{
+		Mode:      tir.ModeThin,
+		TenantID:  &tenant,
+		Artifacts: []tir.ArtifactRef{ref},
+	})
+	if err != nil {
+		return nil, err
+	}
+	pkg, err := tir.Load(path)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]cas.ArtifactEntry, 0, len(pkg.ArtifactsManifest))
+	for _, m := range pkg.ArtifactsManifest {
+		e := cas.ArtifactEntry{}
+		if s, ok := m["content_hash"].(string); ok {
+			e.ContentHash = s
+		}
+		if s, ok := m["logical_path"].(string); ok {
+			e.LogicalPath = s
+		}
+		entries = append(entries, e)
+	}
+	got, err := cas.Rehydrate(store, entries, true)
+	if err != nil {
+		return nil, err
+	}
+	data, ok := got[h]
+	if !ok {
+		return nil, fmt.Errorf("rehydrate missed content_hash=%s", h)
+	}
+	nodeCount := 0
+	if n, ok := pkg.Manifest["node_count"].(float64); ok {
+		nodeCount = int(n)
+	} else if n, ok := pkg.Manifest["node_count"].(int); ok {
+		nodeCount = n
+	}
+	return &PackageResult{
+		TirPath:     path,
+		ContentHash: h,
+		LogicalPath: logical,
+		Rehydrated:  data,
+		NodeCount:   nodeCount,
+	}, nil
+}
+
+func ensureDir(path string) error {
+	return os.MkdirAll(path, 0o755)
+}
+
+func defaultWorkDir() (string, error) {
+	return os.MkdirTemp("", "trajir-adoption-*")
+}
+
+func absJoin(dir, name string) string {
+	return filepath.Join(dir, name)
+}

--- a/go/examples/adoption_host/demo_test.go
+++ b/go/examples/adoption_host/demo_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/sandbox"
+)
+
+func TestLiveHostStep(t *testing.T) {
+	dir := t.TempDir()
+	step, err := runHostStep(dir, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(step.ToolResults) != 2 {
+		t.Fatalf("tool results=%d want 2", len(step.ToolResults))
+	}
+	kinds := map[string]bool{}
+	for _, k := range step.NodeKinds {
+		kinds[k] = true
+	}
+	for _, need := range []string{"PROJECT_CONTEXT", "DECISION", "COMMIT_STEP"} {
+		if !kinds[need] {
+			t.Fatalf("missing kind %s in %v", need, step.NodeKinds)
+		}
+	}
+}
+
+func TestSandboxRejectsShip(t *testing.T) {
+	dir := t.TempDir()
+	_, err := runHostStep(dir, true, nil)
+	var forbidden *sandbox.Forbidden
+	if !errors.As(err, &forbidden) {
+		t.Fatalf("err=%v want sandbox.Forbidden", err)
+	}
+}
+
+func TestCustomModelPureOnly(t *testing.T) {
+	dir := t.TempDir()
+	model := func(ctx map[string]any) map[string]any {
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{
+					"name": "build_manifest",
+					"args": map[string]any{
+						"service": ctx["service"],
+						"release": ctx["release"],
+					},
+				},
+			},
+		}
+	}
+	step, err := runHostStep(dir, false, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(step.ToolResults) != 1 {
+		t.Fatalf("results=%d", len(step.ToolResults))
+	}
+}
+
+func TestExportThinPackage(t *testing.T) {
+	dir := t.TempDir()
+	step, err := runHostStep(dir, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := reportBytes(step)
+	if err != nil {
+		t.Fatal(err)
+	}
+	casRoot := filepath.Join(dir, "cas")
+	dest := filepath.Join(dir, "run.tir")
+	pkg, err := exportThinPackage(dir, casRoot, dest, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(pkg.TirPath); err != nil {
+		t.Fatal(err)
+	}
+	if string(pkg.Rehydrated) != string(payload) {
+		t.Fatalf("rehydrate mismatch")
+	}
+	if pkg.NodeCount < 1 {
+		t.Fatalf("node_count=%d", pkg.NodeCount)
+	}
+}
+
+func TestExportRejectsEmptyPayload(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := runHostStep(dir, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, err := exportThinPackage(dir, filepath.Join(dir, "cas"), filepath.Join(dir, "x.tir"), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/go/examples/adoption_host/main.go
+++ b/go/examples/adoption_host/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/sandbox"
+)
+
+func main() {
+	sandboxFlag := flag.Bool("sandbox", false, "reject NON_IDEMPOTENT_WRITE tools")
+	withPackage := flag.Bool("with-package", false, "after live step, CAS put + thin .tir + rehydrate")
+	workDir := flag.String("workdir", "", "directory for sqlite files (default: temp)")
+	casRoot := flag.String("cas-root", "", "CAS root when using -with-package (default: temp)")
+	tirOut := flag.String("tir-out", "", "destination .tir when using -with-package (default: temp)")
+	flag.Parse()
+
+	if *sandboxFlag && *withPackage {
+		fmt.Fprintln(os.Stderr, "error: -sandbox and -with-package cannot be combined")
+		os.Exit(2)
+	}
+
+	dir := *workDir
+	cleanupDir := false
+	if dir == "" {
+		var err error
+		dir, err = defaultWorkDir()
+		if err != nil {
+			fail(err)
+		}
+		cleanupDir = true
+	}
+	if err := ensureDir(dir); err != nil {
+		fail(err)
+	}
+	if cleanupDir {
+		defer os.RemoveAll(dir)
+	}
+
+	if *sandboxFlag {
+		_, err := runHostStep(dir, true, nil)
+		var forbidden *sandbox.Forbidden
+		if errors.As(err, &forbidden) {
+			fmt.Printf("sandbox correctly rejected non idempotent tool: %v\n", forbidden)
+			os.Exit(0)
+		}
+		if err != nil {
+			fail(err)
+		}
+		fmt.Fprintln(os.Stderr, "error: sandbox should have rejected ship_release")
+		os.Exit(1)
+	}
+
+	step, err := runHostStep(dir, false, nil)
+	if err != nil {
+		fail(err)
+	}
+	fmt.Println("adoption host step complete")
+	fmt.Printf("  tool results: %v\n", step.ToolResults)
+	fmt.Printf("  node kinds:   %v\n", step.NodeKinds)
+
+	if *withPackage {
+		casDir := *casRoot
+		if casDir == "" {
+			casDir = absJoin(dir, "cas")
+		}
+		dest := *tirOut
+		if dest == "" {
+			dest = absJoin(dir, "adoption-run.tir")
+		}
+		payload, err := reportBytes(step)
+		if err != nil {
+			fail(err)
+		}
+		pkg, err := exportThinPackage(dir, casDir, dest, payload)
+		if err != nil {
+			fail(err)
+		}
+		fmt.Println("thin package path complete")
+		fmt.Printf("  tir:          %s\n", pkg.TirPath)
+		fmt.Printf("  content_hash: %s\n", pkg.ContentHash)
+		fmt.Printf("  logical_path: %s\n", pkg.LogicalPath)
+		fmt.Printf("  node_count:   %d\n", pkg.NodeCount)
+		fmt.Printf("  rehydrate:    %d bytes ok\n", len(pkg.Rehydrated))
+	}
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "error:", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Adds go/examples/adoption_host: a newcomer friendly host seal loop on the public Go client only. Includes PURE and gated tools, sandbox rejection, and optional FileSystem CAS with thin .tir export plus rehydrate. Tests keep the example from rotting.

## Related issues

Closes #115  
Parent epic: #113

## How I tested

`ash
cd go
go test ./examples/adoption_host -count=1
go run ./examples/adoption_host
go run ./examples/adoption_host -sandbox
go run ./examples/adoption_host -with-package
`

## Checklist

- [x] Commits are DCO signed (git commit -s)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes (call it out here)

Uses existing effect classes and gate via public ExecTool only.

## AI assistance (if any)

Assisted with Grok for scaffolding; I ran tests and checked client API usage.