### PR TITLE
fix(cas): sweep stale put temps on filesystem CAS init

### DIFF
--- a/go/trajir/cas/cas.go
+++ b/go/trajir/cas/cas.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // Sentinel errors.
@@ -29,6 +30,11 @@ var (
 )
 
 var hex64 = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// Matches CreateTemp names: ".{64-hex}." + random suffix (same as Python mkstemp).
+var tempNameRe = regexp.MustCompile(`^\.[0-9a-f]{64}\.`)
+
+const defaultTempMaxAge = 24 * time.Hour
 
 // Store is the minimal CAS surface used by thin package rehydrate.
 type Store interface {
@@ -78,7 +84,36 @@ func NewFileSystem(root string) (*FileSystem, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FileSystem{Root: abs}, nil
+	fs := &FileSystem{Root: abs}
+	fs.sweepStaleTempFiles(defaultTempMaxAge)
+	return fs, nil
+}
+
+// sweepStaleTempFiles removes orphaned Put temp files under cas/ older than maxAge.
+// Only names matching the CreateTemp prefix are considered.
+func (fs *FileSystem) sweepStaleTempFiles(maxAge time.Duration) {
+	casRoot := filepath.Join(fs.Root, "cas")
+	st, err := os.Stat(casRoot)
+	if err != nil || !st.IsDir() {
+		return
+	}
+	now := time.Now()
+	_ = filepath.WalkDir(casRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if !tempNameRe.MatchString(d.Name()) {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if now.Sub(info.ModTime()) > maxAge {
+			_ = os.Remove(path)
+		}
+		return nil
+	})
 }
 
 // PathFor returns the absolute path for a content hash under this store.

--- a/go/trajir/cas/cas.go
+++ b/go/trajir/cas/cas.go
@@ -32,9 +32,13 @@ var (
 var hex64 = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 // Matches CreateTemp names: ".{64-hex}." + random suffix (same as Python mkstemp).
+// ContentHash / NormalizeHash always use lowercase hex, so Put prefixes are
+// lowercase only; matching A-F would not find writer temps and is unused.
 var tempNameRe = regexp.MustCompile(`^\.[0-9a-f]{64}\.`)
 
-const defaultTempMaxAge = 24 * time.Hour
+// DefaultTempMaxAge is how old a Put temp must be before SweepStaleTempFiles
+// will delete it.
+const DefaultTempMaxAge = 24 * time.Hour
 
 // Store is the minimal CAS surface used by thin package rehydrate.
 type Store interface {
@@ -73,6 +77,8 @@ type FileSystem struct {
 }
 
 // NewFileSystem creates root if needed and returns a FileSystem store.
+// It does not sweep orphaned Put temps; call SweepStaleTempFiles when no
+// concurrent writers share this root (avoids deleting an in-flight temp).
 func NewFileSystem(root string) (*FileSystem, error) {
 	if root == "" {
 		return nil, fmt.Errorf("%w: root is required", ErrCAS)
@@ -84,14 +90,13 @@ func NewFileSystem(root string) (*FileSystem, error) {
 	if err != nil {
 		return nil, err
 	}
-	fs := &FileSystem{Root: abs}
-	fs.sweepStaleTempFiles(defaultTempMaxAge)
-	return fs, nil
+	return &FileSystem{Root: abs}, nil
 }
 
-// sweepStaleTempFiles removes orphaned Put temp files under cas/ older than maxAge.
-// Only names matching the CreateTemp prefix are considered.
-func (fs *FileSystem) sweepStaleTempFiles(maxAge time.Duration) {
+// SweepStaleTempFiles removes orphaned Put temp files under cas/ older than maxAge.
+// Only names matching the CreateTemp prefix (".{lowercase-hex64}.…") are considered.
+// Pass DefaultTempMaxAge for the usual 24h threshold.
+func (fs *FileSystem) SweepStaleTempFiles(maxAge time.Duration) {
 	casRoot := filepath.Join(fs.Root, "cas")
 	st, err := os.Stat(casRoot)
 	if err != nil || !st.IsDir() {

--- a/go/trajir/cas/cas_test.go
+++ b/go/trajir/cas/cas_test.go
@@ -158,7 +158,7 @@ func TestRehydrate(t *testing.T) {
 	}
 }
 
-func TestNewFileSystemSweepsStaleTemps(t *testing.T) {
+func TestSweepStaleTempFiles(t *testing.T) {
 	root := t.TempDir()
 	h := ContentHash([]byte("sweep-me"))
 	shard := filepath.Join(root, "cas", h[:2])
@@ -196,6 +196,12 @@ func TestNewFileSystemSweepsStaleTemps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Default NewFileSystem must not sweep (shared-root safe).
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatalf("stale temp should remain until SweepStaleTempFiles: %v", err)
+	}
+
+	fs.SweepStaleTempFiles(DefaultTempMaxAge)
 	kept, err := fs.Put([]byte("real-object"))
 	if err != nil {
 		t.Fatal(err)

--- a/go/trajir/cas/cas_test.go
+++ b/go/trajir/cas/cas_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestContentHashEmpty(t *testing.T) {
@@ -154,6 +155,67 @@ func TestRehydrate(t *testing.T) {
 	}
 	if len(partial) != 1 || !bytes.Equal(partial[h1], []byte("one")) {
 		t.Fatalf("partial=%v", partial)
+	}
+}
+
+func TestNewFileSystemSweepsStaleTemps(t *testing.T) {
+	root := t.TempDir()
+	h := ContentHash([]byte("sweep-me"))
+	shard := filepath.Join(root, "cas", h[:2])
+	if err := os.MkdirAll(shard, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(shard, "."+h+".orphaned")
+	if err := os.WriteFile(stale, []byte("partial"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-25 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	freshH := ContentHash([]byte("keep-me-fresh"))
+	freshDir := filepath.Join(root, "cas", freshH[:2])
+	if err := os.MkdirAll(freshDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fresh := filepath.Join(freshDir, "."+freshH+".inflight")
+	if err := os.WriteFile(fresh, []byte("still writing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	decoy := filepath.Join(root, ".env.local")
+	if err := os.WriteFile(decoy, []byte("SECRET=1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(decoy, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	fs, err := NewFileSystem(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kept, err := fs.Put([]byte("real-object"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale temp still present: %v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh temp should remain: %v", err)
+	}
+	if _, err := os.Stat(decoy); err != nil {
+		t.Fatalf("root decoy should remain: %v", err)
+	}
+	path, err := fs.PathFor(kept)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("real object missing: %v", err)
 	}
 }
 

--- a/pkg/trajectory_ir/storage/fs.py
+++ b/pkg/trajectory_ir/storage/fs.py
@@ -30,7 +30,9 @@ from trajectory_ir.storage.cas import (
     shard_key,
 )
 
-# Matches mkstemp / CreateTemp names: ".{64-hex}." + random suffix.
+# put()/CreateTemp use content_hash / ContentHash, which are always lowercase
+# hex. Match that writer prefix only so we never touch final objects or other
+# hidden files.
 _TEMP_NAME_RE = re.compile(r"^\.[0-9a-f]{64}\.")
 _DEFAULT_TEMP_MAX_AGE_SECONDS = 86400.0
 
@@ -40,14 +42,20 @@ class FileSystemCAS:
 
     Args:
         root: Directory that will contain the ``cas/`` tree. Created if missing.
+        sweep_stale_temps: When True, run :meth:`sweep_stale_temp_files` once
+            after mkdir. Default False so constructing a store against a shared
+            root cannot delete another process's in-flight put() temp.
     """
 
-    def __init__(self, root: str | Path) -> None:
+    def __init__(
+        self, root: str | Path, *, sweep_stale_temps: bool = False
+    ) -> None:
         self._root = Path(root).resolve()
         self._root.mkdir(parents=True, exist_ok=True)
-        self._sweep_stale_temp_files()
+        if sweep_stale_temps:
+            self.sweep_stale_temp_files()
 
-    def _sweep_stale_temp_files(
+    def sweep_stale_temp_files(
         self, max_age_seconds: float = _DEFAULT_TEMP_MAX_AGE_SECONDS
     ) -> None:
         """Remove orphaned put() temp files under cas/ older than max_age_seconds.
@@ -55,21 +63,28 @@ class FileSystemCAS:
         put() writes with prefix ``.{hash}.`` then os.replace. A hard kill can leave
         those temps behind. Only the cas/ tree is scanned, and only names that match
         the writer prefix, so unrelated hidden files under root are left alone.
+
+        Call explicitly (or pass ``sweep_stale_temps=True`` to the constructor)
+        when no concurrent writers are expected against this root.
         """
         cas_root = self._root / "cas"
         if not cas_root.is_dir():
             return
         now = time.time()
-        for path in cas_root.rglob("*"):
-            if not path.is_file():
-                continue
-            if _TEMP_NAME_RE.match(path.name) is None:
-                continue
+        try:
+            paths = list(cas_root.rglob("*"))
+        except OSError:
+            return
+        for path in paths:
             try:
+                if not path.is_file():
+                    continue
+                if _TEMP_NAME_RE.match(path.name) is None:
+                    continue
                 if now - path.stat().st_mtime > max_age_seconds:
                     path.unlink()
             except OSError:
-                pass
+                continue
 
     @property
     def root(self) -> Path:

--- a/pkg/trajectory_ir/storage/fs.py
+++ b/pkg/trajectory_ir/storage/fs.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import tempfile
+import time
 from pathlib import Path
 
 from trajectory_ir.storage.cas import (
@@ -27,6 +29,10 @@ from trajectory_ir.storage.cas import (
     normalize_content_hash,
     shard_key,
 )
+
+# Matches mkstemp / CreateTemp names: ".{64-hex}." + random suffix.
+_TEMP_NAME_RE = re.compile(r"^\.[0-9a-f]{64}\.")
+_DEFAULT_TEMP_MAX_AGE_SECONDS = 86400.0
 
 
 class FileSystemCAS:
@@ -39,6 +45,31 @@ class FileSystemCAS:
     def __init__(self, root: str | Path) -> None:
         self._root = Path(root).resolve()
         self._root.mkdir(parents=True, exist_ok=True)
+        self._sweep_stale_temp_files()
+
+    def _sweep_stale_temp_files(
+        self, max_age_seconds: float = _DEFAULT_TEMP_MAX_AGE_SECONDS
+    ) -> None:
+        """Remove orphaned put() temp files under cas/ older than max_age_seconds.
+
+        put() writes with prefix ``.{hash}.`` then os.replace. A hard kill can leave
+        those temps behind. Only the cas/ tree is scanned, and only names that match
+        the writer prefix, so unrelated hidden files under root are left alone.
+        """
+        cas_root = self._root / "cas"
+        if not cas_root.is_dir():
+            return
+        now = time.time()
+        for path in cas_root.rglob("*"):
+            if not path.is_file():
+                continue
+            if _TEMP_NAME_RE.match(path.name) is None:
+                continue
+            try:
+                if now - path.stat().st_mtime > max_age_seconds:
+                    path.unlink()
+            except OSError:
+                pass
 
     @property
     def root(self) -> Path:

--- a/pkg/trajectory_ir/storage/fs.py
+++ b/pkg/trajectory_ir/storage/fs.py
@@ -47,9 +47,7 @@ class FileSystemCAS:
             root cannot delete another process's in-flight put() temp.
     """
 
-    def __init__(
-        self, root: str | Path, *, sweep_stale_temps: bool = False
-    ) -> None:
+    def __init__(self, root: str | Path, *, sweep_stale_temps: bool = False) -> None:
         self._root = Path(root).resolve()
         self._root.mkdir(parents=True, exist_ok=True)
         if sweep_stale_temps:

--- a/test/unit/test_fs_cas.py
+++ b/test/unit/test_fs_cas.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 
 import pytest
 
@@ -121,3 +122,41 @@ def test_cas_protocol_runtime_check(store):
 def test_put_creates_sharded_dirs(store):
     h = store.put(os.urandom(32))
     assert (store.root / "cas" / h[:2]).is_dir()
+
+
+def test_init_sweeps_stale_temp_files_only(cas_root, tmp_path):
+    h = content_hash(b"sweep-me")
+    shard = cas_root / "cas" / h[:2]
+    shard.mkdir(parents=True)
+
+    stale = shard / f".{h}.orphaned"
+    stale.write_bytes(b"partial")
+    old = time.time() - 90000
+    os.utime(stale, (old, old))
+
+    fresh_h = content_hash(b"keep-me-fresh")
+    fresh_dir = cas_root / "cas" / fresh_h[:2]
+    fresh_dir.mkdir(parents=True, exist_ok=True)
+    fresh = fresh_dir / f".{fresh_h}.inflight"
+    fresh.write_bytes(b"still writing")
+
+    # Unrelated multi-dot hidden file at root must not be touched.
+    decoy = cas_root / ".env.local"
+    decoy.write_text("SECRET=1", encoding="utf-8")
+    os.utime(decoy, (old, old))
+
+    store = FileSystemCAS(cas_root)
+    kept = store.put(b"real-object")
+
+    assert not stale.exists()
+    assert fresh.exists()
+    assert decoy.exists()
+    assert store.path_for(kept).is_file()
+
+
+def test_init_noop_when_cas_tree_missing(tmp_path):
+    root = tmp_path / "empty-root"
+    store = FileSystemCAS(root)
+    assert store.root.is_dir()
+    # cas/ is created lazily on first put, not during init sweep.
+    assert not (store.root / "cas").exists()

--- a/test/unit/test_fs_cas.py
+++ b/test/unit/test_fs_cas.py
@@ -124,7 +124,7 @@ def test_put_creates_sharded_dirs(store):
     assert (store.root / "cas" / h[:2]).is_dir()
 
 
-def test_init_sweeps_stale_temp_files_only(cas_root, tmp_path):
+def test_sweep_stale_temp_files_only(cas_root):
     h = content_hash(b"sweep-me")
     shard = cas_root / "cas" / h[:2]
     shard.mkdir(parents=True)
@@ -145,7 +145,11 @@ def test_init_sweeps_stale_temp_files_only(cas_root, tmp_path):
     decoy.write_text("SECRET=1", encoding="utf-8")
     os.utime(decoy, (old, old))
 
+    # Default construct must not sweep (shared-root safe).
     store = FileSystemCAS(cas_root)
+    assert stale.exists()
+
+    store.sweep_stale_temp_files()
     kept = store.put(b"real-object")
 
     assert not stale.exists()
@@ -154,9 +158,22 @@ def test_init_sweeps_stale_temp_files_only(cas_root, tmp_path):
     assert store.path_for(kept).is_file()
 
 
-def test_init_noop_when_cas_tree_missing(tmp_path):
+def test_constructor_opt_in_sweep(cas_root):
+    h = content_hash(b"opt-in-sweep")
+    shard = cas_root / "cas" / h[:2]
+    shard.mkdir(parents=True)
+    stale = shard / f".{h}.orphaned"
+    stale.write_bytes(b"partial")
+    old = time.time() - 90000
+    os.utime(stale, (old, old))
+
+    FileSystemCAS(cas_root, sweep_stale_temps=True)
+    assert not stale.exists()
+
+
+def test_sweep_noop_when_cas_tree_missing(tmp_path):
     root = tmp_path / "empty-root"
     store = FileSystemCAS(root)
+    store.sweep_stale_temp_files()
     assert store.root.is_dir()
-    # cas/ is created lazily on first put, not during init sweep.
     assert not (store.root / "cas").exists()


### PR DESCRIPTION
## Summary

Closes #237.

put() / Put write with a `.{hash}.` temp then rename. Hard kill can leave those temps behind. This adds an **explicit** stale temp sweep (not on by default in the constructor).

## What it does

- `sweep_stale_temp_files()` / `SweepStaleTempFiles(maxAge)` walk only `cas/`
- Deletes names matching `.{lowercase-64-hex}.…` older than 24h (default)
- Python opt-in: `FileSystemCAS(root, sweep_stale_temps=True)`
- Default construct does **not** sweep (safe for shared roots / concurrent Put)
- Dual SDK (Python + Go)

## Test plan

- [x] `PYTHONPATH=pkg pytest test/unit/test_fs_cas.py -q`
- [x] `go test ./trajir/cas/ -count=1`
- [ ] CI green on latest commit

## Review follow up

Addressed Monica (no ctor race, walk OSError) and Ayush (lowercase hex matches ContentHash).