### PR TITLE
chore: tighten ruff/mypy strictness (warnings_strict)

### DIFF
--- a/conformance/r07_graft_test.py
+++ b/conformance/r07_graft_test.py
@@ -71,7 +71,7 @@ def test_r07_refuses_graft_from_thought_payload_hash(tmp_path) -> None:
             "demo",
             0,
         )
-        with pytest.raises(GraftError, match="refusing|no ARTIFACT"):
+        with pytest.raises(GraftError, match=r"refusing|no ARTIFACT"):
             graft_artifact_ref(
                 dst,
                 content_hash=h,

--- a/drivers/postgres/log.py
+++ b/drivers/postgres/log.py
@@ -267,17 +267,15 @@ class PostgresNodeLog:
             sql += " AND seq = %s"
             params.append(seq)
         sql += " LIMIT 1"
-        with self._lock:
-            with self._conn.cursor() as cur:
-                cur.execute(sql, params)
-                return cur.fetchone() is not None
+        with self._lock, self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchone() is not None
 
     def count(self, node_id: str) -> int:
-        with self._lock:
-            with self._conn.cursor() as cur:
-                cur.execute("SELECT COUNT(*) FROM nodes WHERE id = %s", (node_id,))
-                row = cur.fetchone()
-                return int(row[0]) if row else 0
+        with self._lock, self._conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM nodes WHERE id = %s", (node_id,))
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
 
     def list_nodes(
         self,
@@ -306,24 +304,23 @@ class PostgresNodeLog:
             sql += " AND tenant_id = %s"
             params.append(tenant_id)
         sql += " ORDER BY COALESCE(step_n, -1), seq"
-        with self._lock:
-            with self._conn.cursor() as cur:
-                cur.execute(sql, params)
-                rows: list[dict[str, Any]] = []
-                for row in cur.fetchall():
-                    rows.append(
-                        {
-                            "id": row[0],
-                            "trajectory_id": row[1],
-                            "tenant_id": row[2],
-                            "step_n": row[3],
-                            "seq": row[4],
-                            "kind": row[5],
-                            "payload": json.loads(row[6]),
-                            "ts": row[7],
-                        }
-                    )
-                return rows
+        with self._lock, self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows: list[dict[str, Any]] = []
+            for row in cur.fetchall():
+                rows.append(
+                    {
+                        "id": row[0],
+                        "trajectory_id": row[1],
+                        "tenant_id": row[2],
+                        "step_n": row[3],
+                        "seq": row[4],
+                        "kind": row[5],
+                        "payload": json.loads(row[6]),
+                        "ts": row[7],
+                    }
+                )
+            return rows
 
     def close(self) -> None:
         with self._lock:

--- a/drivers/s3/cas.py
+++ b/drivers/s3/cas.py
@@ -69,9 +69,7 @@ def _is_not_found(exc: BaseException) -> bool:
     name = type(exc).__name__
     if name == "NoSuchKey":
         return True
-    if isinstance(exc, KeyError):
-        return True
-    return False
+    return isinstance(exc, KeyError)
 
 
 class S3CAS:

--- a/examples/adoption_host/run_demo.py
+++ b/examples/adoption_host/run_demo.py
@@ -19,6 +19,7 @@ Crash safe durable workflow demos remain under ``examples/kill-mid-deploy/``.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import sys
@@ -356,26 +357,20 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     finally:
         if cleanup_db:
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(db_path)
-            except OSError:
-                pass
         if cleanup_tir and tir_out:
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(tir_out)
-            except OSError:
-                pass
         if cleanup_cas and cas_root:
             # Best effort: leave CAS contents if remove fails mid walk.
-            try:
+            with contextlib.suppress(OSError):
                 for root, dirs, files in os.walk(cas_root, topdown=False):
                     for name in files:
                         os.remove(os.path.join(root, name))
                     for name in dirs:
                         os.rmdir(os.path.join(root, name))
                 os.rmdir(cas_root)
-            except OSError:
-                pass
 
 
 if __name__ == "__main__":

--- a/examples/host_loop/run_host.py
+++ b/examples/host_loop/run_host.py
@@ -11,6 +11,7 @@ No paid model API is required: ``stub_model`` is a deterministic stand in.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import sys
 import tempfile
@@ -21,17 +22,17 @@ for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
     if _path not in sys.path:
         sys.path.insert(0, _path)
 
-from client.python.trajectory_client import (  # noqa: E402
+from client.python.trajectory_client import (
     commit_step,
     exec_tool,
     open_trajectory,
     project,
     seal_decision,
 )
-from trajectory_ir.effects import EffectClass  # noqa: E402
-from trajectory_ir.runtime.log import NodeLog  # noqa: E402
-from trajectory_ir.runtime.sandbox import SandboxForbidden  # noqa: E402
-from trajectory_ir.runtime.tool import Tool  # noqa: E402
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.sandbox import SandboxForbidden
+from trajectory_ir.runtime.tool import Tool
 
 TENANT_ID = "demo"
 TRAJECTORY_ID = "host-loop-demo"
@@ -153,10 +154,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     finally:
         if cleanup:
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(db_path)
-            except OSError:
-                pass
 
 
 if __name__ == "__main__":

--- a/pkg/trajectory_ir/effects/classify.py
+++ b/pkg/trajectory_ir/effects/classify.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any
 
 
 class EffectClass(Enum):
@@ -21,7 +22,7 @@ def requires_block_and_gate(effect: EffectClass) -> bool:
     return effect is EffectClass.NON_IDEMPOTENT_WRITE
 
 
-def classify_from_mcp(annotations: dict) -> EffectClass:
+def classify_from_mcp(annotations: Any) -> EffectClass:
     """Fail-closed per spec §7.2. Any missing or ambiguous annotation -> NON_IDEMPOTENT_WRITE.
 
     Contradictory annotations (e.g., readOnlyHint=True AND destructiveHint=True)

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -18,6 +18,7 @@ packages cannot zip-bomb or path-traverse the reader.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -100,7 +101,7 @@ def _content_hash(data: bytes) -> str:
 
 def _safe_zip_name(name: str) -> None:
     """Reject path traversal and absolute paths inside the zip."""
-    if not name or name.startswith("/") or name.startswith("\\"):
+    if not name or name.startswith(("/", "\\")):
         raise TirVerificationError(f"unsafe zip member path: {name!r}")
     # Normalize separators and reject .. segments
     parts = name.replace("\\", "/").split("/")
@@ -342,10 +343,8 @@ def export_tir(
             os.fsync(raw.fileno())
         os.replace(tmp_name, dest_path)
     except Exception:
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(tmp_name)
-        except OSError:
-            pass
         raise
 
     return dest_path

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import sqlite3
 import threading
@@ -163,10 +164,8 @@ class NodeLog:
                 self._conn.execute("ROLLBACK")
                 return False
             except Exception:
-                try:
+                with contextlib.suppress(sqlite3.Error):
                     self._conn.execute("ROLLBACK")
-                except sqlite3.Error:
-                    pass
                 raise
 
     def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
@@ -190,7 +189,7 @@ class NodeLog:
     def count(self, node_id: str) -> int:
         with self._lock:
             cur = self._conn.execute("SELECT COUNT(*) FROM nodes WHERE id = ?", (node_id,))
-            return cur.fetchone()[0]
+            return int(cur.fetchone()[0])
 
     def list_nodes(
         self,
@@ -262,7 +261,5 @@ class NodeLog:
         # of open SQLite connections. This is a best-effort backstop, not a
         # substitute for callers using close()/a context manager when they
         # can.
-        try:
+        with contextlib.suppress(Exception):
             self._conn.close()
-        except Exception:
-            pass

--- a/pkg/trajectory_ir/runtime/projector.py
+++ b/pkg/trajectory_ir/runtime/projector.py
@@ -113,10 +113,9 @@ def project_context(
     seen: set[str] = set()
     for n in nodes:
         nid = str(n.get("id") or "")
-        if n.get("kind") in always_kinds or nid in pinned:
-            if nid and nid not in seen:
-                must.append(n)
-                seen.add(nid)
+        if (n.get("kind") in always_kinds or nid in pinned) and (nid and nid not in seen):
+            must.append(n)
+            seen.add(nid)
 
     must_sorted = sorted(must, key=_sort_key)
     must_size = sum(node_size_units(n) for n in must_sorted)

--- a/pkg/trajectory_ir/storage/artifacts.py
+++ b/pkg/trajectory_ir/storage/artifacts.py
@@ -53,10 +53,7 @@ def put_artifact(
         raise RuntimeError(f"CAS put returned hash {h} that does not match content")
     if uri is None:
         uri_fn = getattr(store, "uri_for", None)
-        if callable(uri_fn):
-            uri = str(uri_fn(h))
-        else:
-            uri = f"cas://{h}"
+        uri = str(uri_fn(h)) if callable(uri_fn) else f"cas://{h}"
     return ArtifactRef(
         logical_path=logical_path,
         content_hash=h,

--- a/pkg/trajectory_ir/storage/fs.py
+++ b/pkg/trajectory_ir/storage/fs.py
@@ -15,6 +15,7 @@ never observe a partial object. Hash is always recomputed on ``get``.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import tempfile
 from pathlib import Path
@@ -83,10 +84,8 @@ class FileSystemCAS:
                 os.fsync(tmp.fileno())
             os.replace(tmp_name, dest)
         except Exception:
-            try:
+            with contextlib.suppress(OSError):
                 os.unlink(tmp_name)
-            except OSError:
-                pass
             raise
         return h
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ select = [
     "I",
     "UP",
     "B",
+    "C4",
+    "SIM",
+    "RUF",
+    "PIE",
+    "RET",
 ]
 ignore = [
     "E501",
@@ -86,3 +91,8 @@ mypy_path = "pkg"
 packages = ["trajectory_ir"]
 warn_unused_configs = true
 show_error_codes = true
+warn_return_any = true
+warn_unreachable = true
+strict_equality = true
+warn_redundant_casts = true
+no_implicit_reexport = true

--- a/test/unit/test_postgres_claim_tool_call_exception_narrowing.py
+++ b/test/unit/test_postgres_claim_tool_call_exception_narrowing.py
@@ -25,11 +25,7 @@ class _RaisingCursor:
 
     def execute(self, sql: str, params=None) -> None:
         normalized = " ".join(sql.lower().split())
-        if (
-            normalized.startswith("create table")
-            or normalized.startswith("create unique index")
-            or normalized.startswith("create index")
-        ):
+        if normalized.startswith(("create table", "create unique index", "create index")):
             # PostgresNodeLog._ensure_schema DDL; no-op for this fake.
             return
         if normalized.startswith("select 1 from nodes"):

--- a/test/unit/test_postgres_node_log.py
+++ b/test/unit/test_postgres_node_log.py
@@ -43,11 +43,7 @@ class _FakeStore:
 
     def execute(self, sql: str, params: tuple | list) -> list[tuple]:
         s = " ".join(sql.split()).lower()
-        if (
-            s.startswith("create table")
-            or s.startswith("create unique index")
-            or s.startswith("create index")
-        ):
+        if s.startswith(("create table", "create unique index", "create index")):
             return []
         if s.startswith("insert into nodes") and "on conflict" in s:
             (


### PR DESCRIPTION
## Summary

Closes #195. Fills the `warnings_strict` gap surfaced by the OpenSSF Best Practices Badge questionnaire ("projects SHOULD be maximally strict with warnings, where practical").

- `[tool.ruff.lint].select` expanded: `E, F, I, UP, B` → adds `C4, SIM, RUF, PIE, RET`.
- `[tool.mypy]` adds `warn_return_any`, `warn_unreachable`, `strict_equality`, `warn_redundant_casts`, `no_implicit_reexport`.
- Fixed every violation the new rules surfaced (no rules silenced/ignored):
  - `try/except OSError: pass` and similar → `with contextlib.suppress(...)` (`fs.py`, `tir.py`, `runtime/log.py`, both `examples/` scripts).
  - Chained `.startswith(a) or .startswith(b) or ...` → single `.startswith((a, b, ...))` (`tir.py`, two Postgres fakes in `test/unit`).
  - Merged nested `with` statements in `drivers/postgres/log.py` (ruff `--fix`).
  - `if/else` assignment → ternary in `storage/artifacts.py`; nested `if` combined with `and` in `runtime/projector.py`; `isinstance(...); return True/False` chain simplified to one `return` in `drivers/s3/cas.py`.
  - Non-raw regex `match=` pattern in a `pytest.raises` call now a raw string (`conformance/r07_graft_test.py`).
  - mypy `no-any-return` fixed with an explicit `int(...)` cast on a SQLite `COUNT(*)` result (`runtime/log.py`).
  - mypy `unreachable` fixed by typing `classify_from_mcp`'s `annotations` param as `Any` instead of bare `dict` — that function is an explicit trust boundary for external/untyped MCP tool annotations, so the `isinstance` check it does is real defensive runtime behavior, not dead code; the old `dict` annotation just made mypy assume it away.

## Out of scope (tracked as follow-up in #195)

- Full `mypy --strict` (`disallow_untyped_defs` etc.) — 22 errors across 7 files, real annotation work.
- ruff `N` (pep8-naming) — 21 `N803` hits that look like an intentional casing convention, needs its own review.
- `golangci-lint` for the Go module — not wired in at all yet, needs a config + first triage pass.

## Test plan

- [x] `ruff check pkg drivers client test conformance examples` — clean
- [x] `ruff format --check pkg drivers client test conformance examples` — clean
- [x] `mypy pkg/trajectory_ir` — clean (0 errors, was 0 before too — new flags didn't regress anything else)
- [x] `pytest test/unit -q` — 142 passed, 2 skipped (unrelated: pip-audit opt-in, live Postgres opt-in)
- [x] `pytest test/e2e -q` — 3 passed
- [x] `pytest conformance/ -q` — 18 passed