### PR TITLE
chore: add dependency license scan vs CNCF allowlist

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,3 +79,64 @@ jobs:
         # Findings reported for review; fail-closed after SHA-pinning (#167).
         continue-on-error: true
         run: zizmor --format plain .github/workflows
+
+  license-scan-python:
+    name: Dependency license scan (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      # Clean venv install of the real runtime dependency tree (dbos, rfc8785,
+      # psycopg[binary], boto3 + transitives) -- not the ambient dev environment,
+      # which pulls in unrelated packages that were never part of this project.
+      - name: Install runtime dependencies
+        run: pip install --upgrade pip pip-licenses ".[postgres,s3]"
+
+      # CNCF allowlist: permissive licenses only. psycopg/psycopg-binary are
+      # LGPL-3.0-only -- an optional extra, imported as an unmodified library
+      # (never statically linked), which is the standard basis on which
+      # CNCF/ASF-style policy treats LGPL as acceptable. Documented exception,
+      # see docs/THIRD_PARTY_LICENSES.md. Anything else outside this list
+      # (e.g. a future GPL/AGPL/SSPL transitive dependency) fails the build.
+      - name: Check licenses against CNCF allowlist
+        run: |
+          pip-licenses \
+            --allow-only="Apache Software License;Apache-2.0;MIT License;MIT;MIT AND PSF-2.0;BSD License;BSD-3-Clause;BSD-2-Clause;ISC License (ISCL);ISC;Python Software Foundation License;PSF-2.0;Apache Software License; BSD License" \
+            --ignore-packages psycopg psycopg-binary
+
+  license-scan-go:
+    name: Dependency license scan (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: "1.25.x"
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      # --ignore excludes: our own module (its LICENSE lives at the repo
+      # root, one level above where go-licenses looks) and two upstream
+      # modules go-licenses mis-flags Unknown -- modernc.org/mathutil has a
+      # BSD-3-Clause LICENSE file the tool's regex misses, and
+      # nexus-rpc/nexus-proto-annotations's v0.1.0 tag predates that repo
+      # adding its (confirmed MIT) LICENSE file. Neither is a real gap; see
+      # docs/THIRD_PARTY_LICENSES.md.
+      - name: Check licenses against CNCF allowlist
+        working-directory: go
+        run: |
+          "$(go env GOPATH)/bin/go-licenses" check ./... \
+            --disallowed_types=forbidden \
+            --ignore github.com/Coder-s-OG-s/Trajectory-IR/go \
+            --ignore modernc.org/mathutil \
+            --ignore github.com/nexus-rpc/nexus-proto-annotations

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | **Status** | `spec-v0.2-draft`. Supersedes the frozen `spec-v0.1` under the version bump process in §14. This revision narrows the project's scope from a standalone execution runtime to a semantics and portability layer over a pluggable, existing durable execution backend, see §3.1. |
 | **Precedence** | This document is authoritative. If any prior document, chat message, or verbal agreement conflicts with this file, this file wins. |
 
-**Project links:** [License (Apache-2.0)](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Contributing (DCO)](CONTRIBUTING.md) · [AI Usage Policy](AI_POLICY.md) · [Security](SECURITY.md) · [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Roadmap](docs/ROADMAP.md) · [Adopters](ADOPTERS.md) · [Scope and non-goals](docs/SCOPE_AND_NON_GOALS.md) · [Quickstart (Go first)](go/QUICKSTART.md) · [CNCF Sandbox prep](docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md)
+**Project links:** [License (Apache-2.0)](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Contributing (DCO)](CONTRIBUTING.md) · [AI Usage Policy](AI_POLICY.md) · [Security](SECURITY.md) · [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Roadmap](docs/ROADMAP.md) · [Adopters](ADOPTERS.md) · [Third-party licenses](docs/THIRD_PARTY_LICENSES.md) · [Scope and non-goals](docs/SCOPE_AND_NON_GOALS.md) · [Quickstart (Go first)](go/QUICKSTART.md) · [CNCF Sandbox prep](docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md)
 
 ---
 

--- a/docs/CI_HARDENING.md
+++ b/docs/CI_HARDENING.md
@@ -13,7 +13,7 @@ Milestone: **[Phase CI/CD harden](https://github.com/Coder-s-OG-s/Trajectory-IR/
 | Least privilege | Workflows default `contents: read`; release only gets `contents: write` + `id-token` |
 | Trusted sources | Prefer GitHub-owned actions; Dependabot weekly for `github-actions` |
 | Keep fresh | Dependabot for pip, gomod, and GitHub Actions |
-| Audit the kitchen | Scorecard, zizmor (advisory), actionlint, gitleaks |
+| Audit the kitchen | Scorecard, zizmor (advisory), actionlint, gitleaks, dependency license scan |
 | Test before ship | Existing CI gates + Go race on core packages |
 | Release integrity | Wheel/sdist + CycloneDX SBOMs attached on `v*` tags |
 
@@ -25,7 +25,7 @@ Milestone: **[Phase CI/CD harden](https://github.com/Coder-s-OG-s/Trajectory-IR/
 | **Release** | `.github/workflows/release.yml` | Build dist, SBOM, attach to GitHub Release |
 | **Scorecard** | `.github/workflows/scorecard.yml` | OpenSSF Scorecard SARIF |
 | **CodeQL** | `.github/workflows/codeql.yml` | Go + Python static analysis |
-| **Security scan** | `.github/workflows/security-scan.yml` | gitleaks CLI (no paid license), actionlint, zizmor |
+| **Security scan** | `.github/workflows/security-scan.yml` | gitleaks CLI (no paid license), actionlint, zizmor, dependency license scan (Python + Go) vs [CNCF allowlist](THIRD_PARTY_LICENSES.md) |
 
 ## Required status checks on `main`
 

--- a/docs/THIRD_PARTY_LICENSES.md
+++ b/docs/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,66 @@
+# Third-party dependency licenses
+
+How Trajectory IR's dependency tree lines up with CNCF's allowed-license
+policy, and how that's kept true going forward.
+
+## Policy
+
+CNCF (following ASF-style license categories) treats permissive licenses
+(Apache-2.0, MIT, BSD-2/3-Clause, ISC, PSF-2.0) as freely usable, weak-copyleft
+licenses (LGPL, MPL) as acceptable when the dependency is used as an
+unmodified, dynamically-linked/imported library rather than compiled into a
+combined work, and strong-copyleft or restrictive licenses (GPL, AGPL, SSPL)
+as disallowed.
+
+## Current state
+
+Scanned the actual resolved dependency trees, not the ambient dev
+environment (which pulls in unrelated packages never part of this project).
+
+### Python
+
+Clean-venv install of `pip install .[postgres,s3]` (the real runtime deps:
+`dbos`, `rfc8785`, `psycopg[binary]`, `boto3`, plus transitives):
+
+| Package | License |
+|---|---|
+| `psycopg`, `psycopg-binary` | **LGPL-3.0-only** — documented exception, see below |
+| everything else (`dbos`, `rfc8785`, `boto3`, `botocore`, `s3transfer`, `jmespath`, `python-dateutil`, `click`, `PyYAML`, `SQLAlchemy`, `greenlet`, `typing_extensions`, `tzdata`, `urllib3`, `six`, `colorama`, `websockets`) | Apache-2.0 / MIT / BSD / PSF-2.0 |
+
+**`psycopg`/`psycopg-binary` exception:** LGPL-3.0-only. `postgres` is an
+optional extra, not a core dependency; it's imported as an unmodified
+library, never statically linked into a single binary. This is the standard
+basis on which CNCF/ASF-style policy treats LGPL as acceptable. Explicitly
+excluded from the strict allow-only gate via `--ignore-packages` in CI
+(`.github/workflows/security-scan.yml`) rather than silently passing.
+
+### Go
+
+Full resolved tree of `go/go.mod` via `go-licenses`: **100% permissive**
+(Apache-2.0 / MIT / BSD-3-Clause / ISC). No GPL/AGPL/LGPL anywhere.
+
+Two modules `go-licenses` flags `Unknown` are tool false-negatives, not real
+gaps:
+
+- `modernc.org/mathutil` — has a BSD-3-Clause `LICENSE` file (identical
+  boilerplate to its sibling `modernc.org/*` packages, which the tool
+  detects correctly); the tool's regex just misses this one file.
+- `github.com/nexus-rpc/nexus-proto-annotations` — the `v0.1.0` module-proxy
+  snapshot predates that repo adding a `LICENSE` file. Confirmed MIT via
+  `gh api repos/nexus-rpc/nexus-proto-annotations -q .license`.
+
+Both are excluded via `--ignore` in CI rather than left silently unverified.
+
+## Keeping this true
+
+`.github/workflows/security-scan.yml` runs two jobs on every PR:
+
+- **Dependency license scan (Python)** — `pip-licenses --allow-only=...
+  --ignore-packages psycopg psycopg-binary` against a clean install of the
+  real runtime dependency tree.
+- **Dependency license scan (Go)** — `go-licenses check ./...
+  --disallowed_types=forbidden` against the full resolved `go.mod` tree.
+
+A future dependency (or transitive dependency) landing under GPL, AGPL, SSPL,
+or anything else outside the allowlist fails the PR instead of going
+unnoticed.


### PR DESCRIPTION
## Summary

- Adds two new jobs to `.github/workflows/security-scan.yml`: **Dependency license scan (Python)** (`pip-licenses --allow-only=... --ignore-packages psycopg psycopg-binary`) and **Dependency license scan (Go)** (`go-licenses check ./... --disallowed_types=forbidden`), gating every PR on the real resolved dependency tree staying within CNCF's allowed-license policy.
- Adds `docs/THIRD_PARTY_LICENSES.md` documenting the scan methodology and current results.

## Findings

Scanned the actual resolved dependency trees (clean venv `pip install .[postgres,s3]` for Python; full `go/go.mod` tree for Go), not the ambient dev environment.

- **Python**: all permissive (Apache-2.0/MIT/BSD/PSF-2.0) **except `psycopg`/`psycopg-binary`, which are LGPL-3.0-only.** `postgres` is an optional extra, imported as an unmodified library (never statically linked) -- the standard basis CNCF/ASF-style policy treats LGPL as acceptable. Explicitly documented and excluded via `--ignore-packages` rather than silently passing.
- **Go**: 100% permissive (Apache-2.0/MIT/BSD-3-Clause/ISC). No GPL/AGPL/LGPL anywhere. Two modules `go-licenses` flags `Unknown` are verified tool false-negatives (`modernc.org/mathutil` has a BSD-3-Clause LICENSE the tool's regex misses; `nexus-rpc/nexus-proto-annotations`'s pinned tag predates that repo's LICENSE file, confirmed MIT via `gh api`) -- excluded via `--ignore` rather than left unverified.

Fixes #253. Follow-up to #175 (dependency license pass vs CNCF allowlist).

## Test plan

- [x] `python -m yaml.safe_load` on the modified workflow -- valid YAML
- [x] `actionlint` against the modified workflow -- clean
- [x] `zizmor` against the modified workflow -- same finding count per new job as every existing job in this file (advisory-only, `continue-on-error: true`, pre-existing pattern per the file's own #167 TODO)
- [x] Dry-ran both new CI checks locally against the real dependency trees (`pip-licenses --allow-only=...`, `go-licenses check ./... --disallowed_types=forbidden`) -- both pass with the documented exceptions, and I confirmed the Python check correctly fails without the `psycopg` ignore
- Docs-only change to `README.md`/`docs/CI_HARDENING.md`, no source touched -- existing test suite unaffected