### PR TITLE
fix: add missing python 3.13 and 3.14 classifiers (#207)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [


### PR DESCRIPTION
Closes #207

**Description**
The `pyproject.toml` file previously only declared classifiers up to Python 3.12. With Python 3.13 and 3.14 being actively used and tested against by modern tooling, the lack of these classifiers made the package appear outdated on PyPI and could negatively affect package discovery algorithms.

**Changes**
- Added `Programming Language :: Python :: 3.13` to the `classifiers` array in `pyproject.toml`.
- Added `Programming Language :: Python :: 3.14` to the `classifiers` array in `pyproject.toml`.

**Verification**
- Once published, the PyPI page will accurately reflect compatibility with these newer Python runtimes.
