### PR TITLE
Fix: resolve unclosed file descriptor leak in test harness

### DIFF
--- a/test/e2e/_util.py
+++ b/test/e2e/_util.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 AGENT_SCRIPT = os.path.join(REPO_ROOT, "examples", "kill-mid-deploy", "agent.py")
@@ -27,27 +29,21 @@ def agent_cmd(*args: str) -> list:
     return [sys.executable, AGENT_SCRIPT, *args]
 
 
-def start_agent(*args: str, cwd: str, log_path: str) -> subprocess.Popen:
+@contextmanager
+def start_agent(*args: str, cwd: str, log_path: str) -> Iterator[subprocess.Popen]:
     """Launch the agent as a real child process, to be hard-killed later.
 
     Output goes to a file rather than a pipe: a hard-killed process's piped
     output is lost, and these runs are killed by design.
-
-    The log file must remain open for the entire lifetime of the child process
-    (it is the process's stdout fd), so it cannot be managed with a plain
-    ``with`` block inside this function.  Instead we guard with try/except: if
-    ``subprocess.Popen`` raises for any reason we close the file immediately so
-    no descriptor is leaked.  On the happy path the handle is stored on the
-    Popen object and closed by :func:`hard_kill` after the process is reaped.
     """
-    log = open(log_path, "w", encoding="utf-8")  # noqa: SIM115
-    try:
+    with open(log_path, "w", encoding="utf-8") as log:
         proc = subprocess.Popen(agent_cmd(*args), cwd=cwd, stdout=log, stderr=subprocess.STDOUT)
-    except Exception:
-        log.close()
-        raise
-    proc._log_file = log  # keep the handle alive until the process is reaped
-    return proc
+        try:
+            yield proc
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
 
 
 def run_agent(*args: str, cwd: str, timeout: float = 120.0) -> subprocess.CompletedProcess:
@@ -68,9 +64,6 @@ def hard_kill(proc: subprocess.Popen) -> None:
     are non-graceful hard kills, so no platform branching is needed."""
     proc.kill()
     proc.wait()
-    log = getattr(proc, "_log_file", None)
-    if log is not None:
-        log.close()
 
 
 def wait_for_marker(path: str, timeout: float = 60.0) -> None:

--- a/test/e2e/test_seal_resume_crash.py
+++ b/test/e2e/test_seal_resume_crash.py
@@ -58,13 +58,13 @@ def test_crash_before_seal_allows_reinference(tmp_path):
     # and left pending and the resume below is a real crash-recovery replay.
     # Killing right after Popen instead would land before the backend launches,
     # leaving nothing pending and making the "resume" a cold first run.
-    proc = start_agent(
+    with start_agent(
         "--crash-during=inference",
         cwd=workdir,
         log_path=os.path.join(workdir, "crash_run.log"),
-    )
-    wait_for_marker(os.path.join(workdir, INFERENCE_STARTED_MARKER))
-    hard_kill(proc)
+    ) as proc:
+        wait_for_marker(os.path.join(workdir, INFERENCE_STARTED_MARKER))
+        hard_kill(proc)
 
     # The kill landed in the intended pre-seal window: inference had started but
     # the decision was never sealed, so no DECISION node exists to replay from.
@@ -94,13 +94,13 @@ def test_crash_after_seal_before_tool_completes_no_reinfer(tmp_path):
     called a second time (assert the counter, not just 'tools ran once')."""
     workdir = str(tmp_path)
 
-    proc = start_agent(
+    with start_agent(
         "--crash-after=decision_sealed",
         cwd=workdir,
         log_path=os.path.join(workdir, "crash_run.log"),
-    )
-    wait_for_marker(os.path.join(workdir, DECISION_SEALED_MARKER))
-    hard_kill(proc)
+    ) as proc:
+        wait_for_marker(os.path.join(workdir, DECISION_SEALED_MARKER))
+        hard_kill(proc)
 
     # The kill landed in the intended window: inference ran and the decision was
     # sealed, but the non-idempotent side effect had not started yet.
@@ -124,13 +124,13 @@ def test_crash_mid_nonidempotent_tool_blocks_not_retries(tmp_path):
     BLOCKED_NEEDS_GATE, nothing auto-retries."""
     workdir = str(tmp_path)
 
-    proc = start_agent(
+    with start_agent(
         "--crash-during=tool_call",
         cwd=workdir,
         log_path=os.path.join(workdir, "crash_run.log"),
-    )
-    wait_for_marker(os.path.join(workdir, TOOL_STARTED_MARKER))
-    hard_kill(proc)
+    ) as proc:
+        wait_for_marker(os.path.join(workdir, TOOL_STARTED_MARKER))
+        hard_kill(proc)
 
     # The kill landed inside the non-idempotent tool call: it was logged as
     # started but never completed.


### PR DESCRIPTION
Resolves #233 by turning start_agent into a context manager, allowing the log file to be opened within a 'with open(...)' block that automatically and safely closes the handle when the subprocess lifecycle ends.
Fixes #233.

This PR fixes a file descriptor leak in the `test/e2e/_util.py` test harness where the `log_path` was opened without being properly closed or wrapped in a context manager. 

`start_agent` has been refactored into a context manager using `@contextmanager`. This allows it to safely manage the `open(...)` lifecycle and automatically reap the file descriptor at the end of the block, preventing resource leaks even if the test crashes or an exception is raised mid-execution. 
