### PR TITLE
chore: Phase 1C status and tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  python-dist:
+    name: Build Python dist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine check dist/*
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Attach dist to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,8 @@ still require a matching `Signed-off-by`.
 3. Fill in the PR template.
 4. Wait for CI to go green.
 5. Set the **Milestone** on both the issue and the PR (see
-   [docs/MILESTONES.md](docs/MILESTONES.md)). Right now: finish **v0.1.1** first,
-   then **Phase 1B Go primary SDK**. Park deferred product ideas under
-   **Future deferred product**.
+   [docs/MILESTONES.md](docs/MILESTONES.md)). Right now prefer **Phase 1C harden
+   and adopt**. Park signatures, Fluid, and SaaS under **Future deferred product**.
 
 ### Automated CI (what runs today)
 

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -10,19 +10,20 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 
 | Milestone | State | Purpose |
 |-----------|--------|---------|
-| **Phase 1A library baseline (v0.1.0)** | Closed | What shipped as the first library tag. Historical only. |
-| **v0.1.1 post 0.1.0 patch** | Open | Patch release cut: reliability, Phase B CI, fold-ins, tag. Issue #111. |
-| **Phase 1B Go primary SDK** | Open | Go is primary product surface; Python is reference/parity. Epic #113. |
-| **Future deferred product** | Open | Signatures, Fluid, SaaS, PyPI Trusted Publishing, etc. Park only. |
+| **Phase 1A library baseline (v0.1.0)** | Closed | First library tag. Historical only. |
+| **v0.1.1 post 0.1.0 patch** | Closed | Absorbed into history; public cut advanced to v0.2.0. |
+| **Phase 1B Go primary SDK** | Closed | Complete; released as **v0.2.0**. |
+| **Phase 1C harden and adopt** | Open | Gates when plan allows, release automation, polish. |
+| **Future deferred product** | Open | Signatures, Fluid, SaaS, etc. Park only. |
 
 ## Rules (follow these)
 
 1. **One milestone per issue and PR.** Set it when you open the issue, not at merge time.
-2. **Do not mix scopes.** Phase 1B work must not sit under v0.1.1. Deferred ideas go to Future, not Phase 1B.
+2. **Do not mix scopes.** Phase 1C harden work stays on Phase 1C. Deferred product ideas go to Future, not Phase 1C.
 3. **Exit criteria live in the milestone description.** Close the milestone only when those criteria are met (and the matching release or epic is done).
 4. **Suggested work order right now**
-   1. Finish **v0.1.1** (merge release metadata PR, tag, GitHub Release).
-   2. Then **Phase 1B** in order: spec, CONTRIBUTING, QUICKSTART, adoption demo, Postgres / S3 drivers.
+   1. **Phase 1C**: branch protection when plan allows (#146), tag release workflow (#147), status docs (#148).
+   2. Keep product non goals under **Future deferred product**.
 5. **Future milestone is a parking lot.** Implementing from Future needs a README scope bump (§14) and a new active milestone or epic first.
 6. **Labels still matter** (`go`, `phase-1b`, `SPEC-QUESTION`, …). Milestone answers *when/why*; labels answer *kind of work*.
 
@@ -30,10 +31,10 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 
 ```bash
 # Issue
-gh issue edit NNN --milestone "Phase 1B Go primary SDK"
+gh issue edit NNN --milestone "Phase 1C harden and adopt"
 
 # Pull request
-gh pr edit NNN --milestone "v0.1.1 post 0.1.0 patch"
+gh pr edit NNN --milestone "Phase 1C harden and adopt"
 ```
 
 In the GitHub UI: issue/PR sidebar → Milestone.

--- a/docs/PHASE_1C_STATUS.md
+++ b/docs/PHASE_1C_STATUS.md
@@ -1,0 +1,41 @@
+# Phase 1C status (harden and adopt)
+
+Follow on after **v0.2.0** (Phase 1B Go primary). Focus: enforce quality on
+merge, automate release cuts, and polish adoption without new Phase 2 product
+scope.
+
+Milestone: **Phase 1C harden and adopt**
+
+## Goals
+
+| Issue | Topic | Status |
+|-------|--------|--------|
+| #146 | Enable required status checks on `main` when plan allows | Open (blocked on private free GitHub: needs public or paid plan) |
+| #147 | Release workflow on `v*` tags (wheel + release assets) | In progress with this doc PR when shipped |
+| #148 | This status doc + maintainer checklist | This file |
+
+## Done already on main (inherited)
+
+- Green PR CI: Quality, Go, Package smoke, Security, Conformance, Integration Postgres/MinIO (Python + Go live paths)
+- Go coverage floor 80% (unit set)
+- Cross language `.tir` golden
+- Tagged **v0.2.0** Phase 1B release
+
+## Branch protection note
+
+API returns HTTP 403 for branch protection on this private free repo. Until the
+org upgrades or the repo is public, **policy** remains: only merge green PRs,
+prefer squash, keep `main` up to date. Track unlock under #146.
+
+## Maintainer checklist (post v0.2.0)
+
+1. Confirm latest `main` CI is green.
+2. Prefer milestone **Phase 1C** for new harden work; park signatures/Fluid/SaaS under **Future deferred product**.
+3. When cutting a tag: `pyproject.toml` version, CHANGELOG section, annotated tag, GitHub Release notes.
+4. After #147: verify tag push builds and attaches wheel/sdist.
+
+## Related
+
+- [PHASE_1B_STATUS.md](PHASE_1B_STATUS.md)
+- [RELEASE.md](RELEASE.md)
+- [RELEASE_NOTES_0.2.0.md](RELEASE_NOTES_0.2.0.md)


### PR DESCRIPTION
## Summary

Starts Phase 1C: PHASE_1C_STATUS, milestone docs for the new phase, and a GitHub Actions Release workflow on v* tags that builds sdist/wheel, runs twine check, and attaches artifacts to the release.

## Related issues

Closes #147
Closes #148

## How I tested

```bash
# Workflow YAML review; full CI on PR
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

- [x] No
- [ ] Yes

## AI assistance (if any)

None material.