### PR TITLE
release: Trajectory IR 0.2.1 Phase 1C harden patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.2.1] - 2026-08-13
+
+Phase 1C harden-and-adopt patch: merge gates on public `main`, live Docker
+matrix tooling, and release workflow proof cut.
+
+### Added
+
 - Phase 1C: `docker-compose.live.yml` and `docs/LIVE_INTEGRATION_DOCKER.md` for
-  local Postgres + MinIO + Temporal live matrix (#154).
-- Phase 1C: maintainer merge policy while branch protection is blocked (#152).
+  local Postgres + MinIO + Temporal live matrix (#154, #157).
+- Phase 1C: maintainer merge policy while protection was blocked (#152, #157).
 - Phase 1C: classic branch protection on `main` with required CI checks
-  (#146, #158).
-- Phase 1C: `scripts/run_live_matrix.sh` / `.ps1` for local live smoke (#160).
+  (#146, #158, #163).
+- Phase 1C: `scripts/run_live_matrix.sh` / `.ps1` for local live smoke (#160, #164).
 
 ### Changed
 
-- Phase 1C status and milestones docs aligned with epic #151 backlog (#155).
-- Release process documents tag workflow asset verification (#153).
+- Phase 1C status and milestones docs (#155, #161).
+- Release process documents tag workflow asset verification (#153, #159).
 - Go QUICKSTART demos and live stack links after first-success audit (#156).
-- Maintainer protection docs and PHASE_1C_STATUS: protection enabled (#158, #161).
 - Live compose: drop broken `minio/mc` one-shot; create bucket via Python (#160).
 
 ### Fixed

--- a/docs/PHASE_1C_STATUS.md
+++ b/docs/PHASE_1C_STATUS.md
@@ -20,9 +20,9 @@ Epic: **[#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151)**
 | [#156](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/156) | First-success Go path audit | **Closed** (#157) |
 | [#147](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/147) | Release workflow on `v*` tags | **Closed** |
 | [#148](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/148) | Initial Phase 1C status scaffold | **Closed** |
-| [#159](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/159) | Prove Release attaches wheel/sdist on next tag | Open |
-| [#160](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/160) | Smoke live Docker stack on maintainer machine | Open |
-| [#161](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/161) | Refresh PHASE_1C_STATUS after #157 | This file |
+| [#159](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/159) | Prove Release attaches wheel/sdist on next tag | **In progress** (`v0.2.1` cut) |
+| [#160](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/160) | Smoke live Docker stack + matrix scripts | **Closed** (#164) |
+| [#161](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/161) | Refresh PHASE_1C_STATUS after #157 | **Closed** (#163) |
 | [#162](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/162) | Close Phase 1C when exit criteria met | Open |
 
 ## Done already on main

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,7 +14,7 @@ On every push of a tag matching `v*`:
 3. Upload Actions artifacts (`python-dist`)
 4. Attach `dist/*` to the GitHub Release for that tag (`softprops/action-gh-release`)
 
-### Verify after a tag push (#153)
+### Verify after a tag push (#153 / #159)
 
 ```bash
 # Workflow must be green
@@ -24,10 +24,9 @@ gh run list --workflow=release.yml --limit 5
 gh release view vX.Y.Z --json assets,url
 ```
 
-**Baseline note:** `v0.2.0` was cut as a Phase 1B library tag; its Release
-currently has **no attached wheel/sdist** (manual notes only). The **next**
-version tag on `main` (with release.yml present) is the acceptance run for
-#153: green `Release` workflow + non-empty assets.
+**History:** `v0.2.0` was cut as a Phase 1B library tag without release.yml
+assets (empty asset list). **`v0.2.1`** is the Phase 1C proof cut for #159:
+green `Release` workflow + non-empty wheel/sdist.
 
 If the workflow is green but assets are missing, check that a GitHub Release
 object exists for the tag (the action creates/updates it) and that
@@ -45,8 +44,8 @@ object exists for the tag (the action creates/updates it) and that
 
 | Surface | Where | Notes |
 |---------|--------|--------|
-| Python package | `pyproject.toml` → `project.version` | Current line: `0.2.0` (Phase 1B) |
-| Git tag | `v0.1.0` shipped; **`v0.2.0`** for Phase 1B | Prefer `v` prefix |
+| Python package | `pyproject.toml` → `project.version` | Current line: `0.2.1` (Phase 1C patch) |
+| Git tag | `v0.2.0` Phase 1B; **`v0.2.1`** Phase 1C harden | Prefer `v` prefix |
 | Go module | `go/go.mod` | No separate semver tag yet; consumers use commit or a later policy |
 
 ### Choosing 0.1.0 vs 0.1.1

--- a/docs/RELEASE_NOTES_0.2.1.md
+++ b/docs/RELEASE_NOTES_0.2.1.md
@@ -1,0 +1,35 @@
+# Trajectory IR v0.2.1
+
+Phase 1C patch after **v0.2.0** (Go primary). No breaking IR API changes.
+
+## Highlights
+
+- **Branch protection on `main`** with required CI checks (public repo).
+- **Live integration sandbox**: `docker-compose.live.yml` + smoke scripts
+  (`scripts/run_live_matrix.sh` / `.ps1`).
+- **Release workflow proof**: this tag should attach Python sdist + wheel via
+  `.github/workflows/release.yml` (#159).
+
+## Install
+
+```bash
+# from git tag
+pip install "git+https://github.com/Coder-s-OG-s/Trajectory-IR.git@v0.2.1"
+
+# or download wheel/sdist from the GitHub Release assets once the Release
+# workflow finishes
+```
+
+## Verify release assets
+
+```bash
+gh run list --workflow=release.yml --limit 3
+gh release view v0.2.1 --json assets,url
+```
+
+## Docs
+
+- [CHANGELOG.md](../CHANGELOG.md) `[0.2.1]`
+- [PHASE_1C_STATUS.md](PHASE_1C_STATUS.md)
+- [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKER.md)
+- [RELEASE.md](RELEASE.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trajectory-ir"
-version = "0.2.0"
+version = "0.2.1"
 description = "Portable, hash-verifiable intermediate representation for agent runs (seals, effects, .tir packages)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Phase 1C **0.2.1** patch cut to prove the tag Release workflow attaches Python dist assets (#159).

- `pyproject.toml` → `0.2.1`
- CHANGELOG `[0.2.1]` (protection, live compose/scripts, docs)
- `docs/RELEASE_NOTES_0.2.1.md`
- RELEASE.md / PHASE_1C_STATUS touch-ups

## After merge

```bash
git checkout main && git pull
git tag -a v0.2.1 -m "Trajectory IR v0.2.1 Phase 1C harden patch"
git push origin v0.2.1
gh run list --workflow=release.yml --limit 3
gh release view v0.2.1 --json assets,url
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.1` and confirm Release workflow attaches `.whl` + `.tar.gz`

Closes #159