### PR TITLE
docs: document new-functionality test policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ cd go && go test ./... -count=1
 ## Checklist
 
 - [ ] Commits are DCO signed (`git commit -s`)
+- [ ] New functionality includes tests in this PR
 - [ ] Change matches the master README (no invented APIs)
 - [ ] Relevant CI checks pass locally (or will pass on the PR)
 - [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,13 @@ still require a matching `Signed-off-by`.
 
 1. Prefer a linked issue (`Closes #N`).
 2. Keep the change focused.
-3. Fill in the PR template.
-4. Wait for CI to go green.
-5. Set the **Milestone** on both the issue and the PR (see
+3. **New functionality must include tests in the same PR** (unit tests at
+   minimum; add integration/conformance coverage where relevant). This is
+   enforced indirectly by the coverage floor below, but do not treat the
+   floor as the bar — add tests for the behavior you actually added.
+4. Fill in the PR template.
+5. Wait for CI to go green.
+6. Set the **Milestone** on both the issue and the PR (see
    [docs/MILESTONES.md](docs/MILESTONES.md)). Right now prefer **Phase 1C harden
    and adopt**. Park signatures, Fluid, and SaaS under **Future deferred product**.
 


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` and the PR template enforced "new functionality gets tests" only indirectly, via the CI coverage floor — never stated in writing.
- Adds it as an explicit numbered step in CONTRIBUTING.md §3 (Pull requests) and a checklist item in the PR template.
- Closes the last open item in the OpenSSF Best Practices Badge "New functionality testing" section (`tests_documented_added`), part of CNCF Sandbox prep (#175).

Closes #193

## Test plan
- [x] Docs-only change; reviewed diff for correctness of renumbered list in CONTRIBUTING.md §3