### PR TITLE
Fix: include client and drivers in MyPy scans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ known-first-party = ["trajectory_ir", "drivers", "client", "test"]
 [tool.mypy]
 python_version = "3.11"
 mypy_path = "pkg"
-packages = ["trajectory_ir"]
+packages = ["trajectory_ir", "client", "drivers"]
 warn_unused_configs = true
 show_error_codes = true
 warn_return_any = true


### PR DESCRIPTION
Resolves #230 by updating tool.mypy.packages to explicitly scan the 'client' and 'drivers' directories, preventing hidden type errors in the SDK and backends.
Fixes #230.

This PR updates `[tool.mypy]` in `pyproject.toml` to explicitly include the `client` and `drivers` packages in its scans. Previously, only `trajectory_ir` was being type-checked, which allowed type violations in the client SDK and storage drivers to silently pass CI.
