### PR TITLE
fix(resume): log TOOL_CALL prior to non-gated tool execution (#262)

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from drivers.durable_backend.dbos.adapter import init_backend
 from trajectory_ir.effects import requires_block_and_gate
-from trajectory_ir.resume.gate import make_gated_tool_call
+from trajectory_ir.resume.gate import make_gated_tool_call, make_plain_tool_call
 from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
 from trajectory_ir.runtime.tool import Tool
@@ -114,25 +114,16 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool, seq: 
         )
         result = fn(**call["args"])
     else:
-        # Not claim-gated, but still needs IR history audit; gate path
-        # already logs its own TOOL_CALL/TOOL_RESULT nodes.
-        result = tool.fn(**call["args"])
-        log.append(
-            "TOOL_CALL",
-            step_n,
-            {"tool": tool.name, "args": call["args"]},
+        fn = make_plain_tool_call(
+            log,
             trajectory.trajectory_id,
             trajectory.tenant_id,
+            step_n,
             seq=seq,
+            tool_name=tool.name,
+            tool_fn=tool.fn,
         )
-        log.append(
-            "TOOL_RESULT",
-            step_n,
-            {"result": result},
-            trajectory.trajectory_id,
-            trajectory.tenant_id,
-            seq=seq + 1,
-        )
+        result = fn(**call["args"])
     return ToolResult(step_n=step_n, result=result)
 
 

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -210,7 +210,6 @@ func (t *Trajectory) ExecTool(stepN, seq int, tool resume.Tool, args map[string]
 	if err := sandbox.AssertToolAllowed(t.Mode, tool.Name, tool.Effect); err != nil {
 		return nil, err
 	}
-	step := stepN
 	if effects.RequiresBlockAndGate(tool.Effect) {
 		fn := resume.MakeGatedToolCall(
 			t.log,
@@ -227,28 +226,17 @@ func (t *Trajectory) ExecTool(stepN, seq int, tool resume.Tool, args map[string]
 		}
 		return &ToolResult{StepN: stepN, Result: result}, nil
 	}
-	result, err := tool.Fn(args)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := t.log.Append(
-		"TOOL_CALL",
-		&step,
-		map[string]any{"tool": tool.Name, "args": args},
+	fn := resume.MakePlainToolCall(
+		t.log,
 		t.TrajectoryID,
 		t.TenantID,
+		stepN,
 		seq,
-	); err != nil {
-		return nil, err
-	}
-	if _, err := t.log.Append(
-		"TOOL_RESULT",
-		&step,
-		map[string]any{"result": result},
-		t.TrajectoryID,
-		t.TenantID,
-		seq+1,
-	); err != nil {
+		tool.Name,
+		tool.Fn,
+	)
+	result, err := fn(args)
+	if err != nil {
 		return nil, err
 	}
 	return &ToolResult{StepN: stepN, Result: result}, nil

--- a/go/trajir/client/client_test.go
+++ b/go/trajir/client/client_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -197,5 +198,32 @@ func TestSandboxRejectsNonIdempotent(t *testing.T) {
 	}
 	if _, err := tr.ExecTool(1, 2, tool, nil); err == nil {
 		t.Fatal("expected sandbox reject")
+	}
+}
+
+func TestExecToolLogsToolCallOnError(t *testing.T) {
+	dir := t.TempDir()
+	tr, err := client.OpenTrajectory("demo", "t-err", client.Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Close()
+	boom := errors.New("tool fail")
+	tool := resume.Tool{
+		Name:   "fetch",
+		Effect: effects.READ_ONLY,
+		Fn:     func(args map[string]any) (any, error) { return nil, boom },
+	}
+	_, err = tr.ExecTool(1, 2, tool, map[string]any{"url": "https://example.com"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err=%v want %v", err, boom)
+	}
+	ok, err := tr.Log().Has("t-err", "demo", 1, "TOOL_CALL", intPtr(2))
+	if err != nil || !ok {
+		t.Fatalf("TOOL_CALL has=%v err=%v", ok, err)
+	}
+	hasResult, err := tr.Log().Has("t-err", "demo", 1, "TOOL_RESULT", intPtr(3))
+	if err != nil || hasResult {
+		t.Fatalf("expected no TOOL_RESULT on error, got %v (err: %v)", hasResult, err)
 	}
 }

--- a/go/trajir/resume/gate.go
+++ b/go/trajir/resume/gate.go
@@ -87,3 +87,51 @@ func MakeGatedToolCall(
 		return result, nil
 	}
 }
+
+// MakePlainToolCall wraps toolFn for non-gated tools with audit logging.
+//
+// Seq layout matches Python: TOOL_CALL at seq, TOOL_RESULT at seq+1.
+// TOOL_CALL is recorded prior to tool execution so failed attempts are audited.
+// On success, TOOL_RESULT is recorded at seq+1 with {"result": ...}.
+func MakePlainToolCall(
+	log *nodelog.NodeLog,
+	trajectoryID, tenantID string,
+	stepN, seq int,
+	toolName string,
+	toolFn ToolFunc,
+) ToolFunc {
+	return func(args map[string]any) (any, error) {
+		if args == nil {
+			args = map[string]any{}
+		}
+		step := stepN
+
+		if _, err := log.Append(
+			"TOOL_CALL",
+			&step,
+			map[string]any{"tool": toolName, "args": args},
+			trajectoryID,
+			tenantID,
+			seq,
+		); err != nil {
+			return nil, err
+		}
+
+		result, err := toolFn(args)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := log.Append(
+			"TOOL_RESULT",
+			&step,
+			map[string]any{"result": result},
+			trajectoryID,
+			tenantID,
+			seq+1,
+		); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+}

--- a/go/trajir/resume/step.go
+++ b/go/trajir/resume/step.go
@@ -135,37 +135,25 @@ func RunStep(
 			result, err = durable.Tool(ctx, cfg.Backend, cfg.WorkflowID, stepKey, func(context.Context) (any, error) {
 				return gated(args)
 			})
-		} else {
-			fn := tool.Fn
-			result, err = durable.Tool(ctx, cfg.Backend, cfg.WorkflowID, stepKey, func(context.Context) (any, error) {
-				return fn(args)
-			})
-			if err == nil {
-				// Plain tools still need IR history for audit; gate path already logs.
-				if _, err := cfg.Log.Append(
-					"TOOL_CALL",
-					&step,
-					map[string]any{"tool": call.Name, "args": args},
-					cfg.TrajectoryID,
-					cfg.TenantID,
-					seq,
-				); err != nil {
-					return nil, err
-				}
-				if _, err := cfg.Log.Append(
-					"TOOL_RESULT",
-					&step,
-					map[string]any{"result": result},
-					cfg.TrajectoryID,
-					cfg.TenantID,
-					seq+1,
-				); err != nil {
-					return nil, err
-				}
+			if err != nil {
+				return nil, err
 			}
-		}
-		if err != nil {
-			return nil, err
+		} else {
+			plain := MakePlainToolCall(
+				cfg.Log,
+				cfg.TrajectoryID,
+				cfg.TenantID,
+				stepN,
+				seq,
+				call.Name,
+				tool.Fn,
+			)
+			result, err = durable.Tool(ctx, cfg.Backend, cfg.WorkflowID, stepKey, func(context.Context) (any, error) {
+				return plain(args)
+			})
+			if err != nil {
+				return nil, err
+			}
 		}
 		results = append(results, result)
 	}

--- a/go/trajir/resume/step_test.go
+++ b/go/trajir/resume/step_test.go
@@ -309,7 +309,7 @@ func TestRunStepSandboxModeBlocksNonIdempotentWrite(t *testing.T) {
 	}
 }
 
-func TestRunStepNonGatedToolErrorNotLogged(t *testing.T) {
+func TestRunStepNonGatedToolErrorLogsToolCall(t *testing.T) {
 	ctx := context.Background()
 	nl, backend := testEnv(t)
 	boom := errors.New("tool boom")
@@ -335,7 +335,120 @@ func TestRunStepNonGatedToolErrorNotLogged(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Fatal("TOOL_CALL should not be logged when non-gated tool errors")
+	if !ok {
+		t.Fatal("TOOL_CALL must be logged when non-gated tool errors")
+	}
+	hasResult, err := nl.Has("t1", "demo", 1, "TOOL_RESULT", intPtr(3))
+	if err != nil || hasResult {
+		t.Fatalf("expected no TOOL_RESULT on error, got %v (err: %v)", hasResult, err)
+	}
+}
+
+func TestRunStepReplayDoesNotDuplicateToolNodes(t *testing.T) {
+	ctx := context.Background()
+	nl, backend := testEnv(t)
+	var executions atomic.Int32
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf-replay-nodup",
+		Tools: map[string]resume.Tool{
+			"echo": {
+				Name:   "echo",
+				Effect: effects.PURE,
+				Fn: func(args map[string]any) (any, error) {
+					executions.Add(1)
+					return args["msg"], nil
+				},
+			},
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "echo", "args": map[string]any{"msg": "hi"}},
+			},
+		}, nil
+	}
+
+	if _, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if executions.Load() != 1 {
+		t.Fatalf("executions=%d want 1", executions.Load())
+	}
+
+	// Replay the step under the same workflow ID.
+	if _, err := resume.RunStep(ctx, cfg, 1, model, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if executions.Load() != 1 {
+		t.Fatalf("executions after replay=%d want 1", executions.Load())
+	}
+
+	nodes, err := nl.ListNodes("t1", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expected exactly: PROJECT_CONTEXT, DECISION, TOOL_CALL, TOOL_RESULT, COMMIT_STEP
+	if len(nodes) != 5 {
+		t.Fatalf("expected 5 nodes after replay, got %d", len(nodes))
+	}
+}
+
+func TestRunStepReplayAfterToolFailureDoesNotConflict(t *testing.T) {
+	ctx := context.Background()
+	nl, backend := testEnv(t)
+	var calls atomic.Int32
+	boom1 := errors.New("timeout after 100ms")
+	boom2 := errors.New("timeout after 150ms")
+
+	cfg := resume.RunStepConfig{
+		Log:          nl,
+		Backend:      backend,
+		TenantID:     "demo",
+		TrajectoryID: "t1",
+		WorkflowID:   "wf-fail-replay",
+		Tools: map[string]resume.Tool{
+			"failing": {
+				Name:   "failing",
+				Effect: effects.PURE,
+				Fn: func(map[string]any) (any, error) {
+					c := calls.Add(1)
+					if c == 1 {
+						return nil, boom1
+					}
+					return nil, boom2
+				},
+			},
+		},
+	}
+	model := func(context.Context, map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"tool_calls": []any{
+				map[string]any{"name": "failing", "args": map[string]any{}},
+			},
+		}, nil
+	}
+
+	if _, err := resume.RunStep(ctx, cfg, 1, model, nil); !errors.Is(err, boom1) {
+		t.Fatalf("expected boom1, got %v", err)
+	}
+
+	// Retry with differently-worded error: must surface boom2 without slot conflict.
+	if _, err := resume.RunStep(ctx, cfg, 1, model, nil); !errors.Is(err, boom2) {
+		t.Fatalf("expected boom2 on replay, got %v", err)
+	}
+
+	nodes, err := nl.ListNodes("t1", "demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// PROJECT_CONTEXT, DECISION, TOOL_CALL (no TOOL_RESULT on error)
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(nodes))
 	}
 }

--- a/pkg/trajectory_ir/resume/gate.py
+++ b/pkg/trajectory_ir/resume/gate.py
@@ -79,3 +79,36 @@ def make_gated_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_n
         return result
 
     return gated
+
+
+def make_plain_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_name, tool_fn):
+    """Wrap a non-gated tool with audit logging.
+
+    Occupies two seq slots: TOOL_CALL at `seq`, and TOOL_RESULT at `seq + 1`.
+    TOOL_CALL is recorded prior to tool execution so failed attempts are audited.
+    On success, TOOL_RESULT is recorded at seq + 1 with {"result": ...}.
+    """
+
+    def plain(**kwargs):
+        node_log.append(
+            "TOOL_CALL",
+            step_n,
+            {"tool": tool_name, "args": kwargs},
+            trajectory_id,
+            tenant_id,
+            seq=seq,
+        )
+
+        result = tool_fn(**kwargs)
+
+        node_log.append(
+            "TOOL_RESULT",
+            step_n,
+            {"result": result},
+            trajectory_id,
+            tenant_id,
+            seq=seq + 1,
+        )
+        return result
+
+    return plain

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from trajectory_ir.effects import requires_block_and_gate
-from trajectory_ir.resume.gate import make_gated_tool_call
+from trajectory_ir.resume.gate import make_gated_tool_call, make_plain_tool_call
 from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
 
 
@@ -139,25 +139,16 @@ def make_run_step(
                 )
                 result = durable_tool(gated)(**call["args"])
             else:
-                # R03: PURE (and other non-gated classes) are not claim-gated.
-                result = durable_tool(tool.fn)(**call["args"])
-                # Plain tools still need IR history audit; gate path already logs.
-                node_log.append(
-                    "TOOL_CALL",
-                    step_n,
-                    {"tool": call["name"], "args": call["args"]},
+                plain = make_plain_tool_call(
+                    node_log,
                     trajectory_id,
                     tenant_id,
-                    seq=seq,
-                )
-                node_log.append(
-                    "TOOL_RESULT",
                     step_n,
-                    {"result": result},
-                    trajectory_id,
-                    tenant_id,
-                    seq=seq + 1,
+                    seq,
+                    call["name"],
+                    tool.fn,
                 )
+                result = durable_tool(plain)(**call["args"])
             results.append(result)
 
         node_log.append(

--- a/test/unit/test_client_sdk_plain_tool_logging.py
+++ b/test/unit/test_client_sdk_plain_tool_logging.py
@@ -1,3 +1,5 @@
+import pytest
+
 from client.python.trajectory_client import exec_tool, open_trajectory
 from trajectory_ir.effects import EffectClass
 from trajectory_ir.runtime.log import NodeLog
@@ -34,3 +36,20 @@ def test_exec_tool_logs_two_plain_tools_same_step_distinct_seq(tmp_path, monkeyp
     assert log.has("plain-2", "demo", 1, "TOOL_RESULT", seq=3)
     assert log.has("plain-2", "demo", 1, "TOOL_CALL", seq=4)
     assert log.has("plain-2", "demo", 1, "TOOL_RESULT", seq=5)
+
+
+def test_exec_tool_logs_tool_call_when_tool_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db_path = str(tmp_path / "test_plain_tool_err.sqlite")
+    traj = open_trajectory(tenant_id="demo", trajectory_id="plain-err", db_path=db_path)
+
+    def failing_fn(x):
+        raise ValueError("boom")
+
+    tool = Tool(name="fail", fn=failing_fn, effect_class=EffectClass.PURE)
+    with pytest.raises(ValueError, match="boom"):
+        exec_tool(traj, step_n=1, call={"args": {"x": 1}}, tool=tool, seq=2)
+
+    log = NodeLog(db_path)
+    assert log.has("plain-err", "demo", 1, "TOOL_CALL", seq=2)
+    assert not log.has("plain-err", "demo", 1, "TOOL_RESULT", seq=3)

--- a/test/unit/test_step.py
+++ b/test/unit/test_step.py
@@ -1,6 +1,20 @@
+import pytest
 from dbos import SetWorkflowID
 
 from drivers.durable_backend.dbos.adapter import init_backend
+from drivers.durable_backend.restate.local_memo import (
+    clear_memo,
+    workflow_scope,
+)
+from drivers.durable_backend.restate.local_memo import (
+    durable_infer as restate_infer,
+)
+from drivers.durable_backend.restate.local_memo import (
+    durable_tool as restate_tool,
+)
+from drivers.durable_backend.restate.local_memo import (
+    durable_workflow as restate_workflow,
+)
 from trajectory_ir.effects import EffectClass
 from trajectory_ir.resume.step import make_run_step
 from trajectory_ir.runtime.log import NodeLog
@@ -45,3 +59,125 @@ def test_plain_tool_logs_tool_call_and_result(tmp_path, monkeypatch):
     assert results == ["hello"]
     assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "TOOL_CALL", seq=2)
     assert node_log.has(TRAJECTORY_ID, TENANT_ID, 1, "TOOL_RESULT", seq=3)
+
+
+def _failing_tool():
+    raise RuntimeError("tool error")
+
+
+def _model_call_fail(context):
+    return {"tool_calls": [{"name": "fail", "args": {}}]}
+
+
+def test_plain_tool_logs_tool_call_when_tool_fails(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    node_log = NodeLog(str(tmp_path / "nodes_fail.sqlite"))
+
+    tool_registry = {
+        "fail": Tool(
+            name="fail",
+            fn=_failing_tool,
+            effect_class=EffectClass.READ_ONLY,
+        ),
+    }
+
+    run_step = make_run_step(node_log, TENANT_ID, "test-step-fail", tool_registry)
+    init_backend(app_name="test-step-fail")
+
+    with SetWorkflowID("test-step-fail"), pytest.raises(RuntimeError, match="tool error"):
+        run_step(step_n=1, model_call=_model_call_fail, context={})
+
+    assert node_log.has("test-step-fail", TENANT_ID, 1, "TOOL_CALL", seq=2)
+    assert not node_log.has("test-step-fail", TENANT_ID, 1, "TOOL_RESULT", seq=3)
+
+
+_REPLAY_CALLS = {"n": 0}
+
+
+def _replay_tool(x="a"):
+    _REPLAY_CALLS["n"] += 1
+    return f"result-{x}"
+
+
+def _model_call_replay(context):
+    return {"tool_calls": [{"name": "count", "args": {"x": "a"}}]}
+
+
+def test_plain_tool_replay_does_not_duplicate_nodes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    node_log = NodeLog(str(tmp_path / "nodes_replay.sqlite"))
+    traj_id = "test-step-replay-nodup"
+    _REPLAY_CALLS["n"] = 0
+
+    tool_registry = {
+        "count": Tool(name="count", fn=_replay_tool, effect_class=EffectClass.PURE),
+    }
+
+    run_step = make_run_step(node_log, TENANT_ID, traj_id, tool_registry)
+    init_backend(app_name="test-step-replay")
+
+    with SetWorkflowID(traj_id):
+        r1 = run_step(step_n=1, model_call=_model_call_replay, context={})
+    assert r1 == ["result-a"]
+    assert _REPLAY_CALLS["n"] == 1
+
+    # Replay under same workflow ID
+    with SetWorkflowID(traj_id):
+        r2 = run_step(step_n=1, model_call=_model_call_replay, context={})
+    assert r2 == ["result-a"]
+    assert _REPLAY_CALLS["n"] == 1
+
+    nodes = node_log.list_nodes(traj_id, tenant_id=TENANT_ID)
+    # Expected exactly: PROJECT_CONTEXT, DECISION, TOOL_CALL, TOOL_RESULT, COMMIT_STEP
+    assert len(nodes) == 5
+
+
+class CustomToolError(Exception):
+    pass
+
+
+_REPLAY_FAIL_CALLS = {"n": 0}
+
+
+def _replay_failing_tool():
+    _REPLAY_FAIL_CALLS["n"] += 1
+    if _REPLAY_FAIL_CALLS["n"] == 1:
+        raise CustomToolError("timeout after 100ms")
+    raise CustomToolError("timeout after 150ms")
+
+
+def _model_call_replay_fail(context):
+    return {"tool_calls": [{"name": "fail", "args": {}}]}
+
+
+def test_plain_tool_failure_replay_does_not_conflict(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    node_log = NodeLog(str(tmp_path / "nodes_fail_replay.sqlite"))
+    traj_id = "test-step-fail-replay"
+    _REPLAY_FAIL_CALLS["n"] = 0
+
+    tool_registry = {
+        "fail": Tool(name="fail", fn=_replay_failing_tool, effect_class=EffectClass.READ_ONLY),
+    }
+
+    clear_memo()
+    run_step = make_run_step(
+        node_log,
+        TENANT_ID,
+        traj_id,
+        tool_registry,
+        durable_infer_fn=restate_infer,
+        durable_tool_fn=restate_tool,
+        durable_workflow_fn=restate_workflow,
+    )
+
+    with workflow_scope(traj_id), pytest.raises(CustomToolError, match="timeout after 100ms"):
+        run_step(step_n=1, model_call=_model_call_replay_fail, context={})
+
+    # Retry with different error text: surfaces second error without slot conflict
+    with workflow_scope(traj_id), pytest.raises(CustomToolError, match="timeout after 150ms"):
+        run_step(step_n=1, model_call=_model_call_replay_fail, context={})
+
+    nodes = node_log.list_nodes(traj_id, tenant_id=TENANT_ID)
+    # Expected exactly: PROJECT_CONTEXT, DECISION, TOOL_CALL (no TOOL_RESULT on error)
+    assert len(nodes) == 3


### PR DESCRIPTION
Non-gated tool executions (PURE, READ_ONLY, IDEMPOTENT_WRITE) in Go RunStep/ExecTool and Python make_run_step/exec_tool previously recorded TOOL_CALL after tool invocation. When a tool returned an error or raised an exception, the function returned before TOOL_CALL was appended, leaving no audit record of the attempted invocation in NodeLog.

Record TOOL_CALL before running the tool, while recording TOOL_RESULT only upon successful completion.

Closes #262