### PR TITLE
fix: add psycopg-pool to postgres optional dependencies (#238)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
-postgres = ["psycopg[binary]>=3.1"]
+postgres = ["psycopg[binary]>=3.1", "psycopg-pool"]
 s3 = ["boto3"]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Fixes #238 — Missing dependency `psycopg-pool` in Postgres optional dependencies.

## Problem

The Postgres NodeLog driver relies on `psycopg`, but connection pooling is practically mandatory for PostgreSQL in durable execution systems like DBOS to handle concurrent agent steps. The `psycopg-pool` package was omitted from the `[postgres]` optional dependencies in `pyproject.toml`.

## Fix

Added `psycopg-pool` to the `postgres` array in `[project.optional-dependencies]` so that a complete, production-ready PostgreSQL driver is provided out-of-the-box.

## Testing
- Verified `pyproject.toml` is updated correctly.
