### PR TITLE
fix: remove global E501 ignore and fix line length violations (#205)

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -142,7 +142,8 @@ def commit_step(trajectory: Trajectory, step_n: int, seq: int) -> None:
     Args:
         trajectory: The trajectory context
         step_n: Step number
-        seq: Sequence number for commit (should be 2 + 2*num_tool_calls to follow after all tool calls)
+        seq: Sequence number for commit (should be 2 + 2*num_tool_calls to follow
+            after all tool calls)
     """
     NodeLog(trajectory.db_path).append(
         "COMMIT_STEP",

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -8,7 +8,8 @@ from trajectory_ir.runtime.nodes import Node
 
 
 class SlotConflictError(ValueError):
-    """Raised when a different payload is written to an occupied (trajectory, step, seq, kind) slot."""
+    """Raised when a different payload is written to an occupied (trajectory, step,
+    seq, kind) slot."""
 
 
 class NodeLog:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,7 @@ select = [
     "PIE",
     "RET",
 ]
-ignore = [
-    "E501",
-]
+
 
 [tool.ruff.lint.per-file-ignores]
 # Fixture agent adjusts sys.path before local imports on purpose.


### PR DESCRIPTION
Closes #205

**Description**
The Ruff configuration in `pyproject.toml` globally ignored `E501` (Line too long), which degraded codebase readability by bypassing the standard 100-character line length limit.

**Changes**
- Removed `E501` from the `ignore` array in `[tool.ruff.lint]`.
- Fixed existing line length violations in `client/python/trajectory_client.py` (line 145) and `pkg/trajectory_ir/runtime/log.py` (line 11) by cleanly wrapping their docstrings.

**Verification**
- Running `python3 -m ruff check .` now enforces the 100-character limit globally and passes with 0 errors.
