### PR TITLE
fix: remove brittle sys.path injection from examples (#208)

### DIFF
--- a/examples/adoption_host/run_demo.py
+++ b/examples/adoption_host/run_demo.py
@@ -29,11 +29,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-# Allow ``python examples/adoption_host/run_demo.py`` without a prior editable install.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
-    if _path not in sys.path:
-        sys.path.insert(0, _path)
 
 from client.python.trajectory_client import (  # noqa: E402
     commit_step,

--- a/examples/host_loop/run_host.py
+++ b/examples/host_loop/run_host.py
@@ -16,12 +16,6 @@ import os
 import sys
 import tempfile
 
-# Allow ``python examples/host_loop/run_host.py`` without a prior editable install.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
-    if _path not in sys.path:
-        sys.path.insert(0, _path)
-
 from client.python.trajectory_client import (
     commit_step,
     exec_tool,

--- a/examples/kill-mid-deploy/README.md
+++ b/examples/kill-mid-deploy/README.md
@@ -4,6 +4,11 @@ Demonstrates the milestone's core claim: a crash mid-tool-execution never silent
 
 ## Run it
 
+First, ensure the repository is installed locally:
+```bash
+pip install -e .
+```
+
 ```bash
 python examples/kill-mid-deploy/run_demo.py
 # in another terminal, once you see "TOOL_CALL: deploy_server started":

--- a/examples/kill-mid-deploy/agent.py
+++ b/examples/kill-mid-deploy/agent.py
@@ -7,6 +7,7 @@ implemented once.
 
 Run it twice against the same working directory to exercise crash recovery:
 
+    pip install -e .
     python examples/kill-mid-deploy/agent.py --crash-during=tool_call   # then kill -9
     python examples/kill-mid-deploy/agent.py --resume
 
@@ -24,13 +25,6 @@ import argparse
 import os
 import sys
 import time
-
-# Run directly from a checkout (`python examples/kill-mid-deploy/agent.py`)
-# without requiring an installed package or a preset PYTHONPATH.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
-    if _path not in sys.path:
-        sys.path.insert(0, _path)
 
 from dbos import SetWorkflowID
 

--- a/examples/kill-mid-deploy/run_demo.py
+++ b/examples/kill-mid-deploy/run_demo.py
@@ -2,6 +2,7 @@
 """Run (or resume) the kill-mid-deploy demo trajectory.
 
 Usage:
+    pip install -e .
     python examples/kill-mid-deploy/run_demo.py
     # in another terminal, once you see "TOOL_CALL: deploy_server started":
     kill -9 <pid>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,7 @@ ignore = [
     "E501",
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# Fixture agent adjusts sys.path before local imports on purpose.
-"examples/kill-mid-deploy/agent.py" = ["E402"]
-"examples/host_loop/run_host.py" = ["E402"]
+
 
 [tool.ruff.lint.isort]
 known-first-party = ["trajectory_ir", "drivers", "client", "test"]


### PR DESCRIPTION
Closes #208

**Description**
The example scripts (`agent.py` and `run_host.py`) were dynamically altering `sys.path` at runtime to allow local module imports without an installation. This is a brittle anti-pattern that breaks static analysis, IDE autocomplete, and forces us to bypass linting rules like `E402`.

**Changes**
- Removed the `sys.path.insert(0, _path)` blocks from `examples/kill-mid-deploy/agent.py` and `examples/host_loop/run_host.py`.
- Removed the per-file `E402` linting bypasses from `pyproject.toml`.
- Ran `ruff check --fix` to correctly sort the imports according to the new structure.

**Verification**
- Running `ruff check .` passes 100% cleanly without the `E402` overrides. Examples now properly expect the repository to be installed via `pip install -e .` prior to execution.
