### PR TITLE
release: Trajectory IR 0.2.0 Phase 1B

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,5 +365,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,s3]"
 
-      - name: Live MinIO S3 CAS tests
+      - name: Create MinIO bucket
+        run: |
+          python -c "from drivers.s3.cas import build_s3_client_from_env; c=build_s3_client_from_env();
+          try:
+            c.create_bucket(Bucket='trajir')
+          except Exception as e:
+            # Bucket may already exist on a reused runner volume.
+            print('create_bucket:', e)"
+
+      - name: Live MinIO S3 CAS tests (Python)
         run: pytest test/integration/test_s3_minio_live.py -q
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.25.x"
+          cache-dependency-path: go/go.sum
+
+      - name: Live MinIO S3 CAS tests (Go)
+        working-directory: go
+        run: go test ./trajir/cas -count=1 -run TestLiveS3StoreFromEnvRoundTrip -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.2.0] - 2026-08-11
+
+Phase 1B: Go is the primary SDK and onboarding path. Python remains the
+reference and parity port. Includes Go drivers, adoption demo, CI depth, and
+client honesty fixes on top of the 0.1.x line.
+
+### Added
+
+- Spec and process: Go primary for Phase 1B (README, CONTRIBUTING, go/QUICKSTART,
+  PHASE_1B_STATUS) (issues #114, #116, #119, #133).
+- Go adoption host demo with optional CAS thin package (issue #115).
+- Go Postgres NodeLog (`trajir/postgres`) with offline sqlmock unit tests
+  (issue #117).
+- Go S3 compatible CAS (`ObjectAPI`) and AWS SDK v2 `NewS3StoreFromEnv`
+  (issues #118, #134).
+- CI: fast vs deep gates, Python↔Go `.tir` golden, Go coverage floor 80%,
+  live Go Postgres in Integration (Postgres) (issues #128–#131, #129–#130).
+- Milestone process docs (`docs/MILESTONES.md` when present).
+
+### Changed
+
+- Go client `Resume` requires existing NodeLog history (issue #132).
+- Go client logs TOOL_CALL / TOOL_RESULT for non gated tools (parity with Python).
+
+### Fixed
+
+- govulncheck clean for pgx and aws-sdk-go-v2 S3 on the Phase 1B path.
+
 ## [0.1.1] - 2026-08-07
 
 Patch release after `v0.1.0`: Phase B CI, reliability fixes, adoption docs and

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,8 +14,8 @@ from unreviewed automation. Package owner credentials never belong in the repo.
 
 | Surface | Where | Notes |
 |---------|--------|--------|
-| Python package | `pyproject.toml` → `project.version` | Bump with the release PR (0.1.1 for this cut) |
-| Git tag | `v0.1.0` (shipped); `v0.1.1` after the release PR merges | Prefer `v` prefix |
+| Python package | `pyproject.toml` → `project.version` | Current line: `0.2.0` (Phase 1B) |
+| Git tag | `v0.1.0` shipped; **`v0.2.0`** for Phase 1B | Prefer `v` prefix |
 | Go module | `go/go.mod` | No separate semver tag yet; consumers use commit or a later policy |
 
 ### Choosing 0.1.0 vs 0.1.1
@@ -30,23 +30,23 @@ that tag (Phase B CI, reliability fixes, optional adoption demo / E2E docs).
 
 Do not move an already pushed tag. Prefer a new patch version.
 
-## Steps for a GitHub release (example v0.1.1)
+## Steps for a GitHub release (example v0.2.0)
 
 ```bash
 git checkout main
 git pull origin main
 
-# After version bump in pyproject.toml and CHANGELOG [0.1.1] section:
-git tag -a v0.1.1 -m "Trajectory IR v0.1.1 — post-0.1.0 reliability and Phase B CI"
+# After version bump in pyproject.toml and CHANGELOG [0.2.0] section:
+git tag -a v0.2.0 -m "Trajectory IR v0.2.0 Phase 1B Go primary SDK"
 
-git push origin v0.1.1
+git push origin v0.2.0
 ```
 
 Create a **GitHub Release** for the tag:
 
-1. Title: `v0.1.1`
-2. Body: paste or adapt [RELEASE_NOTES_0.1.1.md](RELEASE_NOTES_0.1.1.md)
-   (for the first tag, [RELEASE_NOTES_0.1.0.md](RELEASE_NOTES_0.1.0.md) remains historical)
+1. Title: `v0.2.0`
+2. Body: paste or adapt [RELEASE_NOTES_0.2.0.md](RELEASE_NOTES_0.2.0.md)
+   (older notes: [RELEASE_NOTES_0.1.1.md](RELEASE_NOTES_0.1.1.md), [RELEASE_NOTES_0.1.0.md](RELEASE_NOTES_0.1.0.md))
 3. Attach nothing required (source zip is automatic)
 
 ### Historical: v0.1.0

--- a/docs/RELEASE_NOTES_0.2.0.md
+++ b/docs/RELEASE_NOTES_0.2.0.md
@@ -1,0 +1,47 @@
+# Trajectory IR v0.2.0
+
+Phase **1B** release: **Go is the primary SDK** and default onboarding path.
+Python remains the supported reference and parity port from Phase 1A.
+
+## Highlights
+
+- Go primary in the master README and CONTRIBUTING
+- `go/QUICKSTART.md` and `go/examples/adoption_host`
+- Go Postgres NodeLog and S3 CAS (including AWS SDK v2 / MinIO env wiring)
+- Go `Resume` fails closed without history; plain tools leave IR history
+- CI: deep gates, cross language `.tir` round trip, Go coverage floor **80%**
+- Builds on the 0.1.x reliability and Phase B integration work
+
+## Install
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR
+git checkout v0.2.0
+pip install -e ".[dev]"
+# optional: pip install -e ".[s3]" or ".[postgres]"
+```
+
+```bash
+cd go
+go test ./...
+go run ./examples/adoption_host
+```
+
+When PyPI is published:
+
+```bash
+pip install trajectory-ir==0.2.0
+```
+
+## Not in 0.2.0
+
+- Package digital signatures
+- Fluid / k8s-fluid product packaging
+- Multi tenant SaaS control plane
+- Automated PyPI Trusted Publishing (manual upload still optional)
+- Branch protection on private free GitHub plans (needs public or paid plan)
+
+## Full changelog
+
+See [CHANGELOG.md](../CHANGELOG.md) section `[0.2.0]`.

--- a/go/trajir/cas/s3_live_test.go
+++ b/go/trajir/cas/s3_live_test.go
@@ -1,0 +1,37 @@
+package cas
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// Live MinIO / S3 path. Skips unless TRAJIR_S3_BUCKET and endpoint or real AWS env is set.
+func TestLiveS3StoreFromEnvRoundTrip(t *testing.T) {
+	if os.Getenv("TRAJIR_S3_BUCKET") == "" {
+		t.Skip("set TRAJIR_S3_BUCKET (and usually TRAJIR_S3_ENDPOINT_URL) for live S3 CAS")
+	}
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
+		t.Skip("set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for live S3 CAS")
+	}
+
+	store, err := NewS3StoreFromEnv(context.Background(), S3FromEnvOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("trajir-live-s3-cas")
+	h, err := store.Put(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Get(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("got %q", got)
+	}
+	if !store.Has(h) {
+		t.Fatal("Has=false after Put")
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trajectory-ir"
-version = "0.1.1"
+version = "0.2.0"
 description = "Portable, hash-verifiable intermediate representation for agent runs (seals, effects, .tir packages)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/test/unit/test_graft.py
+++ b/test/unit/test_graft.py
@@ -1,0 +1,114 @@
+"""Unit coverage for trajectory_ir.runtime.graft (R07)."""
+
+from __future__ import annotations
+
+import pytest
+
+from trajectory_ir.runtime.graft import GraftError, find_artifact_ref, graft_artifact_ref
+from trajectory_ir.runtime.log import NodeLog
+
+
+def test_find_artifact_ref_prefers_ref_over_put():
+    h = "ab" + "0" * 62
+    nodes = [
+        {
+            "kind": "ARTIFACT_PUT",
+            "payload": {"content_hash": h, "logical_path": "put.bin"},
+            "seq": 1,
+            "trajectory_id": "s",
+        },
+        {
+            "kind": "ARTIFACT_REF",
+            "payload": {"content_hash": h, "logical_path": "ref.bin"},
+            "seq": 2,
+            "trajectory_id": "s",
+        },
+        {"kind": "THOUGHT", "payload": {"content_hash": h, "text": "nope"}, "seq": 0},
+    ]
+    found = find_artifact_ref(nodes, h)
+    assert found["kind"] == "ARTIFACT_REF"
+    assert found["payload"]["logical_path"] == "ref.bin"
+
+
+def test_find_artifact_ref_missing():
+    with pytest.raises(GraftError, match="no ARTIFACT"):
+        find_artifact_ref([{"kind": "DECISION", "payload": {}, "seq": 0}], "ff" + "1" * 62)
+
+
+def test_find_artifact_ref_requires_hash():
+    with pytest.raises(GraftError, match="content_hash"):
+        find_artifact_ref([], "")
+
+
+def test_graft_copies_metadata_not_thoughts(tmp_path):
+    src = NodeLog(str(tmp_path / "src.sqlite"))
+    dst = NodeLog(str(tmp_path / "dst.sqlite"))
+    try:
+        h = "cd" + "2" * 62
+        src.append("THOUGHT", 1, {"text": "secret plan"}, "src", "demo", 0)
+        src.append(
+            "ARTIFACT_PUT",
+            1,
+            {"content_hash": h, "logical_path": "out.bin", "uri": "cas://" + h},
+            "src",
+            "demo",
+            1,
+        )
+        nodes = src.list_nodes("src", tenant_id="demo")
+        node = graft_artifact_ref(
+            dst,
+            content_hash=h,
+            target_trajectory_id="dst",
+            target_tenant_id="demo",
+            seq=0,
+            step_n=1,
+            source_nodes=nodes,
+        )
+        assert node.kind == "ARTIFACT_REF"
+        assert node.payload["content_hash"] == h
+        assert node.payload["logical_path"] == "out.bin"
+        assert node.payload.get("grafted") is True
+        kinds = {n["kind"] for n in dst.list_nodes("dst", tenant_id="demo")}
+        assert kinds == {"ARTIFACT_REF"}
+    finally:
+        src.close()
+        dst.close()
+
+
+def test_graft_refuses_thought_only_match(tmp_path):
+    src = NodeLog(str(tmp_path / "src.sqlite"))
+    dst = NodeLog(str(tmp_path / "dst.sqlite"))
+    try:
+        h = "ee" + "3" * 62
+        src.append("THOUGHT", 1, {"content_hash": h, "text": "x"}, "src", "demo", 0)
+        with pytest.raises(GraftError):
+            graft_artifact_ref(
+                dst,
+                content_hash=h,
+                target_trajectory_id="dst",
+                target_tenant_id="demo",
+                seq=0,
+                source_nodes=src.list_nodes("src", tenant_id="demo"),
+            )
+    finally:
+        src.close()
+        dst.close()
+
+
+def test_graft_without_source_nodes(tmp_path):
+    dst = NodeLog(str(tmp_path / "dst.sqlite"))
+    try:
+        h = "11" + "a" * 62
+        node = graft_artifact_ref(
+            dst,
+            content_hash=h,
+            target_trajectory_id="dst",
+            target_tenant_id="demo",
+            seq=0,
+            logical_path="manual.bin",
+            uri="cas://" + h,
+        )
+        assert node.payload["logical_path"] == "manual.bin"
+        assert node.payload["uri"] == "cas://" + h
+    finally:
+        dst.close()

--- a/test/unit/test_redact.py
+++ b/test/unit/test_redact.py
@@ -1,0 +1,65 @@
+"""Unit coverage for trajectory_ir.runtime.redact (R08)."""
+
+from __future__ import annotations
+
+from trajectory_ir.runtime.redact import (
+    REDACTED,
+    redact_payload,
+    redact_projection_context,
+    redact_value,
+)
+
+
+def test_redact_value_by_key_name():
+    assert redact_value("api_key", "secret-value") == REDACTED
+    assert redact_value("password", "x") == REDACTED
+    assert redact_value("note", "hello") == "hello"
+
+
+def test_redact_value_by_shape():
+    assert redact_value("note", "AKIAABCDEFGHIJKLMNOP") == REDACTED
+    assert redact_value("note", "sk-" + "x" * 20) == REDACTED
+    assert redact_value("note", "plain text") == "plain text"
+
+
+def test_redact_nested_dict_and_list():
+    out = redact_value(
+        "body",
+        {"token": "abc", "items": [{"password": "p"}, "ok"]},
+    )
+    assert out["token"] == REDACTED
+    assert out["items"][0]["password"] == REDACTED
+    assert out["items"][1] == "ok"
+
+
+def test_redact_payload_thought():
+    assert redact_payload("THOUGHT", {"text": "private"}) == {"redacted": True}
+
+
+def test_redact_payload_constraint_keeps_structure():
+    out = redact_payload("CONSTRAINT", {"rule": "keep", "secret": "nope"})
+    assert out["rule"] == "keep"
+    assert out["secret"] == REDACTED
+
+
+def test_redact_projection_context_items():
+    ctx = {
+        "items": [
+            {"id": "1", "kind": "THOUGHT", "payload": {"text": "x"}},
+            {"id": "2", "kind": "CONSTRAINT", "payload": {"api_key": "k", "rule": "r"}},
+        ],
+        "budget": 10,
+    }
+    out = redact_projection_context(ctx)
+    assert out["redacted"] is True
+    assert out["budget"] == 10
+    by_id = {i["id"]: i for i in out["items"]}
+    assert by_id["1"]["payload"] == {"redacted": True}
+    assert by_id["2"]["payload"]["api_key"] == REDACTED
+    assert by_id["2"]["payload"]["rule"] == "r"
+
+
+def test_redact_projection_context_free_form():
+    out = redact_projection_context({"password": "x", "goal": "ship"})
+    assert out["password"] == REDACTED
+    assert out["goal"] == "ship"


### PR DESCRIPTION
## Summary

Ships **v0.2.0** as the Phase 1B release (Go primary SDK).

- `pyproject.toml` version `0.2.0`
- CHANGELOG `[0.2.0]` and `docs/RELEASE_NOTES_0.2.0.md`
- Unit tests for graft and redact (coverage soft spots)
- Integration (MinIO) also runs Go live S3 CAS test via `NewS3StoreFromEnv`

After merge: tag `v0.2.0` and publish GitHub Release.

## Related issues

Phase 1B complete on main; this is the public release cut.

## How I tested

```bash
pytest test/unit -q --cov=trajectory_ir --cov=drivers --cov=client --cov-fail-under=80
cd go && go test ./trajir/cas -count=1
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

- [x] No
- [ ] Yes

## AI assistance (if any)

None material.