### PR TITLE
fix: configure pytest pythonpath to resolve module imports (#204)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ packages = ["pkg/trajectory_ir", "drivers", "client"]
 
 [tool.pytest.ini_options]
 testpaths = ["test", "conformance"]
+pythonpath = ["pkg", "."]
 addopts = [
     "-ra",
     "--strict-markers",


### PR DESCRIPTION
Closes #204

**Description**
Pytest collection was failing completely out-of-the-box (`ModuleNotFoundError: No module named 'trajectory_ir'`) because the project uses a flat `pkg/` layout and depends on `hatchling` to build the package, which means `pytest` didn't inherently know where the source code was located without explicit path resolution.

**Changes**
- Added `pythonpath = ["pkg", "."]` to the `[tool.pytest.ini_options]` block in `pyproject.toml` so that Pytest dynamically injects the correct source directories into `sys.path` during execution and collection.

**Verification**
- Test collection now successfully resolves imports for both `trajectory_ir` (in `pkg/`) and `drivers/` without crashing instantly.
