### PR TITLE
fix(go): signature P2 preserve mode + skip unsigned double Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ No project-hosted CA or multi-tenant key product is required for conformance to 
 
 #### Implementation status
 
-- **Go primary (shipped):** optional `Sign` / `Verify`, optional Export `SignKey` (full 64-byte Ed25519 private key; wrong length fails closed), golden payload vectors under `go/trajir/tir/testdata/sig_v1/`.
+- **Go primary (shipped):** optional `Sign` / `Verify`, optional Export `SignKey` (full 64-byte Ed25519 private key; wrong length fails closed), golden payload vectors under `go/trajir/tir/testdata/sig_v1/`. Rewriting a package to add `SIGNATURE` preserves the existing file permission bits (CreateTemp’s 0600 is chmod’d back before replace).
 - **Python reference (Future):** byte-identical payload construction and verify parity ([#179](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/179)).
 - **Conformance (proposed for Phase C):** R09 sign/verify + mutate fails; R10 unsigned still passes R05, strict mode rejects unsigned; R11 Go-signed verifies in Python and vice versa.
 - **Security-review** required for further sign/verify changes. Private keys never in the repository; tests use ephemeral keys.

--- a/go/trajir/tir/signature.go
+++ b/go/trajir/tir/signature.go
@@ -381,6 +381,12 @@ func collectZipMembers(files []*zip.File) (members map[string][]byte, signature 
 
 func rewriteZipWithSignature(path string, members map[string][]byte, signatureJSON []byte) error {
 	dir := filepath.Dir(path)
+	// Preserve destination mode across CreateTemp (which uses 0600) so signed
+	// exports keep the same permissions as the unsigned zip Export wrote.
+	origMode := os.FileMode(0o644)
+	if st, err := os.Stat(path); err == nil {
+		origMode = st.Mode().Perm()
+	}
 	tmp, err := os.CreateTemp(dir, "tir-sign-*.tmp")
 	if err != nil {
 		return err
@@ -426,6 +432,9 @@ func rewriteZipWithSignature(path string, members map[string][]byte, signatureJS
 	}
 	if err := tmp.Close(); err != nil {
 		return err
+	}
+	if err := os.Chmod(tmpName, origMode); err != nil {
+		return fmt.Errorf("%w: preserve package mode: %v", ErrSignature, err)
 	}
 	if err := replaceFile(tmpName, path); err != nil {
 		return err

--- a/go/trajir/tir/signature.go
+++ b/go/trajir/tir/signature.go
@@ -383,10 +383,11 @@ func rewriteZipWithSignature(path string, members map[string][]byte, signatureJS
 	dir := filepath.Dir(path)
 	// Preserve destination mode across CreateTemp (which uses 0600) so signed
 	// exports keep the same permissions as the unsigned zip Export wrote.
-	origMode := os.FileMode(0o644)
-	if st, err := os.Stat(path); err == nil {
-		origMode = st.Mode().Perm()
+	st, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("%w: stat package for mode: %v", ErrSignature, err)
 	}
+	origMode := st.Mode().Perm()
 	tmp, err := os.CreateTemp(dir, "tir-sign-*.tmp")
 	if err != nil {
 		return err

--- a/go/trajir/tir/signature_test.go
+++ b/go/trajir/tir/signature_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -300,6 +301,37 @@ func TestSignRejectsInvalidKey(t *testing.T) {
 	}
 	if err := tir.Sign(path, ed25519.PrivateKey{1, 2, 3}, tir.SignerMeta{}); !errors.Is(err, tir.ErrSignature) {
 		t.Fatalf("want ErrSignature, got %v", err)
+	}
+}
+
+func TestSignPreservesPackageMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bit preserve is meaningful on unix mode bits")
+	}
+	src := openLog(t, "src.sqlite")
+	seedSample(t, src)
+	out := filepath.Join(t.TempDir(), "mode.tir")
+	path, err := tir.Export(src, "t-export", out, tir.ExportOptions{Mode: tir.ModeThin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv := testOnlySeed()
+	if err := tir.Sign(path, priv, tir.SignerMeta{ID: "mode"}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Mode().Perm() != before.Mode().Perm() {
+		t.Fatalf("mode after Sign=%v want %v", after.Mode().Perm(), before.Mode().Perm())
 	}
 }
 

--- a/go/trajir/tir/signature_test.go
+++ b/go/trajir/tir/signature_test.go
@@ -291,6 +291,27 @@ func TestDuplicateSignatureMemberRejected(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsDuplicateMemberWhenUnsigned(t *testing.T) {
+	// Unsigned Load skips verifySignatureFromZipFiles; duplicate names must
+	// still be rejected in loadImpl (CWE-436), not only on the signed path.
+	src := openLog(t, "src.sqlite")
+	seedSample(t, src)
+	out := filepath.Join(t.TempDir(), "dup-manifest.tir")
+	path, err := tir.Export(src, "t-export", out, tir.ExportOptions{Mode: tir.ModeThin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := appendDuplicateZipMember(path, "manifest.json", []byte(`{"mode":"thin","evil":true}`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tir.Load(path); !errors.Is(err, tir.ErrTir) {
+		t.Fatalf("Load: want ErrTir for duplicate manifest.json, got %v", err)
+	}
+	if _, err := tir.LoadUnverified(path); !errors.Is(err, tir.ErrTir) {
+		t.Fatalf("LoadUnverified: want ErrTir for duplicate manifest.json, got %v", err)
+	}
+}
+
 func TestSignRejectsInvalidKey(t *testing.T) {
 	src := openLog(t, "src.sqlite")
 	seedSample(t, src)

--- a/go/trajir/tir/tir.go
+++ b/go/trajir/tir/tir.go
@@ -716,9 +716,13 @@ func loadImpl(path string, verify bool) (*Package, error) {
 	// Signature check after hash/seal integrity (README §9.1 order).
 	// Use the already-open archive only — never re-open path (TOCTOU / CWE-367).
 	// Present-but-invalid SIGNATURE fails even for LoadUnverified (tamper).
-	sigInfo, err := verifySignatureFromZipFiles(zr.File, VerifyOptions{})
-	if err != nil {
-		return nil, err
+	// Unsigned packages skip the second decompress pass (no SIGNATURE member).
+	var sigInfo *SignatureInfo
+	if _, hasSig := byName[SignatureMemberName]; hasSig {
+		sigInfo, err = verifySignatureFromZipFiles(zr.File, VerifyOptions{})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Package{

--- a/go/trajir/tir/tir.go
+++ b/go/trajir/tir/tir.go
@@ -506,12 +506,21 @@ func loadImpl(path string, verify bool) (*Package, error) {
 		return nil, fmt.Errorf("%w: too many zip entries: %d > %d", ErrLimit, len(zr.File), MaxZipEntries)
 	}
 
+	// Reject duplicate member names up front (CWE-436). collectZipMembers also
+	// checks this, but unsigned Load skips that path to avoid a second decompress.
 	byName := make(map[string]*zip.File, len(zr.File))
 	for _, f := range zr.File {
-		if err := safeZipName(f.Name); err != nil {
+		name := f.Name
+		if strings.HasSuffix(name, "/") {
+			continue
+		}
+		if err := safeZipName(name); err != nil {
 			return nil, err
 		}
-		byName[f.Name] = f
+		if _, exists := byName[name]; exists {
+			return nil, fmt.Errorf("%w: duplicate zip member %q", ErrTir, name)
+		}
+		byName[name] = f
 	}
 	for _, req := range requiredMembers {
 		if _, ok := byName[req]; !ok {


### PR DESCRIPTION
## Summary

Closes #200 (children #190 and #191).

P0 (#260) and P1 (#263) are already on main. This branch is rebased onto main.

## Changes

1. **#190** Sign rewrite preserves the original package permission bits (chmod temp before replace). Documented in README 9.1.
2. **#191** `Load` / `LoadUnverified` skip the signature member collect pass when there is no `SIGNATURE` entry (unsigned default path).

## Test plan

- [x] `go test ./trajir/tir/ -count=1`
- [x] `TestSignPreservesPackageMode` (unix)
- [ ] CI green

## Note

When SIGNATURE is present, verify still collects members once via the existing helper (needed for optional members). The expensive double read on the common unsigned path is gone.