### PR TITLE
docs: correct Go live Postgres/MinIO CI status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ Defined in `.github/workflows/ci.yml`:
 | **Package smoke** | `python -m build`, install the wheel into a clean venv, import smoke |
 | **Security (pip-audit)** | `pip-audit --skip-editable` on the installed dependency tree |
 | **Go** | hash goldens, `go/trajir/...` **coverage floor** (`GO_COV_FAIL_UNDER`, default 50%), `go test ./...`, `govulncheck` |
-| **Integration (Postgres)** | Live `PostgresNodeLog` against a Postgres 16 service (`test/integration/test_postgres_live.py`) |
-| **Integration (MinIO)** | Live `S3CAS` against MinIO (`test/integration/test_s3_minio_live.py`) |
+| **Integration (Postgres)** | Live `PostgresNodeLog` against a Postgres 16 service, Python (`test/integration/test_postgres_live.py`) and Go (`go test ./trajir/postgres/...`) |
+| **Integration (MinIO)** | Live `S3CAS` against MinIO, Python only for now (`test/integration/test_s3_minio_live.py`); Go's `trajir/cas.ObjectAPI` still only has `MemoryObjectAPI` fakes, so a live Go MinIO step needs a real S3 client adapter first (issue #129) |
 
 Local dependency audit (optional): `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_audit.py -q` after `pip install -e ".[dev]"`. Under GitHub Actions the dedicated **Security (pip-audit)** job is authoritative.
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -38,8 +38,8 @@ Match the names shown in the Actions UI (Phase A, issue #81):
 
 Optional after Phase B is proven stable (issue #85):
 
-7. `Integration (Postgres)`
-8. `Integration (MinIO)`
+7. `Integration (Postgres)`: Python and Go (`go test ./trajir/postgres/...`), both live against the same Postgres 16 service
+8. `Integration (MinIO)`: Python only; Go's `trajir/cas.ObjectAPI` has no real client adapter yet, so this job has no Go step (issue #129)
 
 If GitHub shows a slightly different label, use the exact string from the check run.
 


### PR DESCRIPTION
## Summary

Issue #129 asks for Go live Postgres and MinIO deep gate CI jobs. Checked both before writing any code:

1. **Go live Postgres already exists.** PR #124 (`feat: Go Postgres NodeLog driver`) already added a "Live Postgres NodeLog tests (Go)" step to the `integration-postgres` job (`go test ./trajir/postgres/... -count=1 -v` against the same Postgres 16 service the Python integration test uses). No CI change needed there, the docs just never mentioned it.
2. **Go live MinIO is not possible yet.** `go/trajir/cas`'s `ObjectAPI` interface (from PR #125, `feat: Go S3 compatible CAS driver`) is only backed by `MemoryObjectAPI`, an in-memory fake used for unit tests, by design (see that PR's own commit message: "Injectable ObjectAPI keeps unit tests free of AWS credentials"). There is no real S3/MinIO client adapter in the repo to run a live test against, no `aws-sdk-go` or `minio-go` dependency in `go.mod` either. Wiring a live MinIO CI step now would either be fake or would require first writing a whole new client adapter (library choice, credential handling, its own tests), which is a separate feature, not a CI change, and outside this issue's own CI-focused framing.

This PR is docs-only: corrects `CONTRIBUTING.md`'s CI table and `docs/maintainer-branch-protection.md`'s required-check list so the `Integration (Postgres)` row correctly says it covers both Python and Go, and the `Integration (MinIO)` row explicitly says Go coverage is blocked on a real client adapter (linking back to #129) instead of silently implying parity that does not exist.

## Related issues

Addresses the documentation acceptance criterion of #129 ("Docs list the new check names"). Does not close #129: the Go live MinIO half needs a real `ObjectAPI` client adapter as separate follow up work before a CI step can be added honestly.

## How I tested

Docs only. Verified by reading `go/trajir/cas/s3.go` (only `MemoryObjectAPI` implements `ObjectAPI`), `go/go.mod` (no S3 SDK dependency), and `.github/workflows/ci.yml` / `git blame` confirming the Go Postgres live step already shipped in PR #124.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [ ] AI assistance disclosed below
