### PR TITLE
fix(go): signature P0 safe replace and fail-closed Export SignKey

### DIFF
--- a/go/trajir/tir/signature.go
+++ b/go/trajir/tir/signature.go
@@ -422,15 +422,42 @@ func rewriteZipWithSignature(path string, members map[string][]byte, signatureJS
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpName, path); err != nil {
-		// Windows: rename over existing may fail — remove target then rename.
-		if rmErr := os.Remove(path); rmErr != nil {
-			return fmt.Errorf("%w: replace package: %v (also: %v)", ErrSignature, err, rmErr)
-		}
-		if err := os.Rename(tmpName, path); err != nil {
-			return fmt.Errorf("%w: replace package: %v", ErrSignature, err)
-		}
+	if err := replaceFile(tmpName, path); err != nil {
+		return err
 	}
 	success = true
+	return nil
+}
+
+// afterBackupHook is an optional test seam run after the original package is
+// moved aside and before the temp is moved into place. Production leaves it nil.
+var afterBackupHook func(dest string)
+
+// replaceFile installs src at dest without deleting dest until src is in place.
+// On platforms where rename cannot overwrite (Windows), dest is moved to a
+// sibling backup first; if the final rename fails, the backup is restored.
+func replaceFile(src, dest string) error {
+	if err := os.Rename(src, dest); err == nil {
+		return nil
+	}
+	return replaceFileViaBackup(src, dest)
+}
+
+func replaceFileViaBackup(src, dest string) error {
+	bak := dest + ".trajir-replace-bak"
+	_ = os.Remove(bak)
+	if err := os.Rename(dest, bak); err != nil {
+		return fmt.Errorf("%w: replace package (move aside): %v", ErrSignature, err)
+	}
+	if afterBackupHook != nil {
+		afterBackupHook(dest)
+	}
+	if err := os.Rename(src, dest); err != nil {
+		if rbErr := os.Rename(bak, dest); rbErr != nil {
+			return fmt.Errorf("%w: replace package: %v (restore failed: %v)", ErrSignature, err, rbErr)
+		}
+		return fmt.Errorf("%w: replace package: %v", ErrSignature, err)
+	}
+	_ = os.Remove(bak)
 	return nil
 }

--- a/go/trajir/tir/signature_replace_test.go
+++ b/go/trajir/tir/signature_replace_test.go
@@ -1,0 +1,67 @@
+package tir
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReplaceFileHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "pkg.tir")
+	src := filepath.Join(dir, "new.tmp")
+	if err := os.WriteFile(dest, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceFile(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "NEW" {
+		t.Fatalf("got %q want NEW", got)
+	}
+	if _, err := os.Stat(dest + ".trajir-replace-bak"); !os.IsNotExist(err) {
+		t.Fatalf("backup should be gone: %v", err)
+	}
+}
+
+func TestReplaceFileViaBackupRestoresOriginal(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "pkg.tir")
+	src := filepath.Join(dir, "new.tmp")
+	if err := os.WriteFile(dest, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	afterBackupHook = func(string) {
+		// Simulate final rename failure (e.g. AV lock / access denied).
+		_ = os.Remove(src)
+	}
+	defer func() { afterBackupHook = nil }()
+
+	err := replaceFileViaBackup(src, dest)
+	if err == nil {
+		t.Fatal("expected replace failure")
+	}
+	if !strings.Contains(err.Error(), "replace package") {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("original package missing after failed replace: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Fatalf("got %q want ORIGINAL (must not destroy package)", got)
+	}
+}

--- a/go/trajir/tir/signature_test.go
+++ b/go/trajir/tir/signature_test.go
@@ -303,6 +303,21 @@ func TestSignRejectsInvalidKey(t *testing.T) {
 	}
 }
 
+func TestExportRejectsWrongLengthSignKey(t *testing.T) {
+	src := openLog(t, "src.sqlite")
+	seedSample(t, src)
+	out := filepath.Join(t.TempDir(), "seed.tir")
+	// 32-byte seed is not a full private key; Export must fail closed (no silent unsigned).
+	seed := make(ed25519.PrivateKey, 32)
+	_, err := tir.Export(src, "t-export", out, tir.ExportOptions{Mode: tir.ModeThin, SignKey: seed})
+	if !errors.Is(err, tir.ErrSignature) {
+		t.Fatalf("want ErrSignature for 32-byte seed, got %v", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Fatal("export must not leave a package after rejecting SignKey")
+	}
+}
+
 func TestTrustedKeyIDAllowlist(t *testing.T) {
 	src := openLog(t, "src.sqlite")
 	seedSample(t, src)

--- a/go/trajir/tir/tir.go
+++ b/go/trajir/tir/tir.go
@@ -101,7 +101,9 @@ type ExportOptions struct {
 	TenantID      *string // when set, only that tenant's nodes are exported
 	Artifacts     []ArtifactRef
 	ArtifactBytes map[string][]byte // content_hash -> bytes (required for fat)
-	// SignKey, when a full ed25519 private key, writes SIGNATURE after export (README §9.1).
+	// SignKey, when set, must be a full ed25519 private key (64 bytes). Export then
+	// writes SIGNATURE after the zip (README §9.1). A non-empty key of the wrong
+	// length fails closed; it does not silently produce an unsigned package.
 	SignKey    ed25519.PrivateKey
 	SignerMeta SignerMeta
 }
@@ -278,6 +280,9 @@ func Export(nodeLog *nodelog.NodeLog, trajectoryID, dest string, opts ExportOpti
 	}
 	if mode != ModeThin && mode != ModeFat {
 		return "", fmt.Errorf("%w: unsupported mode %q; use thin or fat", ErrTir, mode)
+	}
+	if len(opts.SignKey) != 0 && len(opts.SignKey) != ed25519.PrivateKeySize {
+		return "", fmt.Errorf("%w: invalid ed25519 private key size", ErrSignature)
 	}
 
 	var nodeList []map[string]any
@@ -466,7 +471,7 @@ func Export(nodeLog *nodelog.NodeLog, trajectoryID, dest string, opts ExportOpti
 	}
 	fileClosed = true
 
-	if len(opts.SignKey) == ed25519.PrivateKeySize {
+	if len(opts.SignKey) != 0 {
 		if err := Sign(destPath, opts.SignKey, opts.SignerMeta); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Summary

Closes #198 (and the child bugs #186 / #188). Also covers #258 which is the same destroy-on-failed-rename story.

## Fixes

1. **Safe replace** for `rewriteZipWithSignature`
   - Try normal rename first
   - If that cannot overwrite (Windows), move the original aside, put the temp in place, then drop the backup
   - If the final rename fails, restore the backup so the original `.tir` is not lost

2. **Export SignKey**
   - Empty / unset key: unsigned export (unchanged)
   - Non-empty wrong length (e.g. 32 byte seed): error, no silent skip

## Test plan

- [x] `go test ./trajir/tir/ -count=1`
- [x] `TestReplaceFileViaBackupRestoresOriginal`
- [x] `TestExportRejectsWrongLengthSignKey`
- [ ] CI green

## Out of scope (later P1/P2)

fsync (#189), README honesty (#187), file mode docs (#190), double decompress (#191)