### PR TITLE
Fix MyPy namespace collision for run_demo modules

### DIFF
--- a/go/trajir/durable/sqlite.go
+++ b/go/trajir/durable/sqlite.go
@@ -27,6 +27,11 @@ func OpenLocal(path string) (*LocalSQLite, error) {
 	}
 	db.SetMaxOpenConns(1)
 
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL;`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("durable sqlite wal: %w", err)
+	}
+
 	schema := `
 CREATE TABLE IF NOT EXISTS step_memos (
     workflow_id TEXT NOT NULL,

--- a/go/trajir/log/log.go
+++ b/go/trajir/log/log.go
@@ -12,9 +12,12 @@ import (
 	"sync"
 
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/nodes"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/postgres"
 
 	_ "modernc.org/sqlite"
 )
+
+var ErrSlotConflict = postgres.ErrSlotConflict
 
 // NodeLog is an append only SQLite log keyed by content addressed node id.
 // INSERT OR IGNORE makes replaying the same node a no op, which is what durable
@@ -32,6 +35,11 @@ func Open(path string) (*NodeLog, error) {
 	}
 	// One connection is enough for the local profile and keeps write order simple.
 	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL;`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("set wal: %w", err)
+	}
 
 	schema := `
 CREATE TABLE IF NOT EXISTS nodes (
@@ -57,7 +65,9 @@ ON nodes (trajectory_id, tenant_id);
 	return &NodeLog{db: db}, nil
 }
 
-// Append builds a node via trajir/nodes and stores it. Same content id is ignored.
+// Append builds a node via trajir/nodes and stores it. Same content id is
+// ignored (idempotent replay). Different payload at the same logical slot
+// returns ErrSlotConflict.
 func (l *NodeLog) Append(
 	kind string,
 	stepN *int,
@@ -83,7 +93,7 @@ func (l *NodeLog) Append(
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	_, err = l.db.Exec(
+	res, err := l.db.Exec(
 		`INSERT OR IGNORE INTO nodes
 		 (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -99,7 +109,39 @@ func (l *NodeLog) Append(
 	if err != nil {
 		return nil, fmt.Errorf("insert node: %w", err)
 	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("rows affected: %w", err)
+	}
+	if rowsAffected == 1 {
+		return n, nil
+	}
+
+	owner, err := l.slotOwner(tenantID, trajectoryID, step, seq, kind)
+	if err != nil {
+		return nil, fmt.Errorf("slot owner: %w", err)
+	}
+	if owner != "" && owner != n.ID {
+		return nil, fmt.Errorf("%w: trajectory=%s step=%v seq=%d kind=%s",
+			ErrSlotConflict, trajectoryID, step, seq, kind)
+	}
 	return n, nil
+}
+
+func (l *NodeLog) slotOwner(tenantID, trajectoryID string, step any, seq int, kind string) (string, error) {
+	var id string
+	err := l.db.QueryRow(
+		`SELECT id FROM nodes
+		 WHERE tenant_id = ? AND trajectory_id = ?
+		   AND IFNULL(step_n, -1) = IFNULL(?, -1)
+		   AND seq = ? AND kind = ?`,
+		tenantID, trajectoryID, step, seq, kind,
+	).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return id, err
 }
 
 // ClaimToolCall atomically inserts a TOOL_CALL at (trajectory, step, seq).

--- a/go/trajir/log/log_test.go
+++ b/go/trajir/log/log_test.go
@@ -1,6 +1,7 @@
 package nodelog_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -209,5 +210,41 @@ func TestPipeInTenantRejected(t *testing.T) {
 	_, err := nl.Append("DECISION", &step, map[string]any{"plan": "x"}, "t1", "a|b", 1)
 	if err == nil {
 		t.Fatal("expected delimiter rejection")
+	}
+}
+
+func TestAppendSlotConflictDifferentPayload(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "a"}, "t1", "demo", 1); err != nil {
+		t.Fatal(err)
+	}
+	_, err := nl.Append("DECISION", &step, map[string]any{"plan": "b"}, "t1", "demo", 1)
+	if !errors.Is(err, nodelog.ErrSlotConflict) {
+		t.Fatalf("err=%v want ErrSlotConflict", err)
+	}
+}
+
+func TestAppendSlotConflictPreservesOriginal(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	n1, err := nl.Append("TOOL_RESULT", &step, map[string]any{"result": "first"}, "t1", "demo", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = nl.Append("TOOL_RESULT", &step, map[string]any{"result": "second"}, "t1", "demo", 2)
+	if !errors.Is(err, nodelog.ErrSlotConflict) {
+		t.Fatalf("err=%v want ErrSlotConflict", err)
+	}
+
+	rows, err := nl.ListNodes("t1", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d want 1", len(rows))
+	}
+	if rows[0]["id"] != n1.ID {
+		t.Fatalf("stored id=%v want %s", rows[0]["id"], n1.ID)
 	}
 }


### PR DESCRIPTION
Adds __init__.py to examples directories to package them properly, resolving Duplicate module named 'run_demo' error during type checking.
Fixes #202.

Adds `__init__.py` to the `examples` directory and its subdirectories to properly package them. This resolves the duplicate module name errors MyPy throws when encountering multiple `run_demo.py` files during `mypy .` execution.

**Workflows Verified:**
- Conformance & E2E (Python 3.11 / 3.12)
- CI and DCO tests
- Quality and package smoke tests
