### PR TITLE
ci: SHA-pin Actions and require gitleaks/actionlint on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Python coverage (unit)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-python-${{ matrix.python-version }}
           path: coverage-python.xml
@@ -116,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
           cache: pip
@@ -143,7 +143,7 @@ jobs:
           print('package smoke ok', getattr(trajectory_ir, '__file__', 'n/a'))"
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-dist
           path: dist/*
@@ -154,10 +154,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
           cache: pip
@@ -181,10 +181,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "1.25.x"
           cache-dependency-path: go/go.sum
@@ -198,7 +198,7 @@ jobs:
         run: go test ./trajir/nodes -count=1 -run 'TestHashVectors|TestKeyOrder'
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
           cache: pip
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload Go coverage profile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-go
           path: go/coverage.out
@@ -257,10 +257,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -299,10 +299,10 @@ jobs:
       TRAJIR_DATABASE_URL: postgresql://trajir:trajir@localhost:5432/trajir
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
           cache: pip
@@ -317,7 +317,7 @@ jobs:
         run: pytest test/integration/test_postgres_live.py -q
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "1.25.x"
           cache-dependency-path: go/go.sum
@@ -337,7 +337,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Start MinIO
         run: |
@@ -359,7 +359,7 @@ jobs:
           exit 1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
           cache: pip
@@ -383,7 +383,7 @@ jobs:
         run: pytest test/integration/test_s3_minio_live.py -q
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "1.25.x"
           cache-dependency-path: go/go.sum

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,19 +33,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
@@ -37,14 +37,14 @@ jobs:
           syft dir:pkg -o cyclonedx-json=dist/sbom-python-src.cdx.json
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-dist
           path: dist/*
           if-no-files-found: error
 
       - name: Attach dist and SBOMs to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: dist/*
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.2
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -40,13 +40,13 @@ jobs:
 
       - name: Upload Scorecard SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           sarif_file: results.sarif
 
       - name: Upload Scorecard artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "1.25.x"
 
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - README project links; SECURITY.md supported versions for 0.2.x (#172).
+- Pin GitHub Actions to commit digests with version comments (#167).
+- Require `Secret scan (gitleaks)` and `Workflow lint (actionlint)` on `main` (#168).
 
 ### Fixed
 

--- a/docs/CI_HARDENING.md
+++ b/docs/CI_HARDENING.md
@@ -58,11 +58,11 @@ Local live stack (optional): [LIVE_INTEGRATION_DOCKER.md](LIVE_INTEGRATION_DOCKE
 
 ## Follow-up backlog (issues under Phase CI/CD harden)
 
-1. **SHA-pin GitHub Actions** (digest + Dependabot comments) — Scorecard “Pinned-Dependencies”
-2. **Require** gitleaks + actionlint on `main` protection once stable
+1. ~~**SHA-pin GitHub Actions**~~ — done (#167): digests + version comments in workflows
+2. ~~**Require** gitleaks + actionlint on `main`~~ — done (#168)
 3. **SLSA provenance** / cosign sign release artifacts (when maintainers pick a key strategy)
 4. **Fork PR approval** settings: require approval for first-time contributors (org setting)
-5. **zizmor fail-closed** after pin migration
+5. **zizmor fail-closed** after reviewing residual findings
 
 ## References
 

--- a/docs/maintainer-branch-protection.md
+++ b/docs/maintainer-branch-protection.md
@@ -27,6 +27,8 @@ Expected live settings:
 
 Match Actions job names exactly:
 
+**CI workflow**
+
 1. `DCO`
 2. `Quality (Python 3.11)`
 3. `Quality (Python 3.12)`
@@ -38,7 +40,18 @@ Match Actions job names exactly:
 9. `Integration (Postgres)`
 10. `Integration (MinIO)`
 
-If a job is renamed in `.github/workflows/ci.yml`, update protection in the same PR.
+**Security scan workflow** (#168)
+
+11. `Secret scan (gitleaks)`
+12. `Workflow lint (actionlint)`
+
+If a job is renamed in `.github/workflows/*.yml`, update protection in the same PR.
+
+### Action SHA pinning (#167)
+
+Third-party and GitHub-owned Actions in workflows are pinned to full commit SHAs
+with a version comment (e.g. `actions/checkout@3d3c42e5… # v7`). Dependabot
+still updates the `github-actions` ecosystem weekly; review pin bumps carefully.
 
 ## Merge policy (historical while protection was blocked)
 
@@ -123,7 +136,9 @@ gh api -X PUT repos/Coder-s-OG-s/Trajectory-IR/branches/main/protection \
       "Conformance & E2E (Python 3.11)",
       "Conformance & E2E (Python 3.12)",
       "Integration (Postgres)",
-      "Integration (MinIO)"
+      "Integration (MinIO)",
+      "Secret scan (gitleaks)",
+      "Workflow lint (actionlint)"
     ]
   },
   "enforce_admins": false,


### PR DESCRIPTION
## Summary

Finishes Phase CI/CD harden wave 2:

### #167 SHA-pin GitHub Actions
All `uses:` in `.github/workflows/*` pinned to full commit digests with version comments, e.g. `actions/checkout@3d3c42e5… # v7`.

### #168 Required checks on main
After this merges, branch protection will require:
- `Secret scan (gitleaks)`
- `Workflow lint (actionlint)`

Docs updated in `docs/maintainer-branch-protection.md` and `docs/CI_HARDENING.md`.

### Closes
- #167
- #168
- #166 (epic complete when this lands)

## Test plan
- [ ] CI + Security scan green with pinned SHAs
- [ ] After merge: protection API lists 12 required contexts