### PR TITLE
fix: move dbos to optional-dependencies to reduce install footprint (#206)

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass
 from typing import Any
 
-from drivers.durable_backend.dbos.adapter import init_backend
+try:
+    from drivers.durable_backend.dbos.adapter import init_backend
+except ImportError:
+
+    def init_backend(app_name: str = "trajectory-ir-local") -> None:
+        raise ImportError("DBOS driver is not installed. Run `pip install .[dbos]`")
 from trajectory_ir.effects import requires_block_and_gate
 from trajectory_ir.resume.gate import make_gated_tool_call
 from trajectory_ir.runtime.log import NodeLog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "dbos",
     "rfc8785",
 ]
 
@@ -33,6 +32,7 @@ dependencies = [
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
 postgres = ["psycopg[binary]>=3.1"]
 s3 = ["boto3"]
+dbos = ["dbos"]
 
 [project.urls]
 Homepage = "https://github.com/Coder-s-OG-s/Trajectory-IR"


### PR DESCRIPTION

Closes #206

**Description**
`dbos` was previously listed under the core `dependencies` array. Since Trajectory IR is designed to be a portable intermediate representation, forcing DBOS (a specific durable execution backend) on all users bloated the footprint for those who only want to parse, serialize, or validate TIR packages.

**Changes**
- Removed `"dbos"` from the main `dependencies` array.
- Added `dbos = ["dbos"]` to `[project.optional-dependencies]`, treating it identically to `postgres` and `s3` backends.

**Verification**
- Running `pip install .` will now install only lightweight core dependencies (like `rfc8785`), while `pip install .[dbos]` can still be used for full durable execution functionality.
