### PR TITLE
docs: CNCF Sandbox process pack (MAINTAINERS, governance, roadmap)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,29 @@
+# Adopters
+
+Organizations and projects using or evaluating Trajectory IR in a meaningful
+way (production, staging, or active design partnership).
+
+## How to be listed
+
+Open a PR adding a row, or ask a maintainer. Include:
+
+- Organization or project name
+- Contact (optional public)
+- How you use Trajectory IR (brief)
+- Production / evaluation
+
+## Current entries
+
+| Organization / project | Status | Use |
+|------------------------|--------|-----|
+| *None listed yet* | — | Add the first real adopter via PR |
+
+## Early interest / design partners
+
+| Name or team | Notes |
+|--------------|--------|
+| *Open* | Maintainers welcome design-partner conversations via GitHub issues |
+
+> Empty adopters lists are honest. Do not invent production users for CNCF
+> applications. Replace the placeholder rows when real adopters consent to be
+> named.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CNCF Sandbox process pack: `MAINTAINERS.md`, `GOVERNANCE.md`, `docs/ROADMAP.md`,
+  `ADOPTERS.md`, `docs/SCOPE_AND_NON_GOALS.md` (#172).
+
 ### Changed
+
+- README project links; SECURITY.md supported versions for 0.2.x (#172).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Thanks for helping. Trajectory IR is a portable semantic layer for agent runs
 (seals, effect classes, `.tir`, honest resume). The root `README.md` is the
 master specification.
 
+Also read: [MAINTAINERS.md](MAINTAINERS.md), [GOVERNANCE.md](GOVERNANCE.md),
+[docs/ROADMAP.md](docs/ROADMAP.md), [docs/SCOPE_AND_NON_GOALS.md](docs/SCOPE_AND_NON_GOALS.md),
+[SECURITY.md](SECURITY.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
 ## 1. Spec before code
 
 1. Read the root `README.md` (Phase 1B language priority is in §5 and §12.1).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,68 @@
+# Governance
+
+Trajectory IR is an open source project under the Apache License 2.0. This
+document describes how decisions are made and how maintainership works.
+
+## Principles
+
+1. **Spec before code** — the root `README.md` is the master specification.
+2. **Thin core** — do not reimplement durable execution engines (Temporal, DBOS, Restate).
+3. **Portability first** — the portable `.tir` unit and effect-safe seals are the product.
+4. **CNCF-friendly process** — DCO, public discussion, documented maintainers.
+
+## Roles
+
+| Role | Responsibility |
+|------|----------------|
+| **Maintainer** | Merge rights, release cuts, roadmap, security response, governance changes |
+| **Contributor** | PRs, issues, reviews, docs; no merge rights |
+| **User / adopter** | Feedback, bug reports, optional listing in `ADOPTERS.md` |
+
+Current maintainers: [MAINTAINERS.md](MAINTAINERS.md).
+
+## Decision making
+
+1. **Day-to-day** — maintainers merge PRs that pass CI, match the spec, and have
+   DCO. Prefer squash merge; keep `main` green.
+2. **Spec or scope changes** — open a Spec question issue or PR that edits the
+   root README / roadmap first. Wait for maintainer consensus (lazy consensus:
+   silence of 5 business days after explicit call for objections may count as
+   assent for non-breaking docs; breaking or product-scope changes need explicit
+   approval from at least two maintainers when more than one is active).
+3. **Security** — private coordinated disclosure per [SECURITY.md](SECURITY.md).
+4. **Disputes** — escalate to a short maintainer discussion (issue or call);
+   record the outcome in the issue.
+
+## Becoming a maintainer
+
+A contributor may be nominated when they have:
+
+- Sustained contributions (code, docs, or reviews) over multiple months
+- Demonstrated understanding of the spec and non-goals
+- Responsive, respectful community behavior (Code of Conduct)
+
+Nomination: existing maintainer opens an issue. Acceptance: majority of
+current maintainers (or unanimous if only two). Update `MAINTAINERS.md` in the
+same PR that grants rights.
+
+## Emeritus
+
+Maintainers who step back are moved to an Emeritus section in
+`MAINTAINERS.md` (or removed with thanks) and lose merge rights. They may
+return via the same nomination process.
+
+## Releases
+
+Maintainers cut version tags per [docs/RELEASE.md](docs/RELEASE.md). The
+Release workflow attaches Python dist artifacts and SBOMs on `v*` tags.
+
+## Code of Conduct
+
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Violations are handled by maintainers
+with private contact options listed in that document and SECURITY.md where
+relevant.
+
+## Changes to this document
+
+Edits to `GOVERNANCE.md` require a PR and approval from at least one other
+maintainer when more than one is listed.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,29 @@
+# Maintainers
+
+Active maintainers of Trajectory IR. This file is the CNCF-style maintainers
+list (Name, GitHub ID, Company/Organization).
+
+| Name | GitHub ID | Company/Organization |
+|------|-----------|----------------------|
+| Siddhartha Singh | [@Siddhartha-singh01](https://github.com/Siddhartha-singh01) | EliteFolks |
+| Ayush Patel | [@Ayush-Patel-56](https://github.com/Ayush-Patel-56) | Independent |
+| Monika Jakhar | [@jakharmonika364](https://github.com/jakharmonika364) | Independent |
+
+## Roles
+
+| Maintainer | Focus |
+|------------|--------|
+| Siddhartha Singh | Project lead, release, CNCF prep, overall direction |
+| Ayush Patel | Go SDK, reviews, CI quality |
+| Monika Jakhar | Contributions and review support |
+
+## Becoming a maintainer
+
+See [GOVERNANCE.md](GOVERNANCE.md). Candidates are proposed by an existing
+maintainer after sustained, high-quality contributions and community
+participation. Employer diversity is encouraged for long-term project health.
+
+## Contact
+
+- Security: see [SECURITY.md](SECURITY.md)
+- General: open a GitHub issue or discussion on this repository

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 | **Status** | `spec-v0.2-draft`. Supersedes the frozen `spec-v0.1` under the version bump process in §14. This revision narrows the project's scope from a standalone execution runtime to a semantics and portability layer over a pluggable, existing durable execution backend, see §3.1. |
 | **Precedence** | This document is authoritative. If any prior document, chat message, or verbal agreement conflicts with this file, this file wins. |
 
+**Project links:** [License (Apache-2.0)](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Contributing (DCO)](CONTRIBUTING.md) · [Security](SECURITY.md) · [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Roadmap](docs/ROADMAP.md) · [Adopters](ADOPTERS.md) · [Scope and non-goals](docs/SCOPE_AND_NON_GOALS.md) · [Quickstart (Go first)](go/QUICKSTART.md) · [CNCF Sandbox prep](docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md)
+
 ---
 
 ## 0. Purpose of this document
@@ -433,8 +435,14 @@ This section is binding for implementation choices. Do not introduce alternative
 trajectory-ir/
   README.md                     # Master Specification (this file)
   LICENSE                       # Apache-2.0
-  CODE_OF_CONDUCT.md            # CNCF Code of Conduct
-  CONTRIBUTING.md                # DCO sign-off requirement, PR process
+  CODE_OF_CONDUCT.md            # Code of Conduct
+  CONTRIBUTING.md               # DCO sign-off requirement, PR process
+  MAINTAINERS.md                # Active maintainers (Name / GitHub / Company)
+  GOVERNANCE.md                 # Decision process and maintainership
+  SECURITY.md                   # Vulnerability reporting
+  ADOPTERS.md                   # Adopter list (fill as consent is given)
+  docs/ROADMAP.md               # Public roadmap
+  docs/SCOPE_AND_NON_GOALS.md   # Short scope summary
   spec/
     node-kinds.md
     effect-classes.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,14 @@ This policy is tightly integrated with our [Infrastructure Design](infrastructur
 
 ## 1. Supported Versions
 
-Trajectory IR is currently in its **Phase 1A / v0.1.x** development cycle. 
+Trajectory IR ships **0.2.x** (Phase 1B Go primary + Phase 1C harden). Older
+0.1.x tags remain available but are not the active development line.
 
 | Version | Supported          | Notes |
 | ------- | ------------------ | ----- |
-| v0.1.x  | :white_check_mark: | Active development (DBOS embedded backend) |
-| < v0.1  | :x:                | Historical (CAMI/CLOOP prototypes) |
+| v0.2.x  | :white_check_mark: | Current (Go primary, Python reference) |
+| v0.1.x  | :warning:          | Security fixes only if maintainers agree; prefer upgrade |
+| < v0.1  | :x:                | Historical prototypes |
 
 ## 2. Reporting a Vulnerability
 

--- a/docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md
+++ b/docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md
@@ -47,20 +47,21 @@ Update this table monthly.
 | Apache-2.0 project license | **Ready** | `LICENSE` |
 | Public code, works | **Ready** | Go + Python, releases `v0.2.0` / `v0.2.1` |
 | DCO on contributions | **Ready** | CI DCO job + CONTRIBUTING |
-| Code of Conduct file | **Ready** | `CODE_OF_CONDUCT.md` (confirm README deep link) |
+| Code of Conduct file | **Ready** | `CODE_OF_CONDUCT.md` + README links |
 | Contributing guide | **Ready** | `CONTRIBUTING.md` |
-| Security policy | **Check** | Ensure `SECURITY.md` exists and is linked |
-| MAINTAINERS.md (Name / GitHub ID / **Company**) | **Gap** | Required for form; auto-close if missing |
-| GOVERNANCE.md | **Gap** | Expected soon; strong for review |
-| ROADMAP (public URL) | **Gap** | Form requires roadmap URL |
-| ADOPTERS (optional) | **Gap** | Helps a lot if non-empty |
-| Org diversity of maintainers | **Risk** | TOC considers employer diversity |
+| Security policy | **Ready** | `SECURITY.md` (0.2.x supported versions) |
+| MAINTAINERS.md (Name / GitHub ID / **Company**) | **Ready** | `MAINTAINERS.md` |
+| GOVERNANCE.md | **Ready** | `GOVERNANCE.md` |
+| ROADMAP (public URL) | **Ready** | `docs/ROADMAP.md` |
+| ADOPTERS (optional) | **Template** | `ADOPTERS.md` (empty until real consent) |
+| Scope / non-goals / product separation | **Ready** | `docs/SCOPE_AND_NON_GOALS.md` + roadmap |
+| Org diversity of maintainers | **Partial** | Documented; more multi-employer diversity still helps |
 | Neutral GitHub org transfer-ready | **Plan** | Onboarding requires neutral org |
 | OpenSSF Best Practices badge | **Start** | Not Sandbox-hard-required; expected for maturity |
-| Scorecard / CI harden | **In progress** | Phase CI/CD harden |
+| Scorecard / CI harden | **In progress** | Phase CI/CD harden (#169 / #167 / #168) |
 | Landscape listing | **No** | After acceptance typically |
-| Repo age 6+ months | **Verify** | Auto-close risk if younger than 6 months |
-| Product decoupling story | **Draft needed** | Required form field |
+| Repo age 6+ months | **Not yet** | Created 2026-07-26; wait before apply |
+| Contribution Agreement signatory | **Open** | Org/legal decision |
 
 ---
 
@@ -71,23 +72,23 @@ Copied and adapted from the official form “Pre-Submission Checklist.”
 
 ### Critical (application closed without TOC review if failed)
 
-- [ ] Project uses **Apache-2.0** (or allowlist license) **now**, not “after acceptance”
-- [ ] **MAINTAINERS.md** (or `MAINTAINERS`) with table: **Name | GitHub ID | Company/Organization**
-- [ ] Form links to that file via **GitHub `/blob/` path**, not contributors graph
+- [x] Project uses **Apache-2.0** (or allowlist license) **now**, not “after acceptance”
+- [x] **MAINTAINERS.md** (or `MAINTAINERS`) with table: **Name | GitHub ID | Company/Organization**
+- [x] Form links to that file via **GitHub `/blob/` path**, not contributors graph
 - [ ] Primary repository is **≥ 6 months old** with active development
-- [ ] Project is a **reusable tool/library**, not a reference architecture or company platform demo
-- [ ] If splitting from a parent org/project: public parent maintainer consensus issue linked
+- [x] Project is a **reusable tool/library**, not a reference architecture or company platform demo
+- [x] If splitting from a parent org/project: N/A (standalone repo)
 - [ ] Dependency licenses are on the [CNCF third-party allowlist](https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md) (or documented plan with FOSSA/Snyk)
 
 ### Strongly recommended before review
 
-- [ ] README links CoC, Contributing, Security, license, quickstart
-- [ ] Public **roadmap** URL (issues milestone or `docs/ROADMAP.md`)
-- [ ] **SECURITY.md** with private reporting path
-- [ ] **GOVERNANCE.md** (decision process, maintainers, emeritus)
-- [ ] Clear **scope and non-goals** (durable engines, agent frameworks, memory products)
-- [ ] **Similar projects** section ready (Temporal, Restate, DBOS, LangGraph, OTel, MCP)
-- [ ] At least a thin **ADOPTERS.md** or “early interest” list (even design partners)
+- [x] README links CoC, Contributing, Security, license, quickstart
+- [x] Public **roadmap** URL (`docs/ROADMAP.md`)
+- [x] **SECURITY.md** with private reporting path
+- [x] **GOVERNANCE.md** (decision process, maintainers, emeritus)
+- [x] Clear **scope and non-goals** (`docs/SCOPE_AND_NON_GOALS.md`)
+- [x] **Similar projects** section ready (see outline section 7; freeze before apply)
+- [x] Thin **ADOPTERS.md** template (fill when real adopters consent)
 - [ ] Contribution Agreement signatories identified (legal can sign)
 - [ ] Maintainers agree trademarks/accounts can transfer to LF if accepted
 - [ ] TAG awareness (optional GTR / presentation notes linked)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,71 @@
+# Roadmap
+
+Public roadmap for Trajectory IR. Normative product rules remain in the root
+`README.md`. This file is the **URL** intended for CNCF Sandbox form “Roadmap”
+and for contributors planning work.
+
+Milestones board: https://github.com/Coder-s-OG-s/Trajectory-IR/milestones
+
+## One-line mission
+
+Portable, hash-verifiable intermediate representation for agent execution
+trajectories (seals, effects, `.tir`) on top of existing durable backends.
+
+## Shipped
+
+| Release / phase | Highlights |
+|-----------------|------------|
+| **Phase 1A / v0.1.x** | Python reference, conformance R01–R08 baseline, thin/fat `.tir`, DBOS local profile |
+| **Phase 1B / v0.2.0** | Go primary SDK, Postgres NodeLog, S3 CAS, adoption demos, CI depth |
+| **Phase 1C / v0.2.1** | Branch protection on `main`, live Docker docs/scripts, Release workflow assets |
+
+## Near term (next 1–3 months)
+
+| Track | Goals |
+|-------|--------|
+| **Phase CI/CD harden** | Scorecard, CodeQL, secret/workflow scan, SBOM, Go race; SHA-pin Actions; optional require gitleaks/actionlint on `main` ([docs/CI_HARDENING.md](CI_HARDENING.md) when present) |
+| **CNCF Sandbox prep** | Process pack: MAINTAINERS, governance, this roadmap, adopters; do **not** apply until critical checklist is green ([CNCF_SANDBOX_APPLICATION_OUTLINE.md](CNCF_SANDBOX_APPLICATION_OUTLINE.md)) |
+| **Adoption** | Keep Go QUICKSTART and demos green; interop notes for `.tir` export/import |
+| **Quality** | Keep dual-language parity, coverage floors, live Postgres/MinIO CI |
+
+## Medium term (3–9 months)
+
+| Theme | Direction |
+|-------|-----------|
+| Interop demos | Documented path: produce `.tir` in one runtime, consume in another |
+| Spec stability | Clarify package/compat policy as adoption grows |
+| Community | Multi-org contributors, adopters list, optional TAG engagement |
+| Security maturity | OpenSSF Best Practices badge progress, Scorecard improvements |
+
+## Explicit non-goals (do not prioritize)
+
+Aligned with root README §5 / Future milestone:
+
+- Custom crash detection, retry, or lease engines (use Temporal / DBOS / Restate)
+- Becoming “the” agent framework (LangGraph/CrewAI competitor)
+- Competing on LTM recall quality (Mem0/Zep)
+- Multi-tenant SaaS control plane
+- Fluid/k8s-fluid productization as a core requirement
+- Package digital signatures until scoped under Future ([#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149))
+
+## Business / product separation
+
+Trajectory IR is an **open source library and portable format**. It is not a
+hosted multi-tenant product. Development and releases happen in public on this
+repository under Apache-2.0. Any commercial use by contributors or companies
+must treat this project as **upstream OSS**, not as a private product fork
+that redefines the public API without process.
+
+## How to influence the roadmap
+
+1. Open a Spec question or feature issue.
+2. Assign the correct milestone (not Future for in-scope work).
+3. For scope expansion beyond non-goals, maintainers must update the root
+   README (§14 process) before implementation.
+
+## Related
+
+- [CNCF_SANDBOX_APPLICATION_OUTLINE.md](CNCF_SANDBOX_APPLICATION_OUTLINE.md)
+- [PHASE_1C_STATUS.md](PHASE_1C_STATUS.md)
+- [MILESTONES.md](MILESTONES.md)
+- [RELEASE.md](RELEASE.md)

--- a/docs/SCOPE_AND_NON_GOALS.md
+++ b/docs/SCOPE_AND_NON_GOALS.md
@@ -1,0 +1,37 @@
+# Scope and non-goals
+
+Short public summary for contributors and CNCF reviewers. Normative detail:
+root [README.md](../README.md).
+
+## In scope
+
+- Typed trajectory nodes and stable identity hashing
+- Decision sealing and resume **semantics** (not custom crash engines)
+- Effect classes and MCP annotation mapping (fail closed)
+- Block-and-gate for non-idempotent tools
+- Portable `.tir` packages (thin / fat; redacted export heuristics)
+- Dual SDK: **Go primary**, Python reference/parity
+- Pluggable durable backends (Temporal for Go production; DBOS for Python reference)
+- Conformance tests (R01–R08) and CAS / NodeLog storage drivers
+
+## Out of scope (explicit)
+
+| Topic | Status |
+|-------|--------|
+| Reimplement Temporal/Restate/DBOS crash/retry/leases | Never (adapter only) |
+| Agent graph orchestration / “be LangGraph” | Out |
+| LTM recall quality product | Out (optional node shapes only) |
+| Multi-tenant SaaS control plane | Future / not active |
+| Fluid productization | Future / not active |
+| Package signatures | Future [#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149) |
+
+## One-line pitch
+
+Portable, hash-verifiable intermediate representation for agent execution
+trajectories (seals, effects, `.tir`) on top of existing durable backends.
+
+## Product separation
+
+This project is **upstream open source** (Apache-2.0 libraries and format). It
+is not a hosted multi-tenant commercial control plane. See
+[docs/ROADMAP.md](ROADMAP.md).


### PR DESCRIPTION
## Summary

Implements the **single process PR** designed under **#172** (CNCF Sandbox readiness priority pack).

### Adds

| File | Checklist |
|------|-----------|
| `MAINTAINERS.md` | P0.2 — Name / GitHub ID / Company |
| `GOVERNANCE.md` | P1.1 |
| `docs/ROADMAP.md` | P0.3 + product separation |
| `ADOPTERS.md` | P1.2 template (no invented adopters) |
| `docs/SCOPE_AND_NON_GOALS.md` | P1.3 / P0.4 |

### Updates

- `SECURITY.md` — supported versions for **0.2.x**
- `README.md` — project links + structure
- `CONTRIBUTING.md` — pointers to governance/roadmap
- `docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md` — readiness snapshot / checklist
- `CHANGELOG.md` Unreleased

### Still open after merge (cannot be faked in docs)

- Repo age ≥ 6 months (P0.1)
- Contribution Agreement signatory (P0.5)
- Trademark donation agreement (P0.6)
- Dependency license audit tooling (P1.5)
- OpenSSF badge (P1.8)
- CI follow-ups #169 / #167 / #168 (P1.10)

## Test plan

- [ ] Review MAINTAINERS company column accuracy (maintainers confirm)
- [ ] Doc links resolve
- [ ] CI green

Closes #172