### PR TITLE
ci: add go vet and raise Go coverage floor to 60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ permissions:
 env:
   # Coverage floors (Phase A). Raise only after measured green baselines improve.
   PYTHON_COV_FAIL_UNDER: "80"
-  GO_COV_FAIL_UNDER: "50"
+  # Measured baseline on 2026-08-08: 65.0% statements on go/trajir/...; floor
+  # raised from 50 with headroom, next step targets 70 once more Go drivers
+  # land coverage, per issue #128 part 3.
+  GO_COV_FAIL_UNDER: "60"
 
 jobs:
   dco:
@@ -186,6 +189,10 @@ jobs:
         with:
           go-version: "1.25.x"
           cache-dependency-path: go/go.sum
+
+      - name: go vet
+        working-directory: go
+        run: go vet ./...
 
       - name: Cross language hash goldens (Go)
         working-directory: go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Defined in `.github/workflows/ci.yml`:
 | **Quality** | install, Ruff, Mypy, hash goldens, unit tests with **coverage floor** (`PYTHON_COV_FAIL_UNDER`, default 80%), e2e, full `conformance/` R01–R08 (Python 3.11 and 3.12) |
 | **Package smoke** | `python -m build`, install the wheel into a clean venv, import smoke |
 | **Security (pip-audit)** | `pip-audit --skip-editable` on the installed dependency tree |
-| **Go** | hash goldens, `go/trajir/...` **coverage floor** (`GO_COV_FAIL_UNDER`, default 50%), `go test ./...`, `govulncheck` |
+| **Go** | `go vet`, hash goldens, `go/trajir/...` **coverage floor** (`GO_COV_FAIL_UNDER`, default 60%), `go test ./...`, `govulncheck` |
 | **Integration (Postgres)** | Live `PostgresNodeLog` against a Postgres 16 service (`test/integration/test_postgres_live.py`) |
 | **Integration (MinIO)** | Live `S3CAS` against MinIO (`test/integration/test_s3_minio_live.py`) |
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -56,9 +56,12 @@ Set in `.github/workflows/ci.yml` as `env:`:
 | Variable | Default | Applies to |
 |----------|---------|------------|
 | `PYTHON_COV_FAIL_UNDER` | `80` | unit suite on `trajectory_ir` + `drivers` + `client` |
-| `GO_COV_FAIL_UNDER` | `50` | `go/trajir/...` via `scripts/check_go_coverage.sh` |
+| `GO_COV_FAIL_UNDER` | `60` | `go/trajir/...` via `scripts/check_go_coverage.sh` |
 
 Raise only after a measured green baseline; do not drop floors without a PR.
+`GO_COV_FAIL_UNDER` moved from 50 to 60 on a measured 65.0% baseline
+(2026-08-08, issue #128 part 3); next step targets 70, then 80, as more Go
+drivers land coverage.
 
 ## Post-feature landing checklist
 


### PR DESCRIPTION
## Summary

Part 3 of issue #128 (make Go CI Phase 1B priority), first step only. Adds `go vet ./...` as a step in the `Go` job (confirmed clean locally, no findings) and raises `GO_COV_FAIL_UNDER` from 50 to 60.

The 60 value is not arbitrary: I measured the current baseline locally with `GO_COV_FAIL_UNDER=60 bash scripts/check_go_coverage.sh`, which reports 65.0% total statement coverage on `go/trajir/...`, so 60 leaves real headroom rather than sitting right at the edge. Per the issue, floors should only move up on a measured green baseline, in steps, toward 70 then 80, not jump straight there, so this PR does not raise the floor all the way to 70 (65.0% baseline is below that and would make the gate flaky on the next slightly-lower-coverage PR).

Not included here (left for follow up issues/PRs against #128 part 3, since this PR is scoped to a single change per the requested one line commit): staticcheck/golangci-lint, `go test -race` on lock-using packages, and the Postgres/S3 live Go integration jobs, those are separate, larger pieces of part 3.

## Related issues

Part of #128 (does not close it, parts 1 and 2 are separate PRs; part 3 itself is only partially addressed by this PR).

## How I tested

Locally, from `go/`:

```
go vet ./...                                   # clean, no output
GO_COV_FAIL_UNDER=60 bash scripts/check_go_coverage.sh   # 65.0% meets floor 60%
```

Also validated the workflow YAML still parses after the edit.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [ ] AI assistance disclosed below
