### PR TITLE
Fix: move dbos to optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "dbos",
     "rfc8785",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
+dev = ["dbos", "pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
 postgres = ["psycopg[binary]>=3.1"]
 s3 = ["boto3"]
+dbos = ["dbos"]
 
 [project.urls]
 Homepage = "https://github.com/Coder-s-OG-s/Trajectory-IR"


### PR DESCRIPTION
Resolves #206 by moving dbos from core dependencies to optional-dependencies to avoid bloating the installation footprint for users not using the DBOS backend.
Fixes #206.

This PR moves `dbos` from the core `dependencies` to `[project.optional-dependencies]` in `pyproject.toml`. Since Trajectory IR is designed to be a portable intermediate representation, this change ensures that the DBOS durable execution backend and its heavy dependencies are not forcefully installed for users who only need to parse or serialize TIR packages. 

Users can now opt into it by installing via `pip install .[dbos]`.
