### PR TITLE
docs: display OpenSSF Best Practices passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Trajectory IR: Master Specification and Contributor Guide
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14075/badge)](https://www.bestpractices.dev/projects/14075)
+
 | | |
 |---|---|
 | **Project** | Trajectory IR (package format: `.tir`) |


### PR DESCRIPTION
## Summary

Closes #227. The project earned the OpenSSF Best Practices "passing" badge (https://www.bestpractices.dev/en/projects/14075) — this adds the standard badge markdown to the top of README.md so it's visible to contributors, adopters, and CNCF reviewers.

## Test plan

- [x] Rendered markdown locally — badge image link resolves correctly, placed right under the title above the existing links table.