### PR TITLE
docs: refresh PHASE_1B_STATUS after Go primary landings

### DIFF
--- a/docs/PHASE_1B_STATUS.md
+++ b/docs/PHASE_1B_STATUS.md
@@ -1,7 +1,7 @@
 # Phase 1B status (Go primary SDK)
 
-Honest inventory for the **current development focus** after Phase 1A / `v0.1.0`.
-Normative detail lives in the root `README.md` (spec v1.3 language priority).
+Honest inventory after Phase 1A / `v0.1.0`, the `v0.1.1` line, and the Phase 1B
+landings on main. Normative detail: root `README.md` (Go primary, Python reference).
 
 ## Decision
 
@@ -18,28 +18,53 @@ Epic: [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113)
 
 | Issue | Topic | Status |
 |-------|--------|--------|
-| #114 | Spec: declare Go primary in README | This status doc lands with the spec PR |
-| #115 | Go adoption host demo | Open |
-| #116 | Go first QUICKSTART | Open |
-| #117 | Go Postgres NodeLog | Open |
-| #118 | Go S3 compatible CAS | Open |
-| #119 | CONTRIBUTING Go first process | Open |
+| #114 | Spec: declare Go primary in README | **Shipped** (#120) |
+| #115 | Go adoption host demo | **Shipped** (#123) |
+| #116 | Go first QUICKSTART | **Shipped** (#122) |
+| #117 | Go Postgres NodeLog | **Shipped** (#124) |
+| #118 | Go S3 compatible CAS | **Shipped** (#125) |
+| #119 | CONTRIBUTING Go first process | **Shipped** (#121) |
+| #128 | CI unlock / fast vs deep / Go first | **Shipped** (workflow; branch protection still plan limited) |
+| #129 | Go live Postgres and MinIO CI | **Shipped** |
+| #130 | Python to Go `.tir` round trip CI | **Shipped** (#139) |
+| #131 | Go coverage floor 70 then 80 | **Shipped** (70 in #140, 80 in #143) |
+| #132 | Go Resume fails closed without history | **Shipped** (#141) |
+| #133 | Refresh this status doc | **This change** |
+| #134 | Real AWS/MinIO S3 client for Go CAS | **Shipped** (#142) |
 
 ## Already on main (Go)
 
 - IR: nodes, log (SQLite), effects, resume, sandbox, graft, redact, projector
-- Client SDK and kill mid deploy demo
-- Filesystem CAS and `.tir` thin/fat
+- Client SDK: `OpenTrajectory`, `Resume` (requires history), plain tool logging
+- Demos: kill mid deploy, **adoption host** (`go/examples/adoption_host`)
+- Filesystem CAS; S3 CAS with `ObjectAPI` and AWS SDK v2 `NewS3StoreFromEnv`
+- Postgres NodeLog (`trajir/postgres`) with offline sqlmock unit tests
+- `.tir` thin/fat; Python export → Go import golden in CI
 - Temporal production durable backend; LocalSQLite/Memory test fakes
-- Spec: Temporal recognized for Go (#67 / #112)
+- CI: Go coverage floor **80%** (unit set excludes optional Temporal package)
+
+## How to run (newcomers)
+
+```bash
+cd go
+go test ./...
+go run ./examples/adoption_host
+go run ./examples/adoption_host -with-package
+```
+
+- [go/QUICKSTART.md](../go/QUICKSTART.md)
+- [go/examples/adoption_host/README.md](../go/examples/adoption_host/README.md)
+- Root [QUICKSTART.md](../QUICKSTART.md) (Go first, Python reference below)
 
 ## Explicitly not Phase 1B goals
 
 - Deleting Python or dropping R01–R08 Python CI
 - Package signatures, Fluid productization, multi tenant SaaS
 - Rewriting DBOS out of the Python port
+- Branch protection on private free GitHub plans (needs public or paid plan)
 
 ## Related
 
 - Phase 1A inventory: [PHASE_1A_STATUS.md](PHASE_1A_STATUS.md)
-- Cut patch release: issue #111 (`v0.1.1`) is independent of this epic
+- Milestones: [MILESTONES.md](MILESTONES.md) (when on main)
+- Package version line: `0.1.1` in `pyproject.toml`


### PR DESCRIPTION
## Summary

Updates PHASE_1B_STATUS so shipped Phase 1B work (spec, demos, drivers, CI, Resume, S3 client, coverage 80) is marked correctly, with links for newcomers.

## Related issues

Closes #133

## How I tested

```bash
# Docs only
git diff main -- docs/PHASE_1B_STATUS.md
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

- [x] No
- [ ] Yes

## AI assistance (if any)

None material.