### PR TITLE
fix: live Docker matrix smoke scripts (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Phase 1C: `docker-compose.live.yml` and `docs/LIVE_INTEGRATION_DOCKER.md` for
   local Postgres + MinIO + Temporal live matrix (#154).
 - Phase 1C: maintainer merge policy while branch protection is blocked (#152).
+- Phase 1C: `scripts/run_live_matrix.sh` / `.ps1` for local live smoke (#160).
 
 ### Changed
 
 - Phase 1C status and milestones docs aligned with epic #151 backlog (#155).
 - Release process documents tag workflow asset verification (#153).
 - Go QUICKSTART demos and live stack links after first-success audit (#156).
+- Live compose: drop broken `minio/mc` one-shot; create bucket via Python (#160).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,13 @@ Local dependency audit (optional): `RUN_PIP_AUDIT=1 pytest test/unit/test_pip_au
 **Preferred (full stack):** [docs/LIVE_INTEGRATION_DOCKER.md](docs/LIVE_INTEGRATION_DOCKER.md)
 and root [`docker-compose.live.yml`](docker-compose.live.yml) (Postgres + MinIO + Temporal).
 
+One-command smoke (when Docker Server is up):
+
+```bash
+./scripts/run_live_matrix.sh
+# Windows: .\scripts\run_live_matrix.ps1
+```
+
 One-off containers (same env vars as the compose guide):
 
 Postgres:

--- a/docker-compose.live.yml
+++ b/docker-compose.live.yml
@@ -3,6 +3,9 @@
 #
 # Usage: see docs/LIVE_INTEGRATION_DOCKER.md
 # Not required for offline unit/conformance CI.
+#
+# Bucket create: use scripts/run_live_matrix.sh|.ps1 (Python boto3 / AWS CLI),
+# not a one-shot mc container (pins break when tags vanish from Docker Hub).
 
 services:
   postgres:
@@ -45,24 +48,12 @@ services:
       - "9000:9000"
       - "9001:9001"
     healthcheck:
+      # Official MinIO image ships curl; live endpoint is the supported probe.
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 3s
       timeout: 5s
       retries: 30
-      start_period: 5s
-
-  # One-shot: ensure the S3 bucket exists for live CAS tests.
-  minio-init:
-    image: minio/mc:RELEASE.2024-11-17T19-35-56Z
-    container_name: trajir-live-minio-init
-    depends_on:
-      minio:
-        condition: service_healthy
-    entrypoint: >
-      /bin/sh -c "
-      mc alias set local http://minio:9000 minioadmin minioadmin &&
-      mc mb --ignore-existing local/trajir
-      "
+      start_period: 10s
 
   temporal:
     image: temporalio/auto-setup:1.25.2

--- a/docs/LIVE_INTEGRATION_DOCKER.md
+++ b/docs/LIVE_INTEGRATION_DOCKER.md
@@ -5,39 +5,70 @@ Vacant local stack for **Postgres NodeLog**, **MinIO S3 CAS**, and **Temporal**
 
 Compose file (repo root): [`docker-compose.live.yml`](../docker-compose.live.yml)
 
-Tracked under Phase 1C: [#154](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/154).
+Tracked under Phase 1C: [#154](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/154),
+smoke automation [#160](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/160).
 
 ## Prerequisites
 
 - Docker Desktop (or Docker Engine) with a **running Linux engine**
   - Confirm: `docker version` shows a **Server** version (not only Client)
   - On Windows, if the Server section is missing, wait until `wsl -l -v`
-    shows `docker-desktop` as **Running**
-- Go 1.25.x and Python 3.11+ (for running the live tests against the stack)
-- Free host ports: `5432`, `9000`, `9001`, `7233`
+    shows `docker-desktop` as **Running**, then re-check `docker version`
+- Go 1.25.x and Python 3.11+ with `pip install -e ".[dev,postgres,s3]"`
+- Free host ports: `5432`, `9000`, `9001`, `7233` (7233 only if Temporal is up)
 
-## Start
+## One command smoke (preferred)
 
-From the repository root:
+From the repository root, with Docker **Server** healthy:
 
 ```bash
-docker compose -f docker-compose.live.yml up -d
+# Unix
+chmod +x scripts/run_live_matrix.sh
+./scripts/run_live_matrix.sh              # Postgres + MinIO + live tests
+./scripts/run_live_matrix.sh --with-temporal   # also Temporal integration
+./scripts/run_live_matrix.sh --up-only         # start stack only
+```
+
+```powershell
+# Windows PowerShell
+.\scripts\run_live_matrix.ps1
+.\scripts\run_live_matrix.ps1 -WithTemporal
+.\scripts\run_live_matrix.ps1 -UpOnly
+```
+
+The script:
+
+1. Starts compose services (postgres + minio; Temporal optional)
+2. Waits until Postgres and MinIO answer health probes
+3. Creates the `trajir` bucket via Python (`drivers.s3`) if missing
+4. Runs Python and Go live tests
+
+## Manual start
+
+```bash
+docker compose -f docker-compose.live.yml up -d postgres minio
+# full stack including Temporal:
+# docker compose -f docker-compose.live.yml up -d
 docker compose -f docker-compose.live.yml ps
 ```
 
-Wait until services are healthy (`docker compose ... ps` shows healthy for
-postgres and minio). Compose already healthchecks MinIO and runs `minio-init`
-only after MinIO is healthy; bucket create fails closed if `mc` errors.
+Wait until services are healthy:
 
 ```bash
-# Postgres
 docker exec trajir-live-postgres pg_isready -U trajir -d trajir
-
-# MinIO (from the host)
 curl -sf http://127.0.0.1:9000/minio/health/live
+```
 
-# Bucket init one-shot should have exited 0
-docker compose -f docker-compose.live.yml ps -a minio-init
+MinIO healthcheck is defined in compose (`curl` against `/minio/health/live`).
+The bucket is **not** created by a one-shot `mc` container (tags on Docker Hub
+have disappeared mid-stream); create it with the smoke script or:
+
+```bash
+export TRAJIR_S3_ENDPOINT_URL=http://127.0.0.1:9000
+export TRAJIR_S3_BUCKET=trajir
+export AWS_ACCESS_KEY_ID=minioadmin
+export AWS_SECRET_ACCESS_KEY=minioadmin
+python -c "from drivers.s3.cas import build_s3_client_from_env; c=build_s3_client_from_env(); c.create_bucket(Bucket='trajir')"
 ```
 
 Temporal may take longer on first pull. Frontend: `localhost:7233`.
@@ -68,7 +99,7 @@ $env:AWS_DEFAULT_REGION = "us-east-1"
 $env:TEMPORAL_HOSTPORT = "localhost:7233"
 ```
 
-## Live matrix commands
+## Live matrix commands (manual)
 
 ### Python (reference port)
 
@@ -76,12 +107,6 @@ $env:TEMPORAL_HOSTPORT = "localhost:7233"
 pip install -e ".[dev,postgres,s3]"
 pytest test/integration/test_postgres_live.py -q
 pytest test/integration/test_s3_minio_live.py -q
-```
-
-Optional single live NodeLog case under unit:
-
-```bash
-pytest test/unit/test_postgres_node_log.py -q -k live
 ```
 
 ### Go (primary)
@@ -101,15 +126,21 @@ docker compose -f docker-compose.live.yml down -v
 
 ## Partial stack
 
-Postgres + MinIO only (skip Temporal image):
+Postgres + MinIO only (default for the smoke script):
 
 ```bash
-docker compose -f docker-compose.live.yml up -d postgres minio minio-init
+docker compose -f docker-compose.live.yml up -d postgres minio
 ```
+
+## Windows Docker Desktop note
+
+If `docker compose` fails with a missing `dockerDesktopLinuxEngine` pipe, the
+Linux engine dropped. Restart Docker Desktop and wait until
+`docker version` prints a **Server** version before re-running the smoke script.
 
 ## Related
 
-- [CONTRIBUTING.md](../CONTRIBUTING.md) (one-off `docker run` recipes)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
 - [E2E_POSTGRES_CAS_THIN.md](E2E_POSTGRES_CAS_THIN.md)
 - [PHASE_1C_STATUS.md](PHASE_1C_STATUS.md)
 - [go/QUICKSTART.md](../go/QUICKSTART.md)

--- a/scripts/run_live_matrix.ps1
+++ b/scripts/run_live_matrix.ps1
@@ -1,0 +1,98 @@
+# Smoke the live integration matrix against docker-compose.live.yml.
+# Usage (from repo root):
+#   .\scripts\run_live_matrix.ps1
+#   .\scripts\run_live_matrix.ps1 -WithTemporal
+#   .\scripts\run_live_matrix.ps1 -UpOnly
+param(
+    [switch]$WithTemporal,
+    [switch]$UpOnly,
+    [switch]$SkipUp
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $Root
+
+$env:TRAJIR_DATABASE_URL = if ($env:TRAJIR_DATABASE_URL) { $env:TRAJIR_DATABASE_URL } else { "postgresql://trajir:trajir@127.0.0.1:5432/trajir" }
+$env:TRAJIR_S3_ENDPOINT_URL = if ($env:TRAJIR_S3_ENDPOINT_URL) { $env:TRAJIR_S3_ENDPOINT_URL } else { "http://127.0.0.1:9000" }
+$env:TRAJIR_S3_BUCKET = if ($env:TRAJIR_S3_BUCKET) { $env:TRAJIR_S3_BUCKET } else { "trajir" }
+$env:AWS_ACCESS_KEY_ID = if ($env:AWS_ACCESS_KEY_ID) { $env:AWS_ACCESS_KEY_ID } else { "minioadmin" }
+$env:AWS_SECRET_ACCESS_KEY = if ($env:AWS_SECRET_ACCESS_KEY) { $env:AWS_SECRET_ACCESS_KEY } else { "minioadmin" }
+$env:AWS_DEFAULT_REGION = if ($env:AWS_DEFAULT_REGION) { $env:AWS_DEFAULT_REGION } else { "us-east-1" }
+$env:TEMPORAL_HOSTPORT = if ($env:TEMPORAL_HOSTPORT) { $env:TEMPORAL_HOSTPORT } else { "localhost:7233" }
+
+if (-not $SkipUp) {
+    Write-Host "==> docker compose up"
+    if ($WithTemporal) {
+        docker compose -f docker-compose.live.yml up -d
+    } else {
+        docker compose -f docker-compose.live.yml up -d postgres minio
+    }
+    if ($LASTEXITCODE -ne 0) { throw "docker compose up failed" }
+
+    Write-Host "==> wait postgres healthy"
+    $ok = $false
+    for ($i = 1; $i -le 60; $i++) {
+        docker exec trajir-live-postgres pg_isready -U trajir -d trajir 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { $ok = $true; break }
+        Start-Sleep -Seconds 2
+    }
+    if (-not $ok) { throw "postgres not ready" }
+
+    Write-Host "==> wait minio healthy"
+    $ok = $false
+    for ($i = 1; $i -le 60; $i++) {
+        try {
+            $r = Invoke-WebRequest -Uri "http://127.0.0.1:9000/minio/health/live" -UseBasicParsing -TimeoutSec 2
+            if ($r.StatusCode -eq 200) { $ok = $true; break }
+        } catch {}
+        Start-Sleep -Seconds 2
+    }
+    if (-not $ok) { throw "minio not ready" }
+}
+
+if ($UpOnly) {
+    Write-Host "stack is up; exiting (-UpOnly)"
+    exit 0
+}
+
+Write-Host "==> ensure MinIO bucket exists"
+python -c @"
+import os
+from drivers.s3.cas import build_s3_client_from_env
+bucket = os.environ['TRAJIR_S3_BUCKET']
+client = build_s3_client_from_env()
+try:
+    client.head_bucket(Bucket=bucket)
+    print('bucket exists:', bucket)
+except Exception:
+    client.create_bucket(Bucket=bucket)
+    print('bucket created:', bucket)
+"@
+if ($LASTEXITCODE -ne 0) { throw "bucket ensure failed (pip install -e '.[s3]' ?)" }
+
+Write-Host "==> Python live Postgres"
+python -m pytest test/integration/test_postgres_live.py -q
+if ($LASTEXITCODE -ne 0) { throw "postgres live failed" }
+
+Write-Host "==> Python live MinIO"
+python -m pytest test/integration/test_s3_minio_live.py -q
+if ($LASTEXITCODE -ne 0) { throw "minio live failed" }
+
+Write-Host "==> Go live Postgres"
+Push-Location go
+go test ./trajir/postgres/... -count=1
+if ($LASTEXITCODE -ne 0) { Pop-Location; throw "go postgres live failed" }
+Write-Host "==> Go live S3 CAS"
+go test ./trajir/cas -run TestLiveS3StoreFromEnvRoundTrip -count=1
+if ($LASTEXITCODE -ne 0) { Pop-Location; throw "go s3 live failed" }
+if ($WithTemporal) {
+    Write-Host "==> Go Temporal integration"
+    go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v
+    if ($LASTEXITCODE -ne 0) { Pop-Location; throw "temporal live failed" }
+} else {
+    Write-Host "==> skip Temporal (pass -WithTemporal to enable)"
+}
+Pop-Location
+
+Write-Host "OK: live matrix passed"

--- a/scripts/run_live_matrix.sh
+++ b/scripts/run_live_matrix.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Smoke the live integration matrix against docker-compose.live.yml.
+# Usage (from repo root):
+#   ./scripts/run_live_matrix.sh
+#   ./scripts/run_live_matrix.sh --with-temporal
+#   ./scripts/run_live_matrix.sh --up-only
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+WITH_TEMPORAL=0
+UP_ONLY=0
+SKIP_UP=0
+for arg in "$@"; do
+  case "$arg" in
+    --with-temporal) WITH_TEMPORAL=1 ;;
+    --up-only) UP_ONLY=1 ;;
+    --skip-up) SKIP_UP=1 ;;
+    -h|--help)
+      sed -n '1,8p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+export TRAJIR_DATABASE_URL="${TRAJIR_DATABASE_URL:-postgresql://trajir:trajir@127.0.0.1:5432/trajir}"
+export TRAJIR_S3_ENDPOINT_URL="${TRAJIR_S3_ENDPOINT_URL:-http://127.0.0.1:9000}"
+export TRAJIR_S3_BUCKET="${TRAJIR_S3_BUCKET:-trajir}"
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-minioadmin}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-minioadmin}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+export TEMPORAL_HOSTPORT="${TEMPORAL_HOSTPORT:-localhost:7233}"
+
+if [[ "$SKIP_UP" -eq 0 ]]; then
+  echo "==> docker compose up (postgres + minio$( [[ $WITH_TEMPORAL -eq 1 ]] && echo ' + temporal' ))"
+  if [[ "$WITH_TEMPORAL" -eq 1 ]]; then
+    docker compose -f docker-compose.live.yml up -d
+  else
+    docker compose -f docker-compose.live.yml up -d postgres minio
+  fi
+
+  echo "==> wait postgres healthy"
+  for i in $(seq 1 60); do
+    if docker exec trajir-live-postgres pg_isready -U trajir -d trajir >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+    if [[ "$i" -eq 60 ]]; then
+      echo "postgres not ready" >&2
+      exit 1
+    fi
+  done
+
+  echo "==> wait minio healthy"
+  for i in $(seq 1 60); do
+    if curl -sf "http://127.0.0.1:9000/minio/health/live" >/dev/null; then
+      break
+    fi
+    sleep 2
+    if [[ "$i" -eq 60 ]]; then
+      echo "minio not ready" >&2
+      exit 1
+    fi
+  done
+fi
+
+if [[ "$UP_ONLY" -eq 1 ]]; then
+  echo "stack is up; exiting (--up-only)"
+  exit 0
+fi
+
+echo "==> ensure MinIO bucket exists"
+python - <<'PY'
+import os
+from drivers.s3.cas import build_s3_client_from_env
+
+bucket = os.environ["TRAJIR_S3_BUCKET"]
+client = build_s3_client_from_env()
+try:
+    client.head_bucket(Bucket=bucket)
+    print(f"bucket exists: {bucket}")
+except Exception:
+    client.create_bucket(Bucket=bucket)
+    print(f"bucket created: {bucket}")
+PY
+
+echo "==> Python live Postgres"
+python -m pytest test/integration/test_postgres_live.py -q
+
+echo "==> Python live MinIO"
+python -m pytest test/integration/test_s3_minio_live.py -q
+
+echo "==> Go live Postgres"
+( cd go && go test ./trajir/postgres/... -count=1 )
+
+echo "==> Go live S3 CAS"
+( cd go && go test ./trajir/cas -run TestLiveS3StoreFromEnvRoundTrip -count=1 )
+
+if [[ "$WITH_TEMPORAL" -eq 1 ]]; then
+  echo "==> Go Temporal integration"
+  ( cd go && go test -tags=temporal_integration ./trajir/durable/temporal -count=1 -v )
+else
+  echo "==> skip Temporal (pass --with-temporal to enable)"
+fi
+
+echo "OK: live matrix passed"


### PR DESCRIPTION
## Summary

Next Phase 1C item after protection docs: **#160 live Docker smoke tooling**.

### Problem found while smoking
- `minio/mc:RELEASE.2024-11-17T19-35-56Z` **does not exist** on Docker Hub → `docker compose up` fails before any tests run.

### Changes
- Remove the `minio-init` one-shot service from `docker-compose.live.yml`
- Keep MinIO **healthcheck** + Postgres healthcheck
- Add `scripts/run_live_matrix.sh` and `scripts/run_live_matrix.ps1`:
  - up postgres/minio (optional Temporal)
  - wait healthy
  - create bucket via `drivers.s3`
  - run Python + Go live tests
- Update `docs/LIVE_INTEGRATION_DOCKER.md` and CONTRIBUTING

### Local note
Docker Desktop on the smoke host flaps (`dockerDesktopLinuxEngine` pipe). Full matrix should be re-run when the engine stays up:

```powershell
.\scripts\run_live_matrix.ps1
```

## Test plan
- [x] Identified missing `minio/mc` tag (compose fail)
- [x] Compose file no longer references that image
- [ ] CI green on this PR
- [ ] Maintainer: run smoke script with stable Docker Server

Closes #160