### PR TITLE
ci: split fast and deep gate CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   GO_COV_FAIL_UNDER: "50"
 
 jobs:
+  # ---- Fast gate: required, aim to stay under ~10 minutes, no live services ----
   dco:
     name: DCO
     runs-on: ubuntu-latest
@@ -102,12 +103,6 @@ jobs:
           name: coverage-python-${{ matrix.python-version }}
           path: coverage-python.xml
           if-no-files-found: ignore
-
-      - name: E2E crash/resume tests
-        run: pytest test/e2e -q
-
-      - name: Conformance R01–R08
-        run: pytest conformance/ -q
 
   package-smoke:
     name: Package smoke
@@ -215,6 +210,37 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
+
+  # ---- Deep gate: required, allowed to run slower ----
+  conformance:
+    name: Conformance & E2E (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and dev tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: E2E crash/resume tests
+        run: pytest test/e2e -q
+
+      - name: Conformance R01–R08
+        run: pytest conformance/ -q
 
   # Phase B: real service integrations (separate from Quality so Phase A stays fast).
   integration-postgres:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,15 +54,27 @@ still require a matching `Signed-off-by`.
 
 ### Automated CI (what runs today)
 
-Defined in `.github/workflows/ci.yml`:
+Defined in `.github/workflows/ci.yml`, grouped into a **fast gate** (no live
+services, aims to stay under ~10 minutes) and a **deep gate** (allowed to run
+slower). Both groups run on every PR; both are meant to be required once
+branch protection is on (see
+[docs/maintainer-branch-protection.md](docs/maintainer-branch-protection.md)).
+
+Fast gate:
 
 | Check | What it does |
 |-------|----------------|
 | **DCO** | Every commit on the PR has `Signed-off-by` |
-| **Quality** | install, Ruff, Mypy, hash goldens, unit tests with **coverage floor** (`PYTHON_COV_FAIL_UNDER`, default 80%), e2e, full `conformance/` R01–R08 (Python 3.11 and 3.12) |
+| **Quality** | install, Ruff, Mypy, hash goldens, unit tests with **coverage floor** (`PYTHON_COV_FAIL_UNDER`, default 80%) (Python 3.11 and 3.12) |
 | **Package smoke** | `python -m build`, install the wheel into a clean venv, import smoke |
 | **Security (pip-audit)** | `pip-audit --skip-editable` on the installed dependency tree |
 | **Go** | hash goldens, `go/trajir/...` **coverage floor** (`GO_COV_FAIL_UNDER`, default 50%), `go test ./...`, `govulncheck` |
+
+Deep gate:
+
+| Check | What it does |
+|-------|----------------|
+| **Conformance & E2E** | e2e crash/resume plus full `conformance/` R01-R08 (Python 3.11 and 3.12) |
 | **Integration (Postgres)** | Live `PostgresNodeLog` against a Postgres 16 service (`test/integration/test_postgres_live.py`) |
 | **Integration (MinIO)** | Live `S3CAS` against MinIO (`test/integration/test_s3_minio_live.py`) |
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -27,19 +27,28 @@ GitHub → Settings → Branches → Branch protection rule for `main` (after pl
 
 ## Status checks to require
 
-Match the names shown in the Actions UI (Phase A, issue #81):
+Match the names shown in the Actions UI (Phase A, issue #81). Fast gate and
+deep gate are both required once protection is on (issue #128 part 2 split
+`Quality` so its e2e/conformance steps run as their own deep gate job):
+
+Fast gate:
 
 1. `DCO` (pull requests only; may appear after the first PR with the DCO job)
-2. `Quality (Python 3.11)` — ruff, mypy, unit coverage floor, e2e, conformance
-3. `Quality (Python 3.12)` — same as 3.11
-4. `Package smoke` — `python -m build` + install wheel + import smoke
-5. `Security (pip-audit)` — first-class dependency audit (not only a unit test)
-6. `Go` — trajir coverage floor, full `go test ./...`, `govulncheck`
+2. `Quality (Python 3.11)`: ruff, mypy, unit coverage floor
+3. `Quality (Python 3.12)`: same as 3.11
+4. `Package smoke`: `python -m build` + install wheel + import smoke
+5. `Security (pip-audit)`: first-class dependency audit (not only a unit test)
+6. `Go`: trajir coverage floor, full `go test ./...`, `govulncheck`
+
+Deep gate:
+
+7. `Conformance & E2E (Python 3.11)`: e2e crash/resume, full `conformance/` R01-R08
+8. `Conformance & E2E (Python 3.12)`: same as 3.11
 
 Optional after Phase B is proven stable (issue #85):
 
-7. `Integration (Postgres)`
-8. `Integration (MinIO)`
+9. `Integration (Postgres)`
+10. `Integration (MinIO)`
 
 If GitHub shows a slightly different label, use the exact string from the check run.
 
@@ -94,7 +103,9 @@ gh api -X PUT repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection \
       "Quality (Python 3.12)",
       "Package smoke",
       "Security (pip-audit)",
-      "Go"
+      "Go",
+      "Conformance & E2E (Python 3.11)",
+      "Conformance & E2E (Python 3.12)"
     ]
   },
   "enforce_admins": false,


### PR DESCRIPTION
## Summary

Part 2 of issue #128 (split fast vs deep CI gates). Restructures `.github/workflows/ci.yml` so the existing `Quality (Python 3.11 / 3.12)` job stays a fast gate (ruff, format, mypy, hash goldens, unit tests plus coverage floor) and its e2e/conformance steps move to a new deep gate job, `Conformance & E2E (Python 3.11 / 3.12)`. `Package smoke`, `Security (pip-audit)`, `Go`, `Integration (Postgres)`, and `Integration (MinIO)` are unchanged, they were already in the right bucket. No job depends on live Postgres/MinIO except the two integration jobs, which were already isolated before this PR.

Also updates `CONTRIBUTING.md`'s CI table and `docs/maintainer-branch-protection.md`'s required-check list (including the CLI example) to describe the fast/deep grouping and the new `Conformance & E2E` check names, so the docs stay accurate once branch protection is turned on.

## Related issues

Part of #128 (does not close it, parts 1 and 3 are separate PRs per the issue's own suggested stacking order).

## How I tested

Validated the workflow YAML parses (`python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`) and confirmed the resulting job/name list matches the intended fast/deep split. Did not run the workflow itself (that happens on this PR in Actions).

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [ ] AI assistance disclosed below
