### PR TITLE
docs: add milestone process for planning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ still require a matching `Signed-off-by`.
 4. Wait for CI to go green.
 5. Set the **Milestone** on both the issue and the PR (see
    [docs/MILESTONES.md](docs/MILESTONES.md)). Right now: finish **v0.1.1** first,
-   then **Phase 1B — Go primary SDK**. Park deferred product ideas under
-   **Future — deferred product**.
+   then **Phase 1B Go primary SDK**. Park deferred product ideas under
+   **Future deferred product**.
 
 ### Automated CI (what runs today)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ still require a matching `Signed-off-by`.
 2. Keep the change focused.
 3. Fill in the PR template.
 4. Wait for CI to go green.
+5. Set the **Milestone** on both the issue and the PR (see
+   [docs/MILESTONES.md](docs/MILESTONES.md)). Right now: finish **v0.1.1** first,
+   then **Phase 1B — Go primary SDK**. Park deferred product ideas under
+   **Future — deferred product**.
 
 ### Automated CI (what runs today)
 

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -10,10 +10,10 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 
 | Milestone | State | Purpose |
 |-----------|--------|---------|
-| **Phase 1A — library baseline (v0.1.0)** | Closed | What shipped as the first library tag. Historical only. |
-| **v0.1.1 — post-0.1.0 patch** | Open | Patch release cut: reliability, Phase B CI, fold-ins, tag. Issue #111. |
-| **Phase 1B — Go primary SDK** | Open | Go is primary product surface; Python is reference/parity. Epic #113. |
-| **Future — deferred product** | Open | Signatures, Fluid, SaaS, PyPI Trusted Publishing, etc. Park only. |
+| **Phase 1A library baseline (v0.1.0)** | Closed | What shipped as the first library tag. Historical only. |
+| **v0.1.1 post 0.1.0 patch** | Open | Patch release cut: reliability, Phase B CI, fold-ins, tag. Issue #111. |
+| **Phase 1B Go primary SDK** | Open | Go is primary product surface; Python is reference/parity. Epic #113. |
+| **Future deferred product** | Open | Signatures, Fluid, SaaS, PyPI Trusted Publishing, etc. Park only. |
 
 ## Rules (follow these)
 
@@ -22,7 +22,7 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 3. **Exit criteria live in the milestone description.** Close the milestone only when those criteria are met (and the matching release or epic is done).
 4. **Suggested work order right now**
    1. Finish **v0.1.1** (merge release metadata PR, tag, GitHub Release).
-   2. Then **Phase 1B** in order: spec → CONTRIBUTING → QUICKSTART → adoption demo → Postgres / S3 drivers.
+   2. Then **Phase 1B** in order: spec, CONTRIBUTING, QUICKSTART, adoption demo, Postgres / S3 drivers.
 5. **Future milestone is a parking lot.** Implementing from Future needs a README scope bump (§14) and a new active milestone or epic first.
 6. **Labels still matter** (`go`, `phase-1b`, `SPEC-QUESTION`, …). Milestone answers *when/why*; labels answer *kind of work*.
 
@@ -30,10 +30,10 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 
 ```bash
 # Issue
-gh issue edit NNN --milestone "Phase 1B — Go primary SDK"
+gh issue edit NNN --milestone "Phase 1B Go primary SDK"
 
 # Pull request
-gh pr edit NNN --milestone "v0.1.1 — post-0.1.0 patch"
+gh pr edit NNN --milestone "v0.1.1 post 0.1.0 patch"
 ```
 
 In the GitHub UI: issue/PR sidebar → Milestone.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -1,0 +1,46 @@
+# Milestones (how we plan work)
+
+GitHub **Milestones** are the planning spine for Trajectory IR. Issues and PRs
+should always land on exactly one open milestone (or the closed Phase 1A
+history bucket when you are only filing retrospective notes).
+
+Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
+
+## Active and historical milestones
+
+| Milestone | State | Purpose |
+|-----------|--------|---------|
+| **Phase 1A — library baseline (v0.1.0)** | Closed | What shipped as the first library tag. Historical only. |
+| **v0.1.1 — post-0.1.0 patch** | Open | Patch release cut: reliability, Phase B CI, fold-ins, tag. Issue #111. |
+| **Phase 1B — Go primary SDK** | Open | Go is primary product surface; Python is reference/parity. Epic #113. |
+| **Future — deferred product** | Open | Signatures, Fluid, SaaS, PyPI Trusted Publishing, etc. Park only. |
+
+## Rules (follow these)
+
+1. **One milestone per issue and PR.** Set it when you open the issue, not at merge time.
+2. **Do not mix scopes.** Phase 1B work must not sit under v0.1.1. Deferred ideas go to Future, not Phase 1B.
+3. **Exit criteria live in the milestone description.** Close the milestone only when those criteria are met (and the matching release or epic is done).
+4. **Suggested work order right now**
+   1. Finish **v0.1.1** (merge release metadata PR, tag, GitHub Release).
+   2. Then **Phase 1B** in order: spec → CONTRIBUTING → QUICKSTART → adoption demo → Postgres / S3 drivers.
+5. **Future milestone is a parking lot.** Implementing from Future needs a README scope bump (§14) and a new active milestone or epic first.
+6. **Labels still matter** (`go`, `phase-1b`, `SPEC-QUESTION`, …). Milestone answers *when/why*; labels answer *kind of work*.
+
+## How to assign (maintainers and contributors)
+
+```bash
+# Issue
+gh issue edit NNN --milestone "Phase 1B — Go primary SDK"
+
+# Pull request
+gh pr edit NNN --milestone "v0.1.1 — post-0.1.0 patch"
+```
+
+In the GitHub UI: issue/PR sidebar → Milestone.
+
+## Related docs
+
+- Master spec phases: root `README.md` §5
+- Phase 1A inventory: [PHASE_1A_STATUS.md](PHASE_1A_STATUS.md)
+- Phase 1B program: epic [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113)
+- Release process: [RELEASE.md](RELEASE.md)


### PR DESCRIPTION
## Summary

Sets up how the repo uses GitHub milestones. Adds docs/MILESTONES.md with the four milestones (Phase 1A closed, v0.1.1, Phase 1B, Future) and short rules so issues and PRs stay in the right bucket. CONTRIBUTING now requires a milestone on issues and PRs.

## Related issues

Parent epic: #113 (process support for Phase 1B planning)

## How I tested

`ash
# Docs only
git diff main -- docs/MILESTONES.md CONTRIBUTING.md
gh api repos/Coder-s-OG-s/Trajectory-IR/milestones?state=all
`

## Checklist

- [x] Commits are DCO signed (git commit -s)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes (call it out here)

## AI assistance (if any)

Assisted with Grok for drafting; milestones were created on the GitHub project first.