### PR TITLE
docs: confirm branch protection is still 403 blocked on main

### DIFF
--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -2,6 +2,22 @@
 
 Do this after CI has produced green check names on `main` or on a PR.
 
+## Status (issue #128, part 1)
+
+Re-verified 2026-08-08 against the live repo:
+
+```bash
+gh api repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection
+# {"message":"Upgrade to GitHub Pro or make this repository public to enable
+#  this feature.","status":"403"}
+```
+
+Branch protection is still blocked on the plan/visibility decision below.
+Nothing else in this doc can take effect (main stays ungated, a red PR can
+still be merged by anyone with write access) until a maintainer picks one of
+the two options and someone with admin rights on the repo runs the CLI step
+near the bottom of this doc.
+
 ## GitHub plan note (important)
 
 This repository is currently **private**. On GitHub’s free plan for private


### PR DESCRIPTION
## Summary

Part 1 of issue #128 (unlock real gates on main). Re-verifies live against the repo that classic branch protection is still returning HTTP 403 on `main`, and makes that explicit in `docs/maintainer-branch-protection.md` so the blocking decision (make the repo public, or upgrade to a plan with private branch protection) is visible to whoever is reviewing this, rather than only implied.

This PR does not flip repo visibility or plan, that is a maintainer call outside the scope of a code PR. Parts 2 and 3 of #128 (fast/deep CI split, Go CI priority) are tracked as separate PRs per the issue's own suggested stacking order.

## Related issues

Part of #128 (does not close it, parts 2 and 3 still open).

## How I tested

Ran `gh api repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection` against the live repo on 2026-08-08 and confirmed the 403 response quoted in the doc. Docs only, no CI/runtime change.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [ ] AI assistance disclosed below
