### PR TITLE
fix(log): scope has/Has by tenant_id to enforce multi-tenant isolation

### DIFF
--- a/conformance/r03_pure_recompute_test.py
+++ b/conformance/r03_pure_recompute_test.py
@@ -73,7 +73,7 @@ def test_r03_pure_tool_may_recompute_after_prior_tool_call(tmp_path) -> None:
         assert ei.value.step_n == 1
         assert ei.value.tool_name == "compute"
         assert calls["n"] == 2
-        assert log.has(traj, 1, "ABORT", seq=3)
+        assert log.has(traj, tenant, 1, "ABORT", seq=3)
     finally:
         log.close()
 
@@ -105,7 +105,7 @@ def test_r03_pure_run_step_does_not_block_on_second_invocation(tmp_path, monkeyp
     assert r1 == [1]
     assert r2 == [2]
     assert _R03_CALLS["n"] == 2
-    assert log.has(traj, 1, "TOOL_CALL", seq=2)
-    assert log.has(traj, 2, "TOOL_CALL", seq=2)
-    assert not log.has(traj, 1, "ABORT", seq=3)
-    assert not log.has(traj, 2, "ABORT", seq=3)
+    assert log.has(traj, tenant, 1, "TOOL_CALL", seq=2)
+    assert log.has(traj, tenant, 2, "TOOL_CALL", seq=2)
+    assert not log.has(traj, tenant, 1, "ABORT", seq=3)
+    assert not log.has(traj, tenant, 2, "ABORT", seq=3)

--- a/docs/E2E_POSTGRES_CAS_THIN.md
+++ b/docs/E2E_POSTGRES_CAS_THIN.md
@@ -235,7 +235,7 @@ from drivers.postgres.log import open_postgres_node_log
 log = open_postgres_node_log()  # reads TRAJIR_DATABASE_URL
 traj, tenant = "e2e-pg-1", "demo"
 log.append("DECISION", 1, {"plan": {"tool_calls": []}}, traj, tenant, seq=1)
-assert log.has(traj, 1, "DECISION")
+assert log.has(traj, tenant, 1, "DECISION")
 rows = log.list_nodes(traj, tenant_id=tenant)
 print("count", len(rows), "id", rows[0]["id"][:16])
 log.close()

--- a/drivers/postgres/log.py
+++ b/drivers/postgres/log.py
@@ -260,9 +260,50 @@ class PostgresNodeLog:
                 self._conn.rollback()
                 raise
 
-    def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
+    def has(
+        self,
+        trajectory_id: str,
+        tenant_id: str,
+        step_n: int,
+        kind: str,
+        seq: int | None = None,
+    ) -> bool:
+        """Does a node of `kind` exist for this trajectory/step scoped to `tenant_id`?
+
+        Matches SQLite NodeLog semantics. Callers needing cross-tenant existence
+        checks must use `has_all_tenants` explicitly.
+        """
+        if not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
+        return self._has(trajectory_id, tenant_id=tenant_id, step_n=step_n, kind=kind, seq=seq)
+
+    def has_all_tenants(
+        self,
+        trajectory_id: str,
+        step_n: int,
+        kind: str,
+        seq: int | None = None,
+    ) -> bool:
+        """Does a node of `kind` exist for this trajectory/step across any tenant?
+
+        Bypasses tenant isolation for administrative diagnostics and debugging.
+        """
+        return self._has(trajectory_id, tenant_id=None, step_n=step_n, kind=kind, seq=seq)
+
+    def _has(
+        self,
+        trajectory_id: str,
+        *,
+        tenant_id: str | None,
+        step_n: int,
+        kind: str,
+        seq: int | None,
+    ) -> bool:
         sql = "SELECT 1 FROM nodes WHERE trajectory_id = %s AND step_n = %s AND kind = %s"
         params: list[object] = [trajectory_id, step_n, kind]
+        if tenant_id is not None:
+            sql += " AND tenant_id = %s"
+            params.append(tenant_id)
         if seq is not None:
             sql += " AND seq = %s"
             params.append(seq)

--- a/go/trajir/client/client_test.go
+++ b/go/trajir/client/client_test.go
@@ -32,11 +32,11 @@ func TestOpenProjectSealCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ok, err := tr.Log().Has("t1", 1, "DECISION", nil)
+	ok, err := tr.Log().Has("t1", "demo", 1, "DECISION", nil)
 	if err != nil || !ok {
 		t.Fatalf("DECISION present=%v err=%v", ok, err)
 	}
-	ok, err = tr.Log().Has("t1", 1, "COMMIT_STEP", nil)
+	ok, err = tr.Log().Has("t1", "demo", 1, "COMMIT_STEP", nil)
 	if err != nil || !ok {
 		t.Fatalf("COMMIT_STEP present=%v err=%v", ok, err)
 	}
@@ -139,11 +139,11 @@ func TestExecToolLogsPlainTools(t *testing.T) {
 	if res.Result != "hi" {
 		t.Fatalf("result=%v", res.Result)
 	}
-	ok, err := tr.Log().Has("t-plain", 1, "TOOL_CALL", intPtr(2))
+	ok, err := tr.Log().Has("t-plain", "demo", 1, "TOOL_CALL", intPtr(2))
 	if err != nil || !ok {
 		t.Fatalf("TOOL_CALL has=%v err=%v", ok, err)
 	}
-	ok, err = tr.Log().Has("t-plain", 1, "TOOL_RESULT", intPtr(3))
+	ok, err = tr.Log().Has("t-plain", "demo", 1, "TOOL_RESULT", intPtr(3))
 	if err != nil || !ok {
 		t.Fatalf("TOOL_RESULT has=%v err=%v", ok, err)
 	}

--- a/go/trajir/log/log.go
+++ b/go/trajir/log/log.go
@@ -215,14 +215,32 @@ func (l *NodeLog) ClaimToolCall(
 	return true, nil
 }
 
-// Has reports whether a node of kind exists for trajectory and step.
+// Has reports whether a node of kind exists for trajectory and step scoped to tenantID.
 // When seq is non nil, the match is limited to that sequence slot.
-func (l *NodeLog) Has(trajectoryID string, stepN int, kind string, seq *int) (bool, error) {
+// tenantID must be non-empty; use HasAllTenants for cross-tenant administrative checks.
+func (l *NodeLog) Has(trajectoryID, tenantID string, stepN int, kind string, seq *int) (bool, error) {
+	if tenantID == "" {
+		return false, fmt.Errorf("tenantID must be a non-empty string")
+	}
+	return l.has(trajectoryID, &tenantID, stepN, kind, seq)
+}
+
+// HasAllTenants reports whether a node of kind exists for trajectory and step across any tenant.
+// This bypasses tenant isolation and is intended for administrative or diagnostic tools only.
+func (l *NodeLog) HasAllTenants(trajectoryID string, stepN int, kind string, seq *int) (bool, error) {
+	return l.has(trajectoryID, nil, stepN, kind, seq)
+}
+
+func (l *NodeLog) has(trajectoryID string, tenantID *string, stepN int, kind string, seq *int) (bool, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	q := `SELECT 1 FROM nodes WHERE trajectory_id = ? AND step_n = ? AND kind = ?`
 	args := []any{trajectoryID, stepN, kind}
+	if tenantID != nil {
+		q += ` AND tenant_id = ?`
+		args = append(args, *tenantID)
+	}
 	if seq != nil {
 		q += ` AND seq = ?`
 		args = append(args, *seq)

--- a/go/trajir/log/log_test.go
+++ b/go/trajir/log/log_test.go
@@ -34,7 +34,7 @@ func TestAppendThenHas(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ok, err := nl.Has("t1", 1, "DECISION", nil)
+	ok, err := nl.Has("t1", "demo", 1, "DECISION", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestAppendThenHas(t *testing.T) {
 		t.Fatal("expected DECISION to be present")
 	}
 
-	ok, err = nl.Has("t1", 1, "TOOL_RESULT", nil)
+	ok, err = nl.Has("t1", "demo", 1, "TOOL_RESULT", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestHasWithSeqDistinguishesSlots(t *testing.T) {
 	}
 
 	seq2 := 2
-	ok, err := nl.Has("t1", 1, "TOOL_CALL", &seq2)
+	ok, err := nl.Has("t1", "demo", 1, "TOOL_CALL", &seq2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestHasWithSeqDistinguishesSlots(t *testing.T) {
 	}
 
 	seq4 := 4
-	ok, err = nl.Has("t1", 1, "TOOL_CALL", &seq4)
+	ok, err = nl.Has("t1", "demo", 1, "TOOL_CALL", &seq4)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestHasWithSeqDistinguishesSlots(t *testing.T) {
 	}
 
 	// Unscoped has still finds TOOL_CALL somewhere in the step.
-	ok, err = nl.Has("t1", 1, "TOOL_CALL", nil)
+	ok, err = nl.Has("t1", "demo", 1, "TOOL_CALL", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestClaimToolCallSingleWinner(t *testing.T) {
 		t.Fatal("second claim should lose")
 	}
 	seq := 2
-	ok, err := nl.Has("t1", 1, "TOOL_CALL", &seq)
+	ok, err := nl.Has("t1", "demo", 1, "TOOL_CALL", &seq)
 	if err != nil || !ok {
 		t.Fatalf("TOOL_CALL present=%v err=%v", ok, err)
 	}
@@ -248,3 +248,94 @@ func TestAppendSlotConflictPreservesOriginal(t *testing.T) {
 		t.Fatalf("stored id=%v want %s", rows[0]["id"], n1.ID)
 	}
 }
+
+func TestHasTenantFilter(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+
+	// Direct leak regression test: tenant-a writes DECISION, tenant-b must not see it.
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "a"}, "t1", "tenant-a", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := nl.Has("t1", "tenant-b", 1, "DECISION", nil)
+	if err != nil || ok {
+		t.Fatalf("Has tenant-b=%v err=%v, want false", ok, err)
+	}
+
+	ok, err = nl.Has("t1", "tenant-a", 1, "DECISION", nil)
+	if err != nil || !ok {
+		t.Fatalf("Has tenant-a=%v err=%v, want true", ok, err)
+	}
+
+	// Multi-tenant slot filtering with seq
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "b"}, "t1", "tenant-b", 2); err != nil {
+		t.Fatal(err)
+	}
+
+	seq2 := 2
+	ok, err = nl.Has("t1", "tenant-a", 1, "DECISION", &seq2)
+	if err != nil || ok {
+		t.Fatalf("Has tenant-a seq2=%v err=%v", ok, err)
+	}
+
+	ok, err = nl.Has("t1", "tenant-b", 1, "DECISION", &seq2)
+	if err != nil || !ok {
+		t.Fatalf("Has tenant-b seq2=%v err=%v", ok, err)
+	}
+
+	ok, err = nl.Has("t1", "tenant-c", 1, "DECISION", nil)
+	if err != nil || ok {
+		t.Fatalf("Has tenant-c=%v err=%v", ok, err)
+	}
+}
+
+func TestHasAllTenants(t *testing.T) {
+	nl := openTemp(t)
+	step := 1
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "a"}, "t1", "tenant-a", 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nl.Append("DECISION", &step, map[string]any{"plan": "b"}, "t1", "tenant-b", 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Scoped check for a third tenant is false
+	ok, err := nl.Has("t1", "tenant-c", 1, "DECISION", nil)
+	if err != nil || ok {
+		t.Fatalf("Has tenant-c=%v err=%v, want false", ok, err)
+	}
+
+	// Cross-tenant escape hatch finds nodes from any tenant
+	ok, err = nl.HasAllTenants("t1", 1, "DECISION", nil)
+	if err != nil || !ok {
+		t.Fatalf("HasAllTenants=%v err=%v, want true", ok, err)
+	}
+
+	seq2 := 2
+	ok, err = nl.HasAllTenants("t1", 1, "DECISION", &seq2)
+	if err != nil || !ok {
+		t.Fatalf("HasAllTenants seq2=%v err=%v, want true", ok, err)
+	}
+
+	seq99 := 99
+	ok, err = nl.HasAllTenants("t1", 1, "DECISION", &seq99)
+	if err != nil || ok {
+		t.Fatalf("HasAllTenants seq99=%v err=%v, want false", ok, err)
+	}
+
+	ok, err = nl.HasAllTenants("nonexistent-traj", 1, "DECISION", nil)
+	if err != nil || ok {
+		t.Fatalf("HasAllTenants nonexistent=%v err=%v, want false", ok, err)
+	}
+}
+
+func TestHasRejectsEmptyTenant(t *testing.T) {
+	nl := openTemp(t)
+	_, err := nl.Has("t1", "", 1, "DECISION", nil)
+	if err == nil {
+		t.Fatal("expected error on empty tenantID")
+	}
+}
+
+

--- a/go/trajir/postgres/log.go
+++ b/go/trajir/postgres/log.go
@@ -252,15 +252,34 @@ func (l *NodeLog) ClaimToolCall(
 	return true, nil
 }
 
-// Has reports whether a node of kind exists for trajectory and step.
-func (l *NodeLog) Has(trajectoryID string, stepN int, kind string, seq *int) (bool, error) {
+// Has reports whether a node of kind exists for trajectory and step scoped to tenantID.
+// When seq is non nil, the match is limited to that sequence slot.
+// tenantID must be non-empty; use HasAllTenants for cross-tenant administrative checks.
+func (l *NodeLog) Has(trajectoryID, tenantID string, stepN int, kind string, seq *int) (bool, error) {
+	if tenantID == "" {
+		return false, fmt.Errorf("tenantID must be a non-empty string")
+	}
+	return l.has(trajectoryID, &tenantID, stepN, kind, seq)
+}
+
+// HasAllTenants reports whether a node of kind exists for trajectory and step across any tenant.
+// This bypasses tenant isolation and is intended for administrative or diagnostic tools only.
+func (l *NodeLog) HasAllTenants(trajectoryID string, stepN int, kind string, seq *int) (bool, error) {
+	return l.has(trajectoryID, nil, stepN, kind, seq)
+}
+
+func (l *NodeLog) has(trajectoryID string, tenantID *string, stepN int, kind string, seq *int) (bool, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	q := `SELECT 1 FROM nodes WHERE trajectory_id = $1 AND step_n = $2 AND kind = $3`
 	args := []any{trajectoryID, stepN, kind}
+	if tenantID != nil {
+		q += fmt.Sprintf(" AND tenant_id = $%d", len(args)+1)
+		args = append(args, *tenantID)
+	}
 	if seq != nil {
-		q += ` AND seq = $4`
+		q += fmt.Sprintf(" AND seq = $%d", len(args)+1)
 		args = append(args, *seq)
 	}
 	q += ` LIMIT 1`

--- a/go/trajir/postgres/log_test.go
+++ b/go/trajir/postgres/log_test.go
@@ -51,7 +51,7 @@ func TestLiveAppendHasListIdempotent(t *testing.T) {
 	if n1.ID != n2.ID {
 		t.Fatalf("ids differ %s vs %s", n1.ID, n2.ID)
 	}
-	ok, err := nl.Has(traj, 1, "DECISION", nil)
+	ok, err := nl.Has(traj, "demo", 1, "DECISION", nil)
 	if err != nil || !ok {
 		t.Fatalf("Has=%v err=%v", ok, err)
 	}

--- a/go/trajir/postgres/log_unit_test.go
+++ b/go/trajir/postgres/log_unit_test.go
@@ -52,7 +52,7 @@ func TestMockAppendHasListClose(t *testing.T) {
 
 	mock.ExpectQuery("SELECT 1 FROM nodes WHERE trajectory_id").
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
-	ok, err := nl.Has("t1", 1, "DECISION", nil)
+	ok, err := nl.Has("t1", "demo", 1, "DECISION", nil)
 	if err != nil || !ok {
 		t.Fatalf("Has=%v err=%v", ok, err)
 	}
@@ -60,9 +60,20 @@ func TestMockAppendHasListClose(t *testing.T) {
 	seq := 1
 	mock.ExpectQuery("SELECT 1 FROM nodes WHERE trajectory_id").
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
-	ok, err = nl.Has("t1", 1, "DECISION", &seq)
+	ok, err = nl.Has("t1", "demo", 1, "DECISION", &seq)
 	if err != nil || !ok {
 		t.Fatalf("Has seq=%v err=%v", ok, err)
+	}
+
+	mock.ExpectQuery("SELECT 1 FROM nodes WHERE trajectory_id").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+	ok, err = nl.HasAllTenants("t1", 1, "DECISION", nil)
+	if err != nil || !ok {
+		t.Fatalf("HasAllTenants=%v err=%v", ok, err)
+	}
+
+	if _, err := nl.Has("t1", "", 1, "DECISION", nil); err == nil {
+		t.Fatal("expected error on empty tenantID")
 	}
 
 	mock.ExpectQuery("SELECT id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts").

--- a/go/trajir/resume/gate_test.go
+++ b/go/trajir/resume/gate_test.go
@@ -54,11 +54,11 @@ func TestGatedToolRunsOnceThenBlocks(t *testing.T) {
 		t.Fatalf("sideEffects=%d after block, want 1", sideEffects)
 	}
 
-	ok, err := nl.Has("t1", 1, "TOOL_CALL", intPtr(2))
+	ok, err := nl.Has("t1", "demo", 1, "TOOL_CALL", intPtr(2))
 	if err != nil || !ok {
 		t.Fatalf("TOOL_CALL present=%v err=%v", ok, err)
 	}
-	ok, err = nl.Has("t1", 1, "ABORT", intPtr(3))
+	ok, err = nl.Has("t1", "demo", 1, "ABORT", intPtr(3))
 	if err != nil || !ok {
 		t.Fatalf("ABORT present=%v err=%v", ok, err)
 	}
@@ -111,7 +111,7 @@ func TestGatedToolPropagatesToolError(t *testing.T) {
 	if !errors.Is(err, boom) {
 		t.Fatalf("err=%v want %v", err, boom)
 	}
-	ok, err := nl.Has("t1", 1, "TOOL_RESULT", intPtr(3))
+	ok, err := nl.Has("t1", "demo", 1, "TOOL_RESULT", intPtr(3))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/trajir/resume/step_test.go
+++ b/go/trajir/resume/step_test.go
@@ -66,11 +66,11 @@ func TestRunStepHappyPathIdempotentTool(t *testing.T) {
 		t.Fatalf("results=%#v", results)
 	}
 
-	ok, _ := nl.Has("t1", 1, "DECISION", nil)
+	ok, _ := nl.Has("t1", "demo", 1, "DECISION", nil)
 	if !ok {
 		t.Fatal("missing DECISION")
 	}
-	ok, _ = nl.Has("t1", 1, "COMMIT_STEP", nil)
+	ok, _ = nl.Has("t1", "demo", 1, "COMMIT_STEP", nil)
 	if !ok {
 		t.Fatal("missing COMMIT_STEP")
 	}
@@ -331,7 +331,7 @@ func TestRunStepNonGatedToolErrorNotLogged(t *testing.T) {
 	if _, err := resume.RunStep(ctx, cfg, 1, model, nil); !errors.Is(err, boom) {
 		t.Fatalf("err=%v want %v", err, boom)
 	}
-	ok, err := nl.Has("t1", 1, "TOOL_CALL", intPtr(2))
+	ok, err := nl.Has("t1", "demo", 1, "TOOL_CALL", intPtr(2))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -169,8 +169,19 @@ class NodeLog:
                     self._conn.execute("ROLLBACK")
                 raise
 
-    def has(self, trajectory_id: str, step_n: int, kind: str, seq: int | None = None) -> bool:
-        """Does a node of `kind` exist for this trajectory/step?
+    def has(
+        self,
+        trajectory_id: str,
+        tenant_id: str,
+        step_n: int,
+        kind: str,
+        seq: int | None = None,
+    ) -> bool:
+        """Does a node of `kind` exist for this trajectory/step scoped to `tenant_id`?
+
+        `tenant_id` is required to enforce multi-tenant isolation. Callers that
+        genuinely need cross-tenant existence checks (e.g., administrative or
+        diagnostic tools) must use `has_all_tenants` explicitly instead.
 
         `seq` narrows the question to one exact node slot. Without it, a step
         containing several tool calls cannot distinguish them: one completed
@@ -178,8 +189,38 @@ class NodeLog:
         as None the query is unscoped, which is the right question for
         step-level kinds (DECISION, COMMIT_STEP) that occur at most once.
         """
+        if not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
+        return self._has(trajectory_id, tenant_id=tenant_id, step_n=step_n, kind=kind, seq=seq)
+
+    def has_all_tenants(
+        self,
+        trajectory_id: str,
+        step_n: int,
+        kind: str,
+        seq: int | None = None,
+    ) -> bool:
+        """Does a node of `kind` exist for this trajectory/step across any tenant?
+
+        This bypasses tenant isolation and should only be used for administrative
+        diagnostics or debugging tools, not standard execution paths.
+        """
+        return self._has(trajectory_id, tenant_id=None, step_n=step_n, kind=kind, seq=seq)
+
+    def _has(
+        self,
+        trajectory_id: str,
+        *,
+        tenant_id: str | None,
+        step_n: int,
+        kind: str,
+        seq: int | None,
+    ) -> bool:
         sql = "SELECT 1 FROM nodes WHERE trajectory_id = ? AND step_n = ? AND kind = ?"
         params: list[object] = [trajectory_id, step_n, kind]
+        if tenant_id is not None:
+            sql += " AND tenant_id = ?"
+            params.append(tenant_id)
         if seq is not None:
             sql += " AND seq = ?"
             params.append(seq)

--- a/test/integration/test_postgres_live.py
+++ b/test/integration/test_postgres_live.py
@@ -31,7 +31,7 @@ def test_live_append_has_list_and_idempotent(log):
     n1 = log.append("DECISION", 1, {"plan": "x"}, traj, "demo", 1)
     n2 = log.append("DECISION", 1, {"plan": "x"}, traj, "demo", 1)
     assert n1.id == n2.id
-    assert log.has(traj, 1, "DECISION")
+    assert log.has(traj, "demo", 1, "DECISION")
     rows = log.list_nodes(traj, tenant_id="demo")
     assert len(rows) == 1
     assert rows[0]["id"] == n1.id
@@ -74,4 +74,4 @@ def test_live_claim_tool_call_single_winner(log):
     for t in threads:
         t.join()
     assert sum(1 for w in wins if w) == 1
-    assert log.has(traj, 1, "TOOL_CALL", seq=2)
+    assert log.has(traj, "demo", 1, "TOOL_CALL", seq=2)

--- a/test/unit/test_cas_artifact_export.py
+++ b/test/unit/test_cas_artifact_export.py
@@ -49,7 +49,7 @@ def test_put_export_thin_rehydrate_roundtrip(tmp_path):
     log2 = NodeLog(db2)
     pkg2 = import_tir(dest, log2, cas=cas, rehydrate=True)
     assert pkg2.artifact_bytes[ref.content_hash] == data
-    assert log2.has("t1", 1, "DECISION")
+    assert log2.has("t1", "demo", 1, "DECISION")
     log.close()
     log2.close()
 

--- a/test/unit/test_client_sdk.py
+++ b/test/unit/test_client_sdk.py
@@ -21,13 +21,13 @@ def db_path(tmp_path, monkeypatch):
 def test_project_appends_project_context_node(db_path):
     traj = open_trajectory(tenant_id="demo", trajectory_id="test-t1", db_path=db_path)
     project(traj, step_n=1, context={"foo": "bar"})
-    assert NodeLog(db_path).has("test-t1", 1, "PROJECT_CONTEXT")
+    assert NodeLog(db_path).has("test-t1", "demo", 1, "PROJECT_CONTEXT")
 
 
 def test_seal_decision_appends_decision_node(db_path):
     traj = open_trajectory(tenant_id="demo", trajectory_id="test-t2", db_path=db_path)
     seal_decision(traj, step_n=1, plan={"tool_calls": []})
-    assert NodeLog(db_path).has("test-t2", 1, "DECISION")
+    assert NodeLog(db_path).has("test-t2", "demo", 1, "DECISION")
 
 
 def test_exec_tool_runs_idempotent_write_directly(db_path):
@@ -40,7 +40,7 @@ def test_exec_tool_runs_idempotent_write_directly(db_path):
 def test_commit_step_appends_commit_step_node(db_path):
     traj = open_trajectory(tenant_id="demo", trajectory_id="test-t4", db_path=db_path)
     commit_step(traj, step_n=1, seq=2)
-    assert NodeLog(db_path).has("test-t4", 1, "COMMIT_STEP")
+    assert NodeLog(db_path).has("test-t4", "demo", 1, "COMMIT_STEP")
 
 
 def test_exec_tool_two_non_idempotent_writes_same_step_distinct_seq(db_path):
@@ -59,5 +59,5 @@ def test_exec_tool_two_non_idempotent_writes_same_step_distinct_seq(db_path):
     assert result2.result == 6
 
     # Both should be logged without either being falsely blocked
-    assert NodeLog(db_path).has("test-t5", 1, "TOOL_CALL", seq=2)
-    assert NodeLog(db_path).has("test-t5", 1, "TOOL_CALL", seq=4)
+    assert NodeLog(db_path).has("test-t5", "demo", 1, "TOOL_CALL", seq=2)
+    assert NodeLog(db_path).has("test-t5", "demo", 1, "TOOL_CALL", seq=4)

--- a/test/unit/test_client_sdk_plain_tool_logging.py
+++ b/test/unit/test_client_sdk_plain_tool_logging.py
@@ -14,8 +14,8 @@ def test_exec_tool_logs_tool_call_and_result_for_non_gated_tool(tmp_path, monkey
 
     assert result.result == 10
     log = NodeLog(db_path)
-    assert log.has("plain-1", 1, "TOOL_CALL", seq=2)
-    assert log.has("plain-1", 1, "TOOL_RESULT", seq=3)
+    assert log.has("plain-1", "demo", 1, "TOOL_CALL", seq=2)
+    assert log.has("plain-1", "demo", 1, "TOOL_RESULT", seq=3)
 
 
 def test_exec_tool_logs_two_plain_tools_same_step_distinct_seq(tmp_path, monkeypatch):
@@ -30,7 +30,7 @@ def test_exec_tool_logs_two_plain_tools_same_step_distinct_seq(tmp_path, monkeyp
     exec_tool(traj, step_n=1, call={"args": {"x": 3}}, tool=tool_b, seq=4)
 
     log = NodeLog(db_path)
-    assert log.has("plain-2", 1, "TOOL_CALL", seq=2)
-    assert log.has("plain-2", 1, "TOOL_RESULT", seq=3)
-    assert log.has("plain-2", 1, "TOOL_CALL", seq=4)
-    assert log.has("plain-2", 1, "TOOL_RESULT", seq=5)
+    assert log.has("plain-2", "demo", 1, "TOOL_CALL", seq=2)
+    assert log.has("plain-2", "demo", 1, "TOOL_RESULT", seq=3)
+    assert log.has("plain-2", "demo", 1, "TOOL_CALL", seq=4)
+    assert log.has("plain-2", "demo", 1, "TOOL_RESULT", seq=5)

--- a/test/unit/test_node_log.py
+++ b/test/unit/test_node_log.py
@@ -26,8 +26,8 @@ def test_append_then_has(log):
         tenant_id="demo",
         seq=1,
     )
-    assert log.has("t1", 1, "DECISION")
-    assert not log.has("t1", 1, "TOOL_RESULT")
+    assert log.has("t1", "demo", 1, "DECISION")
+    assert not log.has("t1", "demo", 1, "TOOL_RESULT")
 
 
 def test_append_is_idempotent_by_content(log):
@@ -71,7 +71,7 @@ def test_claim_tool_call_atomic_single_winner(log):
         t.join()
     assert sum(1 for w in wins if w) == 1
     assert sum(1 for w in wins if not w) == 7
-    assert log.has("t1", 1, "TOOL_CALL", seq=2)
+    assert log.has("t1", "demo", 1, "TOOL_CALL", seq=2)
 
 
 def test_list_nodes_tenant_filter(log):
@@ -88,3 +88,36 @@ def test_slot_conflict_different_payload(log):
     log.append("DECISION", 1, {"plan": "a"}, "t1", "demo", 1)
     with pytest.raises(SlotConflictError):
         log.append("DECISION", 1, {"plan": "b"}, "t1", "demo", 1)
+
+
+def test_has_tenant_filter(log):
+    # Direct leak regression test: tenant-a writes DECISION, tenant-b must not see it.
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "tenant-a", 1)
+    assert not log.has("t1", "tenant-b", 1, "DECISION")
+    assert log.has("t1", "tenant-a", 1, "DECISION")
+
+    # Multi-tenant slot filtering with seq
+    log.append("DECISION", 1, {"plan": "b"}, "t1", "tenant-b", 2)
+    assert log.has("t1", "tenant-a", 1, "DECISION")
+    assert not log.has("t1", "tenant-a", 1, "DECISION", seq=2)
+    assert log.has("t1", "tenant-b", 1, "DECISION", seq=2)
+    assert not log.has("t1", "tenant-c", 1, "DECISION")
+
+
+def test_has_all_tenants(log):
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "tenant-a", 1)
+    log.append("DECISION", 1, {"plan": "b"}, "t1", "tenant-b", 2)
+
+    # Scoped check for a third tenant is false
+    assert not log.has("t1", "tenant-c", 1, "DECISION")
+
+    # Cross-tenant escape hatch finds nodes from any tenant
+    assert log.has_all_tenants("t1", 1, "DECISION")
+    assert log.has_all_tenants("t1", 1, "DECISION", seq=2)
+    assert not log.has_all_tenants("t1", 1, "DECISION", seq=99)
+    assert not log.has_all_tenants("nonexistent-traj", 1, "DECISION")
+
+
+def test_has_rejects_empty_tenant(log):
+    with pytest.raises(ValueError, match="tenant_id must be a non-empty string"):
+        log.has("t1", "", 1, "DECISION")

--- a/test/unit/test_postgres_node_log.py
+++ b/test/unit/test_postgres_node_log.py
@@ -128,25 +128,20 @@ class _FakeStore:
             return []
         if s.startswith("select 1 from nodes"):
             # has()
-            if len(params) == 4:
-                trajectory_id, step_n, kind, seq = params
-                for row in self.rows.values():
-                    if (
-                        row["trajectory_id"] == trajectory_id
-                        and row["step_n"] == step_n
-                        and row["kind"] == kind
-                        and row["seq"] == seq
-                    ):
-                        return [(1,)]
-            else:
-                trajectory_id, step_n, kind = params
-                for row in self.rows.values():
-                    if (
-                        row["trajectory_id"] == trajectory_id
-                        and row["step_n"] == step_n
-                        and row["kind"] == kind
-                    ):
-                        return [(1,)]
+            p_iter = iter(params)
+            t_id = next(p_iter)
+            sn = next(p_iter)
+            k = next(p_iter)
+            ten = next(p_iter) if "tenant_id" in s else None
+            sq = next(p_iter) if "seq = %s" in s else None
+            for row in self.rows.values():
+                if row["trajectory_id"] != t_id or row["step_n"] != sn or row["kind"] != k:
+                    continue
+                if ten is not None and row["tenant_id"] != ten:
+                    continue
+                if sq is not None and row["seq"] != sq:
+                    continue
+                return [(1,)]
             return []
         if "select count(*)" in s:
             (node_id,) = params
@@ -210,8 +205,8 @@ def test_append_then_has(log: PostgresNodeLog):
         tenant_id="demo",
         seq=1,
     )
-    assert log.has("t1", 1, "DECISION")
-    assert not log.has("t1", 1, "TOOL_RESULT")
+    assert log.has("t1", "demo", 1, "DECISION")
+    assert not log.has("t1", "demo", 1, "TOOL_RESULT")
 
 
 def test_append_idempotent_by_content(log: PostgresNodeLog):
@@ -236,6 +231,39 @@ def test_list_nodes_tenant_filter(log: PostgresNodeLog):
     assert json.loads(json.dumps(only_a[0]["payload"])) == {"plan": "a"}
 
 
+def test_has_tenant_filter(log: PostgresNodeLog):
+    # Direct leak regression test: tenant-a writes DECISION, tenant-b must not see it.
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "tenant-a", 1)
+    assert not log.has("t1", "tenant-b", 1, "DECISION")
+    assert log.has("t1", "tenant-a", 1, "DECISION")
+
+    # Multi-tenant slot filtering with seq
+    log.append("DECISION", 1, {"plan": "b"}, "t1", "tenant-b", 2)
+    assert log.has("t1", "tenant-a", 1, "DECISION")
+    assert not log.has("t1", "tenant-a", 1, "DECISION", seq=2)
+    assert log.has("t1", "tenant-b", 1, "DECISION", seq=2)
+    assert not log.has("t1", "tenant-c", 1, "DECISION")
+
+
+def test_has_all_tenants(log: PostgresNodeLog):
+    log.append("DECISION", 1, {"plan": "a"}, "t1", "tenant-a", 1)
+    log.append("DECISION", 1, {"plan": "b"}, "t1", "tenant-b", 2)
+
+    # Scoped check for a third tenant is false
+    assert not log.has("t1", "tenant-c", 1, "DECISION")
+
+    # Cross-tenant escape hatch finds nodes from any tenant
+    assert log.has_all_tenants("t1", 1, "DECISION")
+    assert log.has_all_tenants("t1", 1, "DECISION", seq=2)
+    assert not log.has_all_tenants("t1", 1, "DECISION", seq=99)
+    assert not log.has_all_tenants("nonexistent-traj", 1, "DECISION")
+
+
+def test_has_rejects_empty_tenant(log: PostgresNodeLog):
+    with pytest.raises(ValueError, match="tenant_id must be a non-empty string"):
+        log.has("t1", "", 1, "DECISION")
+
+
 def test_claim_tool_call_single_winner(log: PostgresNodeLog):
     wins: list[bool] = []
 
@@ -255,7 +283,7 @@ def test_claim_tool_call_single_winner(log: PostgresNodeLog):
     for t in threads:
         t.join()
     assert sum(1 for w in wins if w) == 1
-    assert log.has("t1", 1, "TOOL_CALL", seq=2)
+    assert log.has("t1", "demo", 1, "TOOL_CALL", seq=2)
 
 
 def test_open_requires_dsn(monkeypatch: pytest.MonkeyPatch):
@@ -274,7 +302,7 @@ def test_live_postgres_roundtrip():
     log = open_postgres_node_log()
     try:
         n = log.append("DECISION", 1, {"plan": "live"}, "live-t", "demo", 1)
-        assert log.has("live-t", 1, "DECISION")
+        assert log.has("live-t", "demo", 1, "DECISION")
         rows = log.list_nodes("live-t", tenant_id="demo")
         assert rows[0]["id"] == n.id
     finally:

--- a/test/unit/test_restate_adapter.py
+++ b/test/unit/test_restate_adapter.py
@@ -90,9 +90,9 @@ def test_make_run_step_with_restate_local_memo(tmp_path):
     # Durable memo: model and tool body run once across replay.
     assert model_calls["n"] == 1
     assert tool_calls["n"] == 1
-    assert node_log.has(TRAJECTORY_ID, 1, "DECISION")
-    assert node_log.has(TRAJECTORY_ID, 1, "TOOL_CALL", seq=2)
-    assert node_log.has(TRAJECTORY_ID, 1, "COMMIT_STEP")
+    assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "DECISION")
+    assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "TOOL_CALL", seq=2)
+    assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "COMMIT_STEP")
 
 
 def test_partial_durable_injection_fails_loud(tmp_path):

--- a/test/unit/test_step.py
+++ b/test/unit/test_step.py
@@ -43,5 +43,5 @@ def test_plain_tool_logs_tool_call_and_result(tmp_path, monkeypatch):
         results = run_step(step_n=1, model_call=_model_call, context={})
 
     assert results == ["hello"]
-    assert node_log.has(TRAJECTORY_ID, 1, "TOOL_CALL", seq=2)
-    assert node_log.has(TRAJECTORY_ID, 1, "TOOL_RESULT", seq=3)
+    assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "TOOL_CALL", seq=2)
+    assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "TOOL_RESULT", seq=3)


### PR DESCRIPTION
## Summary

NodeLog.has() and PostgresNodeLog.has() queried by trajectory_id, step_n, and kind without filtering on tenant_id. In a shared database with overlapping trajectory IDs across tenants, one tenant's nodes could satisfy another tenant's existence check, leaking execution state across tenant boundaries.

This PR makes tenant_id a required positional parameter in has() / Has() across all four NodeLog implementations (Python SQLite, Python Postgres, Go SQLite, Go Postgres), adds has_all_tenants() / HasAllTenants() as an explicit escape hatch for diagnostics, validates that tenant_id is non-empty, and fixes the Go Postgres driver's hard-coded placeholder for seq to use dynamic numbering.

Note: This is a breaking signature change for has() / Has() (now accepts tenant_id as second positional parameter).

## Related issues

Closes #226

## How I tested

`ash
# Python reference
pip install -e .[dev]
pytest test/unit -q
pytest conformance/ -q
ruff check pkg drivers client test conformance examples
mypy

# Go primary
cd go && go test ./... -count=1
go vet ./...
`

All 169 Python tests pass (11 skipped for live services). All Go tests pass across all packages.

## Checklist

- [x] Commits are DCO signed (\git commit -s\)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed \.github/workflows/**\, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No

## AI assistance (if any)

None.