### PR TITLE
docs: Phase 1C harden-and-adopt (live Docker, merge policy, status)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Phase 1C: `docker-compose.live.yml` and `docs/LIVE_INTEGRATION_DOCKER.md` for
+  local Postgres + MinIO + Temporal live matrix (#154).
+- Phase 1C: maintainer merge policy while branch protection is blocked (#152).
+
 ### Changed
+
+- Phase 1C status and milestones docs aligned with epic #151 backlog (#155).
+- Release process documents tag workflow asset verification (#153).
+- Go QUICKSTART demos and live stack links after first-success audit (#156).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,11 @@ Local dependency audit (optional): `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_au
 
 #### Optional local integration services
 
+**Preferred (full stack):** [docs/LIVE_INTEGRATION_DOCKER.md](docs/LIVE_INTEGRATION_DOCKER.md)
+and root [`docker-compose.live.yml`](docker-compose.live.yml) (Postgres + MinIO + Temporal).
+
+One-off containers (same env vars as the compose guide):
+
 Postgres:
 
 ```bash
@@ -153,12 +158,14 @@ go test ./conformance -count=1 -v
 Optional Temporal (needs a local server and worker; not required for default tests):
 
 ```bash
+# Full stack: docker compose -f docker-compose.live.yml up -d
 # TEMPORAL_HOSTPORT=localhost:7233
 go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v
 ```
 
 See `go/README.md` for package map, client usage, and backend choices
-(LocalSQLite coding default, Temporal production target).
+(LocalSQLite coding default, Temporal production target). Live stack:
+[docs/LIVE_INTEGRATION_DOCKER.md](docs/LIVE_INTEGRATION_DOCKER.md).
 
 ## 5. Local setup (Python, reference port)
 

--- a/docker-compose.live.yml
+++ b/docker-compose.live.yml
@@ -1,0 +1,75 @@
+# Vacant live-integration sandbox for Trajectory IR maintainers.
+# Hosts Postgres (NodeLog), MinIO (S3 CAS), and Temporal (Go durable).
+#
+# Usage: see docs/LIVE_INTEGRATION_DOCKER.md
+# Not required for offline unit/conformance CI.
+
+services:
+  postgres:
+    image: postgres:16.6
+    container_name: trajir-live-postgres
+    environment:
+      POSTGRES_USER: trajir
+      POSTGRES_PASSWORD: trajir
+      POSTGRES_DB: trajir
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U trajir -d trajir"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+
+  # Separate database for Temporal auto-setup (do not share trajir app DB).
+  temporal-postgres:
+    image: postgres:16.6
+    container_name: trajir-live-temporal-pg
+    environment:
+      POSTGRES_USER: temporal
+      POSTGRES_PASSWORD: temporal
+      POSTGRES_DB: temporal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U temporal -d temporal"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+
+  minio:
+    image: quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z
+    container_name: trajir-live-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  # One-shot: ensure the S3 bucket exists for live CAS tests.
+  minio-init:
+    image: minio/mc:RELEASE.2024-11-17T19-35-56Z
+    container_name: trajir-live-minio-init
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      sleep 3;
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb --ignore-existing local/trajir;
+      exit 0;
+      "
+
+  temporal:
+    image: temporalio/auto-setup:1.25.2
+    container_name: trajir-live-temporal
+    depends_on:
+      temporal-postgres:
+        condition: service_healthy
+    environment:
+      DB: postgres12
+      DB_PORT: 5432
+      POSTGRES_USER: temporal
+      POSTGRES_PWD: temporal
+      POSTGRES_SEEDS: temporal-postgres
+    ports:
+      - "7233:7233"

--- a/docker-compose.live.yml
+++ b/docker-compose.live.yml
@@ -44,19 +44,24 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
 
   # One-shot: ensure the S3 bucket exists for live CAS tests.
   minio-init:
     image: minio/mc:RELEASE.2024-11-17T19-35-56Z
     container_name: trajir-live-minio-init
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      sleep 3;
-      mc alias set local http://minio:9000 minioadmin minioadmin;
-      mc mb --ignore-existing local/trajir;
-      exit 0;
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing local/trajir
       "
 
   temporal:

--- a/docs/LIVE_INTEGRATION_DOCKER.md
+++ b/docs/LIVE_INTEGRATION_DOCKER.md
@@ -1,0 +1,110 @@
+# Live integration Docker sandbox
+
+Vacant local stack for **Postgres NodeLog**, **MinIO S3 CAS**, and **Temporal**
+(Go durable). Offline unit and conformance tests do **not** need this.
+
+Compose file (repo root): [`docker-compose.live.yml`](../docker-compose.live.yml)
+
+Tracked under Phase 1C: [#154](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/154).
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine) with a **running Linux engine**
+  - Confirm: `docker version` shows a **Server** version (not only Client)
+  - On Windows, if the Server section is missing, wait until `wsl -l -v`
+    shows `docker-desktop` as **Running**
+- Go 1.25.x and Python 3.11+ (for running the live tests against the stack)
+- Free host ports: `5432`, `9000`, `9001`, `7233`
+
+## Start
+
+From the repository root:
+
+```bash
+docker compose -f docker-compose.live.yml up -d
+docker compose -f docker-compose.live.yml ps
+```
+
+Wait until `trajir-live-postgres` is healthy and MinIO answers:
+
+```bash
+# Postgres
+docker exec trajir-live-postgres pg_isready -U trajir -d trajir
+
+# MinIO (from the host)
+curl -sf http://127.0.0.1:9000/minio/health/live
+```
+
+Temporal may take longer on first pull. Frontend: `localhost:7233`.
+
+## Environment
+
+Export these for live tests (Unix shell):
+
+```bash
+export TRAJIR_DATABASE_URL=postgresql://trajir:trajir@127.0.0.1:5432/trajir
+export TRAJIR_S3_ENDPOINT_URL=http://127.0.0.1:9000
+export TRAJIR_S3_BUCKET=trajir
+export AWS_ACCESS_KEY_ID=minioadmin
+export AWS_SECRET_ACCESS_KEY=minioadmin
+export AWS_DEFAULT_REGION=us-east-1
+export TEMPORAL_HOSTPORT=localhost:7233
+```
+
+PowerShell:
+
+```powershell
+$env:TRAJIR_DATABASE_URL = "postgresql://trajir:trajir@127.0.0.1:5432/trajir"
+$env:TRAJIR_S3_ENDPOINT_URL = "http://127.0.0.1:9000"
+$env:TRAJIR_S3_BUCKET = "trajir"
+$env:AWS_ACCESS_KEY_ID = "minioadmin"
+$env:AWS_SECRET_ACCESS_KEY = "minioadmin"
+$env:AWS_DEFAULT_REGION = "us-east-1"
+$env:TEMPORAL_HOSTPORT = "localhost:7233"
+```
+
+## Live matrix commands
+
+### Python (reference port)
+
+```bash
+pip install -e ".[dev,postgres,s3]"
+pytest test/integration/test_postgres_live.py -q
+pytest test/integration/test_s3_minio_live.py -q
+```
+
+Optional single live NodeLog case under unit:
+
+```bash
+pytest test/unit/test_postgres_node_log.py -q -k live
+```
+
+### Go (primary)
+
+```bash
+cd go
+go test ./trajir/postgres/... -count=1 -v
+go test ./trajir/cas -run TestLiveS3StoreFromEnvRoundTrip -count=1 -v
+go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v
+```
+
+## Teardown
+
+```bash
+docker compose -f docker-compose.live.yml down -v
+```
+
+## Partial stack
+
+Postgres + MinIO only (skip Temporal image):
+
+```bash
+docker compose -f docker-compose.live.yml up -d postgres minio minio-init
+```
+
+## Related
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) (one-off `docker run` recipes)
+- [E2E_POSTGRES_CAS_THIN.md](E2E_POSTGRES_CAS_THIN.md)
+- [PHASE_1C_STATUS.md](PHASE_1C_STATUS.md)
+- [go/QUICKSTART.md](../go/QUICKSTART.md)

--- a/docs/LIVE_INTEGRATION_DOCKER.md
+++ b/docs/LIVE_INTEGRATION_DOCKER.md
@@ -25,7 +25,9 @@ docker compose -f docker-compose.live.yml up -d
 docker compose -f docker-compose.live.yml ps
 ```
 
-Wait until `trajir-live-postgres` is healthy and MinIO answers:
+Wait until services are healthy (`docker compose ... ps` shows healthy for
+postgres and minio). Compose already healthchecks MinIO and runs `minio-init`
+only after MinIO is healthy; bucket create fails closed if `mc` errors.
 
 ```bash
 # Postgres
@@ -33,6 +35,9 @@ docker exec trajir-live-postgres pg_isready -U trajir -d trajir
 
 # MinIO (from the host)
 curl -sf http://127.0.0.1:9000/minio/health/live
+
+# Bucket init one-shot should have exited 0
+docker compose -f docker-compose.live.yml ps -a minio-init
 ```
 
 Temporal may take longer on first pull. Frontend: `localhost:7233`.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -13,7 +13,7 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 | **Phase 1A library baseline (v0.1.0)** | Closed | First library tag. Historical only. |
 | **v0.1.1 post 0.1.0 patch** | Closed | Absorbed into history; public cut advanced to v0.2.0. |
 | **Phase 1B Go primary SDK** | Closed | Complete; released as **v0.2.0**. |
-| **Phase 1C harden and adopt** | Open | Gates when plan allows, release automation, polish. |
+| **Phase 1C harden and adopt** | Open | Gates when plan allows, release proof, live Docker matrix, adoption polish. Epic [#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151). |
 | **Future deferred product** | Open | Signatures, Fluid, SaaS, etc. Park only. |
 
 ## Rules (follow these)
@@ -21,11 +21,15 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 1. **One milestone per issue and PR.** Set it when you open the issue, not at merge time.
 2. **Do not mix scopes.** Phase 1C harden work stays on Phase 1C. Deferred product ideas go to Future, not Phase 1C.
 3. **Exit criteria live in the milestone description.** Close the milestone only when those criteria are met (and the matching release or epic is done).
-4. **Suggested work order right now**
-   1. **Phase 1C**: branch protection when plan allows (#146), tag release workflow (#147), status docs (#148).
-   2. Keep product non goals under **Future deferred product**.
-5. **Future milestone is a parking lot.** Implementing from Future needs a README scope bump (§14) and a new active milestone or epic first.
-6. **Labels still matter** (`go`, `phase-1b`, `SPEC-QUESTION`, …). Milestone answers *when/why*; labels answer *kind of work*.
+4. **Suggested work order right now (Phase 1C)**
+   1. Maintainer merge policy while #146 blocked ([#152](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/152))
+   2. Docker live matrix docs/compose ([#154](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/154))
+   3. Status docs keep pace ([#155](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/155))
+   4. First-success Go path audit ([#156](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/156))
+   5. Next `v*` tag: prove Release attaches wheel/sdist ([#153](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/153))
+   6. Branch protection when public or paid plan allows ([#146](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/146))
+5. **Future milestone is a parking lot.** Implementing from Future needs a README scope bump (§14) and a new active milestone or epic first. Example: [#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149) signatures.
+6. **Labels still matter** (`go`, `phase-1c`, `SPEC-QUESTION`, …). Milestone answers *when/why*; labels answer *kind of work*.
 
 ## How to assign (maintainers and contributors)
 
@@ -44,4 +48,7 @@ In the GitHub UI: issue/PR sidebar → Milestone.
 - Master spec phases: root `README.md` §5
 - Phase 1A inventory: [PHASE_1A_STATUS.md](PHASE_1A_STATUS.md)
 - Phase 1B program: epic [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113)
+- Phase 1C status: [PHASE_1C_STATUS.md](PHASE_1C_STATUS.md)
+- Phase 1C epic: [#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151)
 - Release process: [RELEASE.md](RELEASE.md)
+- Live Docker stack: [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKER.md)

--- a/docs/PHASE_1C_STATUS.md
+++ b/docs/PHASE_1C_STATUS.md
@@ -1,41 +1,59 @@
 # Phase 1C status (harden and adopt)
 
 Follow on after **v0.2.0** (Phase 1B Go primary). Focus: enforce quality on
-merge, automate release cuts, and polish adoption without new Phase 2 product
-scope.
+merge, prove release automation, deepen live integrations, and polish adoption
+without new Phase 2 product scope.
 
-Milestone: **Phase 1C harden and adopt**
+Milestone: **[Phase 1C harden and adopt](https://github.com/Coder-s-OG-s/Trajectory-IR/milestone/5)**  
+Epic: **[#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151)**
 
 ## Goals
 
 | Issue | Topic | Status |
 |-------|--------|--------|
-| #146 | Enable required status checks on `main` when plan allows | Open (blocked on private free GitHub: needs public or paid plan) |
-| #147 | Release workflow on `v*` tags (wheel + release assets) | In progress with this doc PR when shipped |
-| #148 | This status doc + maintainer checklist | This file |
+| [#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151) | Epic: Phase 1C tracking | Open |
+| [#146](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/146) | Required status checks on `main` when plan allows | Open (blocked: private free GitHub 403) |
+| [#152](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/152) | Maintainer merge policy while protection blocked | Open → this PR documents checklist |
+| [#153](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/153) | Verify Release workflow attaches wheel/sdist on next `v*` tag | Open (workflow on main; v0.2.0 assets empty until next cut) |
+| [#154](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/154) | Docker Compose live matrix (Postgres + MinIO + Temporal) | Open → `docker-compose.live.yml` + [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKER.md) |
+| [#155](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/155) | Refresh this status doc + milestones | Open → this file |
+| [#156](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/156) | First-success Go QUICKSTART + demos audit | Open → go path re-verified green |
+| [#147](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/147) | Release workflow on `v*` tags | **Closed** (workflow landed) |
+| [#148](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/148) | Initial Phase 1C status scaffold | **Closed** |
 
 ## Done already on main (inherited)
 
 - Green PR CI: Quality, Go, Package smoke, Security, Conformance, Integration Postgres/MinIO (Python + Go live paths)
-- Go coverage floor 80% (unit set)
+- Go coverage floor 80% (unit set; Temporal package excluded from floor only)
 - Cross language `.tir` golden
 - Tagged **v0.2.0** Phase 1B release
+- `.github/workflows/release.yml` on `v*` tags (build + attach dist)
 
 ## Branch protection note
 
 API returns HTTP 403 for branch protection on this private free repo. Until the
 org upgrades or the repo is public, **policy** remains: only merge green PRs,
-prefer squash, keep `main` up to date. Track unlock under #146.
+prefer squash, keep `main` up to date. Permanent unlock: [#146](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/146).
+Temporary checklist: [maintainer-branch-protection.md](maintainer-branch-protection.md)
+(section **Merge policy while protection is blocked**).
 
 ## Maintainer checklist (post v0.2.0)
 
 1. Confirm latest `main` CI is green.
-2. Prefer milestone **Phase 1C** for new harden work; park signatures/Fluid/SaaS under **Future deferred product**.
-3. When cutting a tag: `pyproject.toml` version, CHANGELOG section, annotated tag, GitHub Release notes.
-4. After #147: verify tag push builds and attaches wheel/sdist.
+2. Prefer milestone **Phase 1C** for new harden work; park signatures/Fluid/SaaS under **Future deferred product** ([#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149)).
+3. When cutting a tag: `pyproject.toml` version, CHANGELOG section, annotated tag, GitHub Release notes; confirm **Release** workflow attaches wheel + sdist ([RELEASE.md](RELEASE.md)).
+4. Live services locally: [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKER.md).
+5. First-success path: [go/QUICKSTART.md](../go/QUICKSTART.md).
+
+## Explicitly not Phase 1C product
+
+- Package signatures ([#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149))
+- Fluid / multi-tenant SaaS / automated PyPI Trusted Publishing (Future milestone)
 
 ## Related
 
 - [PHASE_1B_STATUS.md](PHASE_1B_STATUS.md)
+- [MILESTONES.md](MILESTONES.md)
 - [RELEASE.md](RELEASE.md)
 - [RELEASE_NOTES_0.2.0.md](RELEASE_NOTES_0.2.0.md)
+- [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKER.md)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -3,12 +3,43 @@
 How to cut a GitHub release and optionally publish to PyPI. **Do not** push tags
 from unreviewed automation. Package owner credentials never belong in the repo.
 
+## Automated dist on `v*` tags (#147 / #153)
+
+Workflow: [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+
+On every push of a tag matching `v*`:
+
+1. Build sdist + wheel (`python -m build`)
+2. `twine check dist/*`
+3. Upload Actions artifacts (`python-dist`)
+4. Attach `dist/*` to the GitHub Release for that tag (`softprops/action-gh-release`)
+
+### Verify after a tag push (#153)
+
+```bash
+# Workflow must be green
+gh run list --workflow=release.yml --limit 5
+
+# Release must list wheel + sdist assets (not empty)
+gh release view vX.Y.Z --json assets,url
+```
+
+**Baseline note:** `v0.2.0` was cut as a Phase 1B library tag; its Release
+currently has **no attached wheel/sdist** (manual notes only). The **next**
+version tag on `main` (with release.yml present) is the acceptance run for
+#153: green `Release` workflow + non-empty assets.
+
+If the workflow is green but assets are missing, check that a GitHub Release
+object exists for the tag (the action creates/updates it) and that
+`permissions: contents: write` remains on the workflow.
+
 ## Preconditions
 
 1. `main` is green (Quality + Go green on the merge commit / latest PR).
 2. CHANGELOG has a version section that matches what you intend to ship.
 3. Working tree clean; `git pull origin main`.
 4. You have rights to push tags and (for PyPI) upload the project.
+5. After the tag push: confirm **Release** workflow green and assets attached.
 
 ## Version numbers
 
@@ -42,12 +73,14 @@ git tag -a v0.2.0 -m "Trajectory IR v0.2.0 Phase 1B Go primary SDK"
 git push origin v0.2.0
 ```
 
-Create a **GitHub Release** for the tag:
+Create or update a **GitHub Release** for the tag:
 
-1. Title: `v0.2.0`
+1. Title: `v0.2.0` (or the version you are cutting)
 2. Body: paste or adapt [RELEASE_NOTES_0.2.0.md](RELEASE_NOTES_0.2.0.md)
    (older notes: [RELEASE_NOTES_0.1.1.md](RELEASE_NOTES_0.1.1.md), [RELEASE_NOTES_0.1.0.md](RELEASE_NOTES_0.1.0.md))
-3. Attach nothing required (source zip is automatic)
+3. Prefer letting **release.yml** attach wheel + sdist automatically on tag push.
+   Source zip remains automatic from GitHub.
+4. Confirm assets: `gh release view vX.Y.Z --json assets`
 
 ### Historical: v0.1.0
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -2,9 +2,9 @@
 
 Do this after CI has produced green check names on `main` or on a PR.
 
-## Status (issue #128, part 1)
+## Status (issue #146, Phase 1C)
 
-Re-verified 2026-08-08 against the live repo:
+Re-verified against the live repo (still private free tier):
 
 ```bash
 gh api repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection
@@ -13,10 +13,28 @@ gh api repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection
 ```
 
 Branch protection is still blocked on the plan/visibility decision below.
-Nothing else in this doc can take effect (main stays ungated, a red PR can
-still be merged by anyone with write access) until a maintainer picks one of
-the two options and someone with admin rights on the repo runs the CLI step
-near the bottom of this doc.
+Until a maintainer unlocks #146, **main is not machine-gated**: a red PR can
+still be merged by anyone with write access. Use the merge policy section next.
+
+## Merge policy while protection is blocked (#152)
+
+**Temporary.** Replace with required checks after #146 lands. Maintainers MUST:
+
+1. **Do not merge** unless the latest PR commit shows green:
+   - Fast: `DCO`, `Quality (Python 3.11)`, `Quality (Python 3.12)`,
+     `Package smoke`, `Security (pip-audit)`, `Go`
+   - Deep: `Conformance & E2E (Python 3.11)`, `Conformance & E2E (Python 3.12)`
+   - Integration (when jobs ran on the PR): `Integration (Postgres)`,
+     `Integration (MinIO)`
+2. Prefer **squash** merge; keep the PR branch **up to date** with `main`
+   (repo `allow_update_branch` is enabled).
+3. Require **Signed-off-by** / DCO on every commit in the PR.
+4. **No force push** to `main`; no direct commits to `main` for product work.
+5. Assign milestone **Phase 1C harden and adopt** (or Future) before merge.
+6. After merge: confirm `main` CI is green; close shipped issues with the PR link.
+
+Solo maintainers still follow this list. When #146 is enabled, keep the same
+check names as required contexts and treat this section as historical.
 
 ## GitHub plan note (important)
 
@@ -24,12 +42,12 @@ This repository is currently **private**. On GitHub’s free plan for private
 repos, **classic branch protection** and **repository rulesets** return HTTP
 403 (“Upgrade to GitHub Pro or make this repository public”).
 
-To enable step 1 of post-v0.1.0 stabilization, pick one:
+To enable automated gates (#146), pick one:
 
 1. **Make the repo public** (free branch protection + free secret scanning for public repos), or  
 2. **Upgrade the org/user to a plan that includes branch protection on private repos** (GitHub Pro / Team / Enterprise as applicable).
 
-Until then, enforce process by policy: only merge green PRs, prefer squash, and use **Update branch** (repo setting `allow_update_branch` is enabled).
+Until then, enforce process by the **Merge policy** section above.
 
 ## Recommended settings
 
@@ -61,7 +79,7 @@ Deep gate:
 7. `Conformance & E2E (Python 3.11)`: e2e crash/resume, full `conformance/` R01-R08
 8. `Conformance & E2E (Python 3.12)`: same as 3.11
 
-Optional after Phase B is proven stable (issue #85):
+Integration (require once stable on every PR, Phase 1C preference):
 
 9. `Integration (Postgres)`
 10. `Integration (MinIO)`
@@ -100,7 +118,7 @@ After large merges (packages, conformance, security):
 1. Latest `main` CI is green (all six check families above).
 2. Required checks still match the names above (rename jobs only with a protection update).
 3. Close GitHub issues that already shipped (link the merge PR).
-4. Skim [QUICKSTART.md](../QUICKSTART.md) and [PHASE_1A_STATUS.md](PHASE_1A_STATUS.md) for fictional APIs.
+4. Skim [QUICKSTART.md](../QUICKSTART.md), [go/QUICKSTART.md](../go/QUICKSTART.md), and [PHASE_1C_STATUS.md](PHASE_1C_STATUS.md) for fictional APIs.
 5. Prefer Dependabot PRs reviewed weekly; do not bulk-merge without CI.
 
 ## Order
@@ -129,7 +147,9 @@ gh api -X PUT repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection \
       "Security (pip-audit)",
       "Go",
       "Conformance & E2E (Python 3.11)",
-      "Conformance & E2E (Python 3.12)"
+      "Conformance & E2E (Python 3.12)",
+      "Integration (Postgres)",
+      "Integration (MinIO)"
     ]
   },
   "enforce_admins": false,

--- a/go/QUICKSTART.md
+++ b/go/QUICKSTART.md
@@ -1,13 +1,15 @@
-# Go quickstart (Phase 1B primary path)
+# Go quickstart (primary path)
 
-First success path without Python. Matches APIs under `go/trajir` on `main`.
+First success path without Python. Matches APIs under `go/trajir` on `main`
+(Phase 1B shipped as **v0.2.0**; Phase 1C is harden/adopt).
 
 ## Prerequisites
 
 - Go **1.25.x** (see `go/go.mod`)
 - Git
 
-Optional later: Docker Postgres/MinIO, Temporal for production durable backends.
+Optional later: Docker Postgres/MinIO/Temporal for live drivers
+([docs/LIVE_INTEGRATION_DOCKER.md](../docs/LIVE_INTEGRATION_DOCKER.md)).
 
 ## 1. Clone and test
 
@@ -83,10 +85,19 @@ go test ./trajir/client/... -count=1
 
 ## 3. Demos
 
+From `go/` (no paid model API):
+
+```bash
+go run ./examples/adoption_host
+go run ./examples/adoption_host -sandbox
+go run ./examples/adoption_host -with-package
+go run ./examples/kill-mid-deploy -workdir ./demo-data
+```
+
 | Demo | Command | Intent |
 |------|---------|--------|
-| Kill mid deploy | `go run ./examples/kill-mid-deploy -workdir ./demo-data` | Crash safety |
-| Adoption host | `go run ./examples/adoption_host` (when merged) | Host seal loop + optional CAS |
+| Adoption host | `go run ./examples/adoption_host` | Host seal loop + optional CAS / thin `.tir` |
+| Kill mid deploy | `go run ./examples/kill-mid-deploy -workdir ./demo-data` | Crash safety / sealed plan |
 
 ## 4. Durable backends
 
@@ -96,13 +107,23 @@ go test ./trajir/client/... -count=1
 | Temporal | Production for Go |
 
 ```bash
-# optional live Temporal check
+# optional live Temporal check (stack: docs/LIVE_INTEGRATION_DOCKER.md)
 # TEMPORAL_HOSTPORT=localhost:7233
 go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v
 ```
 
-## 5. Next
+## 5. Live drivers (optional)
+
+```bash
+# from repo root
+docker compose -f docker-compose.live.yml up -d
+# then export TRAJIR_DATABASE_URL / MinIO env / TEMPORAL_HOSTPORT
+# see docs/LIVE_INTEGRATION_DOCKER.md
+```
+
+## 6. Next
 
 - Package map: [README.md](README.md)
-- Phase 1B epic: [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113)
+- Phase 1C status: [../docs/PHASE_1C_STATUS.md](../docs/PHASE_1C_STATUS.md)
+- Phase 1B epic (closed): [#113](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/113)
 - Root docs (includes Python reference path): [../QUICKSTART.md](../QUICKSTART.md)


### PR DESCRIPTION
## Summary

Implements the open Phase 1C backlog under epic #151 (post v0.2.0 harden and adopt).

- **#152** — Maintainer merge policy while branch protection is blocked (`docs/maintainer-branch-protection.md`)
- **#154** — `docker-compose.live.yml` + `docs/LIVE_INTEGRATION_DOCKER.md` (Postgres, MinIO, Temporal)
- **#155** — Refresh `PHASE_1C_STATUS.md` and `MILESTONES.md` to match open issues
- **#156** — First-success Go path re-verified (`go test ./...`, adoption host, kill-mid-deploy); QUICKSTART demos/live links updated
- **#153** — Release workflow verification steps in `docs/RELEASE.md` (v0.2.0 still has empty assets; issue stays open until next `v*` cut proves attach)
- **#146** — Unchanged plan block; temporary policy points at permanent unlock

## Test plan

- [x] `cd go && go test ./... -count=1` (pass)
- [x] `go run ./examples/adoption_host` and `-with-package` (pass)
- [x] `go run ./examples/kill-mid-deploy -workdir ...` (pass)
- [ ] CI green on this PR
- [ ] Optional: `docker compose -f docker-compose.live.yml up -d` when Docker engine is stable, then live matrix from `docs/LIVE_INTEGRATION_DOCKER.md`

## Notes

- Does **not** enable GitHub branch protection (#146 still plan-blocked)
- Does **not** close #153 until a real tag attaches wheel/sdist
- Future #149 signatures remains parked

Closes #152
Closes #154
Closes #155
Closes #156