### PR TITLE
fix(log): detect slot conflicts in SQLite NodeLog.Append

### DIFF
--- a/go/trajir/log/log.go
+++ b/go/trajir/log/log.go
@@ -8,6 +8,7 @@ package nodelog
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -15,6 +16,10 @@ import (
 
 	_ "modernc.org/sqlite"
 )
+
+// ErrSlotConflict is returned when a different payload already occupies the
+// logical slot (tenant_id, trajectory_id, step_n, seq, kind).
+var ErrSlotConflict = errors.New("nodelog: slot conflict")
 
 // NodeLog is an append only SQLite log keyed by content addressed node id.
 // INSERT OR IGNORE makes replaying the same node a no op, which is what durable
@@ -57,7 +62,9 @@ ON nodes (trajectory_id, tenant_id);
 	return &NodeLog{db: db}, nil
 }
 
-// Append builds a node via trajir/nodes and stores it. Same content id is ignored.
+// Append builds a node via trajir/nodes and stores it. Same content id is
+// ignored (idempotent replay). Different payload at the same logical slot
+// returns ErrSlotConflict.
 func (l *NodeLog) Append(
 	kind string,
 	stepN *int,
@@ -99,7 +106,31 @@ func (l *NodeLog) Append(
 	if err != nil {
 		return nil, fmt.Errorf("insert node: %w", err)
 	}
+
+	owner, err := l.slotOwner(tenantID, trajectoryID, step, seq, kind)
+	if err != nil {
+		return nil, err
+	}
+	if owner != "" && owner != n.ID {
+		return nil, fmt.Errorf("%w: trajectory=%s step=%v seq=%d kind=%s",
+			ErrSlotConflict, trajectoryID, step, seq, kind)
+	}
 	return n, nil
+}
+
+func (l *NodeLog) slotOwner(tenantID, trajectoryID string, step any, seq int, kind string) (string, error) {
+	var id string
+	err := l.db.QueryRow(
+		`SELECT id FROM nodes
+		 WHERE tenant_id = ? AND trajectory_id = ?
+		   AND IFNULL(step_n, -1) = IFNULL(?, -1)
+		   AND seq = ? AND kind = ?`,
+		tenantID, trajectoryID, step, seq, kind,
+	).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return id, err
 }
 
 // ClaimToolCall atomically inserts a TOOL_CALL at (trajectory, step, seq).

--- a/go/trajir/log/log.go
+++ b/go/trajir/log/log.go
@@ -8,18 +8,16 @@ package nodelog
 import (
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/nodes"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/postgres"
 
 	_ "modernc.org/sqlite"
 )
 
-// ErrSlotConflict is returned when a different payload already occupies the
-// logical slot (tenant_id, trajectory_id, step_n, seq, kind).
-var ErrSlotConflict = errors.New("nodelog: slot conflict")
+var ErrSlotConflict = postgres.ErrSlotConflict
 
 // NodeLog is an append only SQLite log keyed by content addressed node id.
 // INSERT OR IGNORE makes replaying the same node a no op, which is what durable
@@ -90,7 +88,7 @@ func (l *NodeLog) Append(
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	_, err = l.db.Exec(
+	res, err := l.db.Exec(
 		`INSERT OR IGNORE INTO nodes
 		 (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -107,9 +105,17 @@ func (l *NodeLog) Append(
 		return nil, fmt.Errorf("insert node: %w", err)
 	}
 
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("rows affected: %w", err)
+	}
+	if rowsAffected == 1 {
+		return n, nil
+	}
+
 	owner, err := l.slotOwner(tenantID, trajectoryID, step, seq, kind)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("slot owner: %w", err)
 	}
 	if owner != "" && owner != n.ID {
 		return nil, fmt.Errorf("%w: trajectory=%s step=%v seq=%d kind=%s",

--- a/go/trajir/log/log_test.go
+++ b/go/trajir/log/log_test.go
@@ -1,6 +1,7 @@
 package nodelog_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -209,5 +210,38 @@ func TestPipeInTenantRejected(t *testing.T) {
 	_, err := nl.Append("DECISION", &step, map[string]any{"plan": "x"}, "t1", "a|b", 1)
 	if err == nil {
 		t.Fatal("expected delimiter rejection")
+	}
+}
+
+func TestAppendSlotConflictDifferentPayload(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "a"}, "t1", "demo", 1); err != nil {
+		t.Fatal(err)
+	}
+	_, err := nl.Append("DECISION", &step, map[string]any{"plan": "b"}, "t1", "demo", 1)
+	if !errors.Is(err, nodelog.ErrSlotConflict) {
+		t.Fatalf("err=%v want ErrSlotConflict", err)
+	}
+}
+
+func TestAppendSlotConflictPreservesOriginal(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	n1, err := nl.Append("TOOL_RESULT", &step, map[string]any{"result": "first"}, "t1", "demo", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = nl.Append("TOOL_RESULT", &step, map[string]any{"result": "second"}, "t1", "demo", 2)
+
+	rows, err := nl.ListNodes("t1", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d want 1", len(rows))
+	}
+	if rows[0]["id"] != n1.ID {
+		t.Fatalf("stored id=%v want %s", rows[0]["id"], n1.ID)
 	}
 }

--- a/go/trajir/log/log_test.go
+++ b/go/trajir/log/log_test.go
@@ -232,7 +232,10 @@ func TestAppendSlotConflictPreservesOriginal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _ = nl.Append("TOOL_RESULT", &step, map[string]any{"result": "second"}, "t1", "demo", 2)
+	_, err = nl.Append("TOOL_RESULT", &step, map[string]any{"result": "second"}, "t1", "demo", 2)
+	if !errors.Is(err, nodelog.ErrSlotConflict) {
+		t.Fatalf("err=%v want ErrSlotConflict", err)
+	}
 
 	rows, err := nl.ListNodes("t1", "demo")
 	if err != nil {


### PR DESCRIPTION
## Summary

Go SQLite `NodeLog.Append` uses `INSERT OR IGNORE` which silently swallows
unique-slot index violations. When a different payload targets an already
occupied `(tenant_id, trajectory_id, step_n, seq, kind)` slot, the insert is
ignored but `Append` still returns `(node, nil)` pretending the write
succeeded. The database keeps the original row while the caller proceeds with
stale assumptions.

This adds a post-insert `slotOwner` check (the same approach Python
`NodeLog.append` and Go Postgres `NodeLog.Append` already use) and returns
`ErrSlotConflict` when the stored ID does not match. Idempotent replay (same
content-addressed ID) continues to work as before.

## Related issues

Fixes #224

## How I tested

```bash
cd go && go test ./... -count=1
go test -race ./trajir/log/... -count=1
go vet ./...
```

All 18 Go packages pass. Race detector clean. go vet clean.

New tests added:
- `TestAppendSlotConflictDifferentPayload` verifies `ErrSlotConflict` is returned
- `TestAppendSlotConflictPreservesOriginal` verifies the original row stays in the DB

Existing `TestAppendIsIdempotentByContent` and `TestStoredIdentityMatchesNodesPackage`
continue to pass, confirming durable replay idempotency is preserved.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No


