### PR TITLE
ci: Phase CI/CD harden wave 1 (Scorecard, CodeQL, supply-chain gates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CI/CD and process surface needs maintainer review (CNCF-style CODEOWNERS gate).
+# Users must be org members with write access for reviews to be required.
+# Adjust handles if the maintainer set changes.
+
+# Workflows and automation
+.github/ @Siddhartha-singh01
+
+# Release and security-sensitive policy docs
+docs/RELEASE.md @Siddhartha-singh01
+docs/maintainer-branch-protection.md @Siddhartha-singh01
+docs/CI_HARDENING.md @Siddhartha-singh01
+SECURITY.md @Siddhartha-singh01

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,18 +9,23 @@
 ## How I tested
 
 ```bash
+# Python reference (if you touched Python)
 pip install -e ".[dev]"
 pytest test/unit -q
 pytest test/e2e -q
 pytest conformance/ -q
 ruff check pkg drivers client test conformance examples
+
+# Go primary (if you touched go/)
+cd go && go test ./... -count=1
 ```
 
 ## Checklist
 
 - [ ] Commits are DCO signed (`git commit -s`)
 - [ ] Change matches the master README (no invented APIs)
-- [ ] Relevant CI checks pass locally
+- [ ] Relevant CI checks pass locally (or will pass on the PR)
+- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
 - [ ] AI assistance disclosed below if a tool wrote a meaningful share of the change
 
 ## Safety areas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,9 +347,9 @@ jobs:
             -e MINIO_ROOT_PASSWORD=minioadmin \
             quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z \
             server /data --console-address ":9001"
-          for i in $(seq 1 40); do
+          for attempt in $(seq 1 40); do
             if curl -sf http://127.0.0.1:9000/minio/health/live; then
-              echo "MinIO is up"
+              echo "MinIO is up (attempt ${attempt})"
               exit 0
             fi
             sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,11 @@ jobs:
         working-directory: go
         run: go test ./... -count=1
 
+      - name: Go race detector (core packages)
+        working-directory: go
+        # Race on IR packages only; temporal integration stays optional.
+        run: go test -race ./trajir/client/... ./trajir/log/... ./trajir/resume/... ./trajir/cas/... ./trajir/nodes/... ./trajir/tir/... -count=1
+
       - name: Upload Go coverage profile
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+# Static analysis for Go (primary) and Python (reference).
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "22 6 * * 2"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     tags:
       - "v*"
 
+# Least privilege: write only what release needs (CNCF GHA least-privilege).
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   python-dist:
@@ -27,6 +29,13 @@ jobs:
           python -m build
           twine check dist/*
 
+      - name: Generate SBOMs with syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          syft dir:. -o cyclonedx-json=dist/sbom-repo.cdx.json
+          syft dir:go -o cyclonedx-json=dist/sbom-go.cdx.json
+          syft dir:pkg -o cyclonedx-json=dist/sbom-python-src.cdx.json
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -34,7 +43,7 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-      - name: Attach dist to GitHub Release
+      - name: Attach dist and SBOMs to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+# OpenSSF Scorecard — supply-chain posture (CNCF TAG Security aligned).
+# Results publish to the Security tab when code scanning is enabled.
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "17 5 * * 1"
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload Scorecard artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          if-no-files-found: ignore

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,10 +24,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      # Use upstream gitleaks CLI (not gitleaks-action). The Action requires a
+      # paid GITLEAKS_LICENSE for GitHub organization repos and would block OSS CI.
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.24.2"
+        run: |
+          set -euo pipefail
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --verbose --redact --exit-code 1
 
   actionlint:
     name: Workflow lint (actionlint)
@@ -36,8 +47,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Install actionlint
+      - name: Install and run actionlint
         run: |
+          set -euo pipefail
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
@@ -57,7 +69,7 @@ jobs:
         run: pip install --upgrade pip "zizmor>=1.5"
 
       - name: Audit workflows (advisory first wave)
-        # CNCF recipe recommends zizmor. Findings are uploaded for review;
-        # do not fail PRs until SHA-pinning follow-up lands.
+        # CNCF recipe recommends zizmor. Findings are reported for review;
+        # do not fail PRs until SHA-pinning follow-up lands (#167).
         continue-on-error: true
         run: zizmor --format plain .github/workflows

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,63 @@
+# Fast supply-chain / workflow hygiene checks for every PR (CNCF GHA recipe card).
+name: Security scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: security-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  actionlint:
+    name: Workflow lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+
+  zizmor:
+    name: Workflow audit (zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install zizmor
+        run: pip install --upgrade pip "zizmor>=1.5"
+
+      - name: Audit workflows (advisory first wave)
+        # CNCF recipe recommends zizmor. Findings are uploaded for review;
+        # do not fail PRs until SHA-pinning follow-up lands.
+        continue-on-error: true
+        run: zizmor --format plain .github/workflows

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,21 +24,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Use upstream gitleaks CLI (not gitleaks-action). The Action requires a
-      # paid GITLEAKS_LICENSE for GitHub organization repos and would block OSS CI.
+      # Free CLI (not gitleaks-action): org repos would require a paid GITLEAKS_LICENSE.
       - name: Install gitleaks
         env:
           GITLEAKS_VERSION: "8.24.2"
         run: |
           set -euo pipefail
-          curl -sSfL \
+          curl -sSfL --retry 5 --retry-all-errors \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/gitleaks
           gitleaks version
 
       - name: Run gitleaks
-        run: gitleaks detect --source . --verbose --redact --exit-code 1
+        # --no-git: scan working tree only (current tree is what merges).
+        # Allowlist for intentional redaction fixtures: .gitleaks.toml
+        run: gitleaks detect --source . --no-git --verbose --redact --exit-code 1 --config .gitleaks.toml
 
   actionlint:
     name: Workflow lint (actionlint)
@@ -47,11 +48,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.25.x"
+
+      # go install is more reliable than curl|tar from GitHub releases on flaky networks.
       - name: Install and run actionlint
         run: |
           set -euo pipefail
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          "$(go env GOPATH)/bin/actionlint" -color
 
   zizmor:
     name: Workflow audit (zizmor)
@@ -69,7 +76,6 @@ jobs:
         run: pip install --upgrade pip "zizmor>=1.5"
 
       - name: Audit workflows (advisory first wave)
-        # CNCF recipe recommends zizmor. Findings are reported for review;
-        # do not fail PRs until SHA-pinning follow-up lands (#167).
+        # Findings reported for review; fail-closed after SHA-pinning (#167).
         continue-on-error: true
         run: zizmor --format plain .github/workflows

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+# Gitleaks config for Trajectory IR.
+# Fake AWS-shaped strings are intentional fixtures for redaction tests
+# (they must look like credentials for the product under test).
+
+title = "Trajectory IR"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures that intentionally contain secret-shaped values for redaction coverage"
+paths = [
+  '''(^|/)go/trajir/redact/.*_test\.go$''',
+  '''(^|/)pkg/trajectory_ir/runtime/.*redact.*''',
+  '''(^|/)test/unit/test_.*redact.*\.py$''',
+  '''(^|/)test/unit/test_tir_package\.py$''',
+  '''(^|/)conformance/r08_.*\.py$''',
+  '''(^|/)test/unit/test_redact\.py$''',
+]
+regexTarget = "match"
+regexes = [
+  '''AKIAABCDEFGHIJKLMNOP''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Phase CI/CD harden: OpenSSF Scorecard, CodeQL (Go+Python), gitleaks,
+  actionlint, zizmor advisory scan, Go race on core packages, CODEOWNERS,
+  CycloneDX SBOM on release tags ([docs/CI_HARDENING.md](docs/CI_HARDENING.md)).
+
 ### Changed
 
 ### Fixed

--- a/docs/CI_HARDENING.md
+++ b/docs/CI_HARDENING.md
@@ -25,7 +25,7 @@ Milestone: **[Phase CI/CD harden](https://github.com/Coder-s-OG-s/Trajectory-IR/
 | **Release** | `.github/workflows/release.yml` | Build dist, SBOM, attach to GitHub Release |
 | **Scorecard** | `.github/workflows/scorecard.yml` | OpenSSF Scorecard SARIF |
 | **CodeQL** | `.github/workflows/codeql.yml` | Go + Python static analysis |
-| **Security scan** | `.github/workflows/security-scan.yml` | gitleaks, actionlint, zizmor |
+| **Security scan** | `.github/workflows/security-scan.yml` | gitleaks CLI (no paid license), actionlint, zizmor |
 
 ## Required status checks on `main`
 

--- a/docs/CI_HARDENING.md
+++ b/docs/CI_HARDENING.md
@@ -1,0 +1,72 @@
+# CI/CD hardening (CNCF-aligned)
+
+How Trajectory IR strengthens contributor and maintainer CI after Phase 1C.
+Grounded in CNCF TAG Security supply-chain guidance and the CNCF
+[GitHub Actions CI dependency recipe card](https://www.cncf.io/blog/2026/05/04/securing-github-actions-ci-dependencies-recipe-card/).
+
+Milestone: **[Phase CI/CD harden](https://github.com/Coder-s-OG-s/Trajectory-IR/milestone/6)**
+
+## Principles (from CNCF / OpenSSF)
+
+| Principle | Practice here |
+|-----------|----------------|
+| Least privilege | Workflows default `contents: read`; release only gets `contents: write` + `id-token` |
+| Trusted sources | Prefer GitHub-owned actions; Dependabot weekly for `github-actions` |
+| Keep fresh | Dependabot for pip, gomod, and GitHub Actions |
+| Audit the kitchen | Scorecard, zizmor (advisory), actionlint, gitleaks |
+| Test before ship | Existing CI gates + Go race on core packages |
+| Release integrity | Wheel/sdist + CycloneDX SBOMs attached on `v*` tags |
+
+## Current workflows
+
+| Workflow | File | Role |
+|----------|------|------|
+| **CI** | `.github/workflows/ci.yml` | DCO, Quality, Package smoke, pip-audit, Go (+ race), Conformance, Postgres, MinIO |
+| **Release** | `.github/workflows/release.yml` | Build dist, SBOM, attach to GitHub Release |
+| **Scorecard** | `.github/workflows/scorecard.yml` | OpenSSF Scorecard SARIF |
+| **CodeQL** | `.github/workflows/codeql.yml` | Go + Python static analysis |
+| **Security scan** | `.github/workflows/security-scan.yml` | gitleaks, actionlint, zizmor |
+
+## Required status checks on `main`
+
+Machine gates (classic branch protection) still require the **CI** job names
+listed in [maintainer-branch-protection.md](maintainer-branch-protection.md).
+
+**Optional to promote later** (once green and stable on every PR):
+
+- `Secret scan (gitleaks)`
+- `Workflow lint (actionlint)`
+- Scorecard / CodeQL are often schedule + main push; require only if they run on every PR and stay green
+
+## Contributor path (strong defaults)
+
+```bash
+# Python reference
+pip install -e ".[dev]"
+ruff check pkg drivers client test conformance examples
+pytest test/unit -q
+pytest test/e2e conformance/ -q
+
+# Go primary
+cd go
+go test ./... -count=1
+go test -race ./trajir/client/... ./trajir/log/... ./trajir/resume/... -count=1
+govulncheck ./...
+```
+
+Local live stack (optional): [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKER.md).
+
+## Follow-up backlog (issues under Phase CI/CD harden)
+
+1. **SHA-pin GitHub Actions** (digest + Dependabot comments) — Scorecard “Pinned-Dependencies”
+2. **Require** gitleaks + actionlint on `main` protection once stable
+3. **SLSA provenance** / cosign sign release artifacts (when maintainers pick a key strategy)
+4. **Fork PR approval** settings: require approval for first-time contributors (org setting)
+5. **zizmor fail-closed** after pin migration
+
+## References
+
+- [CNCF: Securing GitHub Actions CI dependencies (recipe card)](https://www.cncf.io/blog/2026/05/04/securing-github-actions-ci-dependencies-recipe-card/)
+- [CNCF: Securing CI/CD for OSS — access control (Cilium series)](https://www.cncf.io/blog/2026/06/04/securing-ci-cd-for-an-open-source-project-controlling-who-runs-what/)
+- [CNCF TAG Security — Software Supply Chain Best Practices](https://tag-security.cncf.io/community/working-groups/supply-chain-security/supply-chain-security-paper/sscsp/)
+- [OpenSSF Scorecard](https://scorecard.dev/)

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -13,22 +13,23 @@ Board: [Milestones](https://github.com/Coder-s-OG-s/Trajectory-IR/milestones)
 | **Phase 1A library baseline (v0.1.0)** | Closed | First library tag. Historical only. |
 | **v0.1.1 post 0.1.0 patch** | Closed | Absorbed into history; public cut advanced to v0.2.0. |
 | **Phase 1B Go primary SDK** | Closed | Complete; released as **v0.2.0**. |
-| **Phase 1C harden and adopt** | Open | Gates when plan allows, release proof, live Docker matrix, adoption polish. Epic [#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151). |
+| **Phase 1C harden and adopt** | Closed | Complete at **v0.2.1**. |
+| **Phase CI/CD harden** | Open | Scorecard, CodeQL, secret/workflow scan, SBOM, race, CODEOWNERS. See [CI_HARDENING.md](CI_HARDENING.md). |
 | **Future deferred product** | Open | Signatures, Fluid, SaaS, etc. Park only. |
 
 ## Rules (follow these)
 
 1. **One milestone per issue and PR.** Set it when you open the issue, not at merge time.
-2. **Do not mix scopes.** Phase 1C harden work stays on Phase 1C. Deferred product ideas go to Future, not Phase 1C.
+2. **Do not mix scopes.** Active phase work stays on the active milestone. Deferred product ideas go to Future.
 3. **Exit criteria live in the milestone description.** Close the milestone only when those criteria are met (and the matching release or epic is done).
-4. **Suggested work order right now (Phase 1C)**
-   1. ~~Branch protection on `main`~~ ([#146](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/146) / [#158](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/158)) — **done**
-   2. Refresh status docs ([#161](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/161))
-   3. Smoke live Docker stack ([#160](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/160))
-   4. Next `v*` tag: prove Release attaches wheel/sdist ([#159](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/159))
-   5. Close Phase 1C epic when exit criteria met ([#162](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/162) / [#151](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/151))
+4. **Suggested work order right now (Phase CI/CD harden)**
+   1. Land Scorecard, CodeQL, gitleaks, actionlint, zizmor, Go race, SBOM, CODEOWNERS ([CI_HARDENING.md](CI_HARDENING.md))
+   2. SHA-pin Actions digests; then fail-closed zizmor
+   3. Optionally require new security-scan jobs on `main` protection
+   4. SLSA/cosign when maintainers choose a signing strategy
 5. **Future milestone is a parking lot.** Implementing from Future needs a README scope bump (§14) and a new active milestone or epic first. Example: [#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149) signatures.
 6. **Labels still matter** (`go`, `phase-1c`, `SPEC-QUESTION`, …). Milestone answers *when/why*; labels answer *kind of work*.
+
 
 ## How to assign (maintainers and contributors)
 


### PR DESCRIPTION
## Summary

Next phase after Phase 1C: **strengthen CI/CD for contributors** using CNCF TAG Security supply-chain practices and the CNCF [GitHub Actions dependency recipe card](https://www.cncf.io/blog/2026/05/04/securing-github-actions-ci-dependencies-recipe-card/).

### Research to actions

| CNCF / OpenSSF practice | This PR |
|-------------------------|---------|
| Least-privilege tokens | CI read-only; release contents write + id-token |
| Dependabot for Actions | Already weekly (kept) |
| Audit workflows | actionlint + zizmor (advisory) |
| Secret hygiene | gitleaks |
| Continuous posture | OpenSSF Scorecard |
| Static analysis | CodeQL Go + Python |
| Concurrency safety | go test -race on core trajir packages |
| CODEOWNERS on CI | .github/CODEOWNERS |
| Release integrity | Syft CycloneDX SBOMs on v* tags |

### Docs and tracking

- docs/CI_HARDENING.md
- Milestone: Phase CI/CD harden
- Epic #166; follow-ups #167 (SHA pin), #168 (require new checks)

## Test plan

- [ ] CI green (incl. Go race)
- [ ] Security scan workflow runs
- [ ] Scorecard/CodeQL configured for main

Refs #166