### PR TITLE
fix: register pytest markers to prevent strict-markers errors (#210)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ addopts = [
     "-ra",
     "--strict-markers",
 ]
+markers = [
+    "integration: marks tests as integration tests",
+    "e2e: marks tests as end-to-end tests",
+]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Closes #210

**Description**
`pyproject.toml` configured PyTest with `addopts = ["--strict-markers"]`, which forces PyTest to throw a hard error and refuse to run if it encounters an unregistered custom marker. However, the accompanying `markers = [...]` configuration block was entirely missing.

**Changes**
- Added the `markers` array to the `[tool.pytest.ini_options]` block in `pyproject.toml`.
- Pre-registered standard marker categories (e.g., `integration` and `e2e`) to support future test segregation without breaking the CI build.

**Verification**
- Test collection behaves exactly as before, but the project is now protected against hard crashes when developers introduce valid testing markers.
