### PR TITLE
fix: make rfc8785 import graceful to avoid crashing pytest collection (#209)

### DIFF
--- a/pkg/trajectory_ir/runtime/nodes.py
+++ b/pkg/trajectory_ir/runtime/nodes.py
@@ -2,7 +2,10 @@ import hashlib
 import time
 from dataclasses import dataclass, field
 
-import rfc8785
+try:
+    import rfc8785  # type: ignore[import-not-found]
+except ImportError:
+    rfc8785 = None
 
 NODE_KINDS = frozenset(
     {
@@ -53,6 +56,8 @@ def payload_hash(payload: dict) -> str:
         raise NodeValidationError("payload must be an object")
     if "ts" in payload:
         raise NodeValidationError("wall-clock ts must never be hashed (spec §6.3)")
+    if rfc8785 is None:
+        raise ModuleNotFoundError("rfc8785 is required for payload hashing. Please install it.")
     canon = rfc8785.dumps(payload)
     return hashlib.sha256(canon).hexdigest()
 

--- a/pkg/trajectory_ir/runtime/projector.py
+++ b/pkg/trajectory_ir/runtime/projector.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-import rfc8785
+try:
+    import rfc8785  # type: ignore[import-not-found]
+except ImportError:
+    rfc8785 = None  # type: ignore
 
 SIZE_METRIC = "rfc8785_bytes"
 
@@ -56,6 +59,10 @@ def node_size_units(node: dict[str, Any]) -> int:
     if not isinstance(payload, dict):
         raise TypeError("payload must be an object for size measurement")
     # RFC 8785 JCS — same stack as runtime.nodes.payload_hash (byte-stable vs Go jcs).
+    if rfc8785 is None:
+        raise ImportError(
+            "rfc8785 must be installed to measure node size during projection."
+        )
     canon = rfc8785.dumps({"kind": kind, "payload": payload})
     return len(canon)
 


### PR DESCRIPTION

Closes #209

**Description**
When running PyTest in environments isolating specific driver tests or verifying basic syntax, the entire test suite collection would crash completely (`ModuleNotFoundError`) if the `rfc8785` core dependency was missing, because it was imported unconditionally at the root module level in `nodes.py`.

**Changes**
- Wrapped `import rfc8785` in a `try/except ImportError` block in `pkg/trajectory_ir/runtime/nodes.py`.
- Moved the `ModuleNotFoundError` to trigger only when `payload_hash()` is actually invoked at runtime.

**Verification**
- Merely collecting tests with PyTest no longer crashes the test runner on missing core dependencies.
- Tests that explicitly rely on payload hashing will correctly fail or be skipped individually if the dependency is absent.
