### PR TITLE
feat(python): trajir-pkg-sig-v1 sign and verify (Phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tools `trajectory_status`, `trajectory_export_tir`, `trajectory_import_tir`,
   `trajectory_verify_signature`; docs in [docs/INTEGRATIONS.md](docs/INTEGRATIONS.md)
   and [integrations/mcp/README.md](integrations/mcp/README.md).
+- Python: `trajir-pkg-sig-v1` `sign_package` / `verify_package`, optional
+  `export_tir(..., sign_key=)`, load verifies present `SIGNATURE` (Phase C,
+  [#179](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/179)). Matches Go
+  golden vectors under `go/trajir/tir/testdata/sig_v1/`.
 - Go: `trajir/tir` package signatures — `Sign` / `Verify`, optional
   `ExportOptions.SignKey`, Load verifies present `SIGNATURE` (README §9.1,
   [#177](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/177) / epic
   [#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149)). Golden
-  vectors under `go/trajir/tir/testdata/sig_v1/` for Python parity (Phase C).
+  vectors under `go/trajir/tir/testdata/sig_v1/`.
 - Spec: package signature scheme **`trajir-pkg-sig-v1`** in README §9.1
   (payload digest, domain-separated Ed25519, file-only `SIGNATURE` member,
-  unsigned default). Implementation remains Future ([#149](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/149)).
+  unsigned default).
 - Phase CI/CD harden: OpenSSF Scorecard, CodeQL (Go+Python), gitleaks,
   actionlint, zizmor advisory scan, Go race on core packages, CODEOWNERS,
   CycloneDX SBOM on release tags ([docs/CI_HARDENING.md](docs/CI_HARDENING.md)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python: `trajir-pkg-sig-v1` `sign_package` / `verify_package`, optional
   `export_tir(..., sign_key=)`, load verifies present `SIGNATURE` (Phase C,
   [#179](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/179)). Matches Go
-  golden vectors under `go/trajir/tir/testdata/sig_v1/`.
+  golden vectors under `go/trajir/tir/testdata/sig_v1/`. Uses PyNaCl (Apache-2.0).
 - Go: `trajir/tir` package signatures — `Sign` / `Verify`, optional
   `ExportOptions.SignKey`, Load verifies present `SIGNATURE` (README §9.1,
   [#177](https://github.com/Coder-s-OG-s/Trajectory-IR/issues/177) / epic

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 - **Sensitive Data Leakage**: Flaws where secret-like fields or thoughts leak during a `redacted` `.tir` package export.
 - **Package resource exhaustion**: Zip bombs / oversized members must be rejected by load limits (`TirLimitError`).
 - **Unverified import**: `import_tir` always verifies; `load_tir(verify=False)` is disabled. Inspection without verification requires explicit `load_tir_unverified()` and must never write to a durable NodeLog.
-- **Integrity vs provenance**: Node hash verification proves content integrity, not publisher authenticity. Package signatures remain reserved / unimplemented until a cryptography-focused design lands.
+- **Integrity vs provenance**: Node hash verification proves content integrity, not publisher authenticity. Optional package signatures (`trajir-pkg-sig-v1`, Ed25519) prove publisher authenticity when a `SIGNATURE` member is present; unsigned packages remain valid by default.
 
 ### D. Execution concurrency
 - **Block-and-gate races**: Claiming a `TOOL_CALL` slot must be atomic so concurrent workers cannot double-run a `NON_IDEMPOTENT_WRITE` tool (R02).
@@ -54,7 +54,7 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 | Atomic TOOL_CALL claim (gate) | Implemented |
 | `.tir` size / path safety limits | Implemented |
 | Redacted export (secret-like keys/values + thoughts) | Implemented (basic, keyword/pattern heuristic — not a secret scanner; still review before external sharing) |
-| Package digital signatures | Not implemented (reserved) |
+| Package digital signatures (`trajir-pkg-sig-v1`) | Implemented (optional; verify on load when present) |
 | Full multi-tenant SaaS isolation | Not a product surface yet; tenant_id filter on list/export exists |
 | Fluid / k8s cache poisoning controls | Design only (future profile) |
 

--- a/pkg/trajectory_ir/package/__init__.py
+++ b/pkg/trajectory_ir/package/__init__.py
@@ -1,5 +1,12 @@
 """Portable `.tir` package export and import."""
 
+from trajectory_ir.package.signature import (
+    SignatureInfo,
+    SignerMeta,
+    TirSignatureError,
+    sign_package,
+    verify_package,
+)
 from trajectory_ir.package.tir import (
     COMPAT,
     PACKAGE_FORMAT_VERSION,
@@ -18,12 +25,17 @@ __all__ = [
     "COMPAT",
     "PACKAGE_FORMAT_VERSION",
     "ArtifactRef",
+    "SignatureInfo",
+    "SignerMeta",
     "TirError",
     "TirLimitError",
     "TirPackage",
+    "TirSignatureError",
     "TirVerificationError",
     "export_tir",
     "import_tir",
     "load_tir",
     "load_tir_unverified",
+    "sign_package",
+    "verify_package",
 ]

--- a/pkg/trajectory_ir/package/__init__.py
+++ b/pkg/trajectory_ir/package/__init__.py
@@ -1,5 +1,6 @@
 """Portable `.tir` package export and import."""
 
+from trajectory_ir.package.errors import TirError
 from trajectory_ir.package.signature import (
     SignatureInfo,
     SignerMeta,
@@ -11,7 +12,6 @@ from trajectory_ir.package.tir import (
     COMPAT,
     PACKAGE_FORMAT_VERSION,
     ArtifactRef,
-    TirError,
     TirLimitError,
     TirPackage,
     TirVerificationError,

--- a/pkg/trajectory_ir/package/errors.py
+++ b/pkg/trajectory_ir/package/errors.py
@@ -1,0 +1,5 @@
+"""Shared package error types (no imports from tir/signature)."""
+
+
+class TirError(Exception):
+    """Base error for package operations."""

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -125,6 +125,8 @@ def _collect_zip_members(
     for info in infos:
         name = info.filename
         _safe_member_name(name)
+        # Declared size is advisory only: a malicious header can understate
+        # file_size. Cap the read so a lying local header cannot OOM us.
         if info.file_size > MAX_UNCOMPRESSED_ENTRY_BYTES:
             raise TirLimitError(
                 f"zip member {name!r} uncompressed size {info.file_size} "
@@ -134,9 +136,14 @@ def _collect_zip_members(
             raise TirLimitError(
                 f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
             )
-        data = zf.read(name)
+        with zf.open(name) as fp:
+            data = fp.read(MAX_UNCOMPRESSED_ENTRY_BYTES + 1)
         if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
             raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
+        if len(data) > budget:
+            raise TirLimitError(
+                f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
+            )
         budget -= len(data)
         if name == SIGNATURE_MEMBER:
             if signature is not None:

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -89,12 +89,18 @@ def payload_hash_from_members(members: dict[str, bytes]) -> bytes:
 
 
 def _safe_member_name(name: str) -> None:
+    # Match tir._safe_zip_name / Go safeZipName so load and sign agree.
     if not name or name.startswith(("/", "\\")):
         raise TirSignatureError(f"unsafe zip path: {name!r}")
     parts = name.replace("\\", "/").split("/")
-    for p in parts:
-        if p in ("", ".", ".."):
-            raise TirSignatureError(f"unsafe zip path: {name!r}")
+    if parts and parts[0] == "":
+        raise TirSignatureError(f"unsafe zip path: {name!r}")
+    if ".." in parts:
+        raise TirSignatureError(f"unsafe zip path: {name!r}")
+    if name.startswith("artifacts/") and not (
+        name == "artifacts/" or name.startswith("artifacts/cas/")
+    ):
+        raise TirSignatureError(f"unexpected artifact path: {name!r}")
 
 
 def _signing_key_from_bytes(key: bytes) -> SigningKey:
@@ -132,12 +138,9 @@ def _collect_zip_members(
                 f"zip member {name!r} uncompressed size {info.file_size} "
                 f"exceeds limit {MAX_UNCOMPRESSED_ENTRY_BYTES}"
             )
-        if info.file_size > budget:
-            raise TirLimitError(
-                f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
-            )
+        limit = min(MAX_UNCOMPRESSED_ENTRY_BYTES, budget)
         with zf.open(name) as fp:
-            data = fp.read(MAX_UNCOMPRESSED_ENTRY_BYTES + 1)
+            data = fp.read(limit + 1)
         if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
             raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
         if len(data) > budget:
@@ -293,7 +296,7 @@ def sign_package(
     meta = meta or SignerMeta()
     signed_at = meta.signed_at or datetime.now(UTC)
     if signed_at.tzinfo is None:
-        signed_at = signed_at.replace(tzinfo=UTC)
+        raise TirSignatureError("signed_at must be timezone aware")
     signer: dict[str, str] = {"key_id": key_id(pub)}
     if meta.id:
         signer["id"] = meta.id

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -98,14 +98,16 @@ def _safe_member_name(name: str) -> None:
 
 
 def _signing_key_from_bytes(key: bytes) -> SigningKey:
-    if len(key) == _PRIVATE_KEY_SIZE:
-        return SigningKey(key[:_SEED_SIZE])
-    if len(key) == _SEED_SIZE:
-        return SigningKey(key)
-    raise TirSignatureError("invalid ed25519 private key size")
+    # Match Go Sign: public API accepts only the full 64 byte private key.
+    if len(key) != _PRIVATE_KEY_SIZE:
+        raise TirSignatureError("invalid ed25519 private key size")
+    return SigningKey(key[:_SEED_SIZE])
 
 
-def _read_zip_members(path: Path) -> tuple[dict[str, bytes], bytes | None]:
+def _collect_zip_members(
+    zf: zipfile.ZipFile,
+) -> tuple[dict[str, bytes], bytes | None]:
+    """Read members from an already open archive with tir.py size budgets."""
     # Local import avoids a cycle: tir.py imports this module at load time.
     from trajectory_ir.package.tir import (
         MAX_TOTAL_UNCOMPRESSED_BYTES,
@@ -116,36 +118,64 @@ def _read_zip_members(path: Path) -> tuple[dict[str, bytes], bytes | None]:
 
     members: dict[str, bytes] = {}
     signature: bytes | None = None
-    with zipfile.ZipFile(path, "r") as zf:
-        infos = [i for i in zf.infolist() if not i.filename.endswith("/")]
-        if len(infos) > MAX_ZIP_ENTRIES:
-            raise TirLimitError(f"too many zip entries: {len(infos)} > {MAX_ZIP_ENTRIES}")
-        budget = MAX_TOTAL_UNCOMPRESSED_BYTES
-        for info in infos:
-            name = info.filename
-            _safe_member_name(name)
-            if info.file_size > MAX_UNCOMPRESSED_ENTRY_BYTES:
-                raise TirLimitError(
-                    f"zip member {name!r} uncompressed size {info.file_size} "
-                    f"exceeds limit {MAX_UNCOMPRESSED_ENTRY_BYTES}"
-                )
-            if info.file_size > budget:
-                raise TirLimitError(
-                    f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
-                )
-            data = zf.read(name)
-            if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
-                raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
-            budget -= len(data)
-            if name == SIGNATURE_MEMBER:
-                if signature is not None:
-                    raise TirSignatureError("duplicate SIGNATURE member")
-                signature = data
-                continue
-            if name in members:
-                raise TirSignatureError(f"duplicate zip member {name!r}")
-            members[name] = data
+    infos = [i for i in zf.infolist() if not i.filename.endswith("/")]
+    if len(infos) > MAX_ZIP_ENTRIES:
+        raise TirLimitError(f"too many zip entries: {len(infos)} > {MAX_ZIP_ENTRIES}")
+    budget = MAX_TOTAL_UNCOMPRESSED_BYTES
+    for info in infos:
+        name = info.filename
+        _safe_member_name(name)
+        if info.file_size > MAX_UNCOMPRESSED_ENTRY_BYTES:
+            raise TirLimitError(
+                f"zip member {name!r} uncompressed size {info.file_size} "
+                f"exceeds limit {MAX_UNCOMPRESSED_ENTRY_BYTES}"
+            )
+        if info.file_size > budget:
+            raise TirLimitError(
+                f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
+            )
+        data = zf.read(name)
+        if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
+            raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
+        budget -= len(data)
+        if name == SIGNATURE_MEMBER:
+            if signature is not None:
+                raise TirSignatureError("duplicate SIGNATURE member")
+            signature = data
+            continue
+        if name in members:
+            raise TirSignatureError(f"duplicate zip member {name!r}")
+        members[name] = data
     return members, signature
+
+
+def _read_zip_members(path: Path) -> tuple[dict[str, bytes], bytes | None]:
+    with zipfile.ZipFile(path, "r") as zf:
+        return _collect_zip_members(zf)
+
+
+def verify_package_from_zip(
+    zf: zipfile.ZipFile,
+    *,
+    require_signature: bool = False,
+    trusted_keys: list[bytes] | None = None,
+    trusted_key_ids: list[str] | None = None,
+) -> SignatureInfo | None:
+    """Verify SIGNATURE against members from an already open ZipFile.
+
+    Prefer this from load_tir so the archive is never re opened (TOCTOU).
+    """
+    members, sig_raw = _collect_zip_members(zf)
+    if sig_raw is None:
+        if require_signature:
+            raise TirSignatureError("package is unsigned (SIGNATURE missing)")
+        return None
+    return _verify_signature_bytes(
+        members,
+        sig_raw,
+        trusted_keys=trusted_keys,
+        trusted_key_ids=trusted_key_ids,
+    )
 
 
 def verify_package(
@@ -160,17 +190,13 @@ def verify_package(
     Returns None when unsigned and require_signature is False.
     """
     path = Path(path)
-    members, sig_raw = _read_zip_members(path)
-    if sig_raw is None:
-        if require_signature:
-            raise TirSignatureError("package is unsigned (SIGNATURE missing)")
-        return None
-    return _verify_signature_bytes(
-        members,
-        sig_raw,
-        trusted_keys=trusted_keys,
-        trusted_key_ids=trusted_key_ids,
-    )
+    with zipfile.ZipFile(path, "r") as zf:
+        return verify_package_from_zip(
+            zf,
+            require_signature=require_signature,
+            trusted_keys=trusted_keys,
+            trusted_key_ids=trusted_key_ids,
+        )
 
 
 def _verify_signature_bytes(
@@ -184,6 +210,8 @@ def _verify_signature_bytes(
         doc = json.loads(sig_raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as e:
         raise TirSignatureError(f"SIGNATURE JSON: {e}") from e
+    if not isinstance(doc, dict):
+        raise TirSignatureError("SIGNATURE JSON must be an object")
     if doc.get("scheme") != SCHEME_V1:
         raise TirSignatureError(f"unknown scheme {doc.get('scheme')!r}")
     if doc.get("payload_alg") != PAYLOAD_ALG_V1:
@@ -217,6 +245,8 @@ def _verify_signature_bytes(
         raise TirSignatureError("ed25519 verification failed") from e
 
     signer = doc.get("signer") or {}
+    if not isinstance(signer, dict):
+        raise TirSignatureError("signer must be an object")
     kid = str(signer.get("key_id") or "") or key_id(pub_raw)
     if signer.get("key_id") and kid != key_id(pub_raw):
         raise TirSignatureError("signer.key_id does not match public_key")
@@ -241,8 +271,6 @@ def sign_package(
     meta: SignerMeta | None = None,
 ) -> None:
     """Write or replace the SIGNATURE member of an existing .tir package."""
-    if len(private_key) != _PRIVATE_KEY_SIZE and len(private_key) != _SEED_SIZE:
-        raise TirSignatureError("invalid ed25519 private key size")
     # Match Go Sign: require full 64 byte private key for the public API.
     if len(private_key) != _PRIVATE_KEY_SIZE:
         raise TirSignatureError("invalid ed25519 private key size")

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -23,6 +23,8 @@ from typing import Any
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SigningKey, VerifyKey
 
+from trajectory_ir.package.errors import TirError
+
 SIGNATURE_MEMBER = "SIGNATURE"
 SCHEME_V1 = "trajir-pkg-sig-v1"
 PAYLOAD_ALG_V1 = "trajir-pkg-payload-v1"
@@ -34,7 +36,7 @@ _SEED_SIZE = 32
 _PUBLIC_KEY_SIZE = 32
 
 
-class TirSignatureError(Exception):
+class TirSignatureError(TirError):
     """Package signature failure (missing when required, tamper, unknown scheme)."""
 
 

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -1,0 +1,281 @@
+"""Package signatures for .tir (README 9.1, trajir-pkg-sig-v1).
+
+File only SIGNATURE zip member; manifest.signature stays null.
+Payload: trajir-pkg-payload-v1 over all members except SIGNATURE.
+Crypto: domain separated Ed25519 (byte identical to go/trajir/tir).
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+import json
+import os
+import struct
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+SIGNATURE_MEMBER = "SIGNATURE"
+SCHEME_V1 = "trajir-pkg-sig-v1"
+PAYLOAD_ALG_V1 = "trajir-pkg-payload-v1"
+ALG_ED25519 = "ed25519"
+
+# Match Go ed25519.PrivateKeySize / PublicKeySize.
+_PRIVATE_KEY_SIZE = 64
+_SEED_SIZE = 32
+_PUBLIC_KEY_SIZE = 32
+
+
+class TirSignatureError(Exception):
+    """Package signature failure (missing when required, tamper, unknown scheme)."""
+
+
+@dataclass(frozen=True)
+class SignerMeta:
+    """Optional metadata written into the SIGNATURE document."""
+
+    id: str = ""
+    signed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class SignatureInfo:
+    """Result of a successful verify."""
+
+    document: dict[str, Any]
+    payload_hash: bytes
+    public_key: bytes
+    key_id: str
+    signer_id: str
+
+
+def key_id(public_key: bytes) -> str:
+    """First 16 hex chars of SHA-256(public_key raw)."""
+    if len(public_key) != _PUBLIC_KEY_SIZE:
+        raise TirSignatureError("invalid public key size")
+    return hashlib.sha256(public_key).hexdigest()[:16]
+
+
+def domain_separated_message(payload_hash: bytes) -> bytes:
+    """SHA-256(scheme || 0x00 || payload_hash_raw)."""
+    if len(payload_hash) != 32:
+        raise TirSignatureError("payload_hash must be 32 bytes")
+    h = hashlib.sha256()
+    h.update(SCHEME_V1.encode("ascii"))
+    h.update(b"\x00")
+    h.update(payload_hash)
+    return h.digest()
+
+
+def payload_hash_from_members(members: dict[str, bytes]) -> bytes:
+    """trajir-pkg-payload-v1 over members (must not include SIGNATURE)."""
+    names = sorted(n for n in members if n != SIGNATURE_MEMBER)
+    stream = hashlib.sha256()
+    for name in names:
+        _safe_member_name(name)
+        name_b = name.encode("utf-8")
+        stream.update(struct.pack(">Q", len(name_b)))
+        stream.update(name_b)
+        stream.update(hashlib.sha256(members[name]).digest())
+    return stream.digest()
+
+
+def _safe_member_name(name: str) -> None:
+    if not name or name.startswith(("/", "\\")):
+        raise TirSignatureError(f"unsafe zip path: {name!r}")
+    parts = name.replace("\\", "/").split("/")
+    for p in parts:
+        if p in ("", ".", ".."):
+            raise TirSignatureError(f"unsafe zip path: {name!r}")
+
+
+def _private_key_from_bytes(key: bytes) -> Ed25519PrivateKey:
+    if len(key) == _PRIVATE_KEY_SIZE:
+        return Ed25519PrivateKey.from_private_bytes(key[:_SEED_SIZE])
+    if len(key) == _SEED_SIZE:
+        return Ed25519PrivateKey.from_private_bytes(key)
+    raise TirSignatureError("invalid ed25519 private key size")
+
+
+def _read_zip_members(path: Path) -> tuple[dict[str, bytes], bytes | None]:
+    members: dict[str, bytes] = {}
+    signature: bytes | None = None
+    with zipfile.ZipFile(path, "r") as zf:
+        for info in zf.infolist():
+            name = info.filename
+            if name.endswith("/"):
+                continue
+            _safe_member_name(name)
+            data = zf.read(name)
+            if name == SIGNATURE_MEMBER:
+                if signature is not None:
+                    raise TirSignatureError("duplicate SIGNATURE member")
+                signature = data
+                continue
+            if name in members:
+                raise TirSignatureError(f"duplicate zip member {name!r}")
+            members[name] = data
+    return members, signature
+
+
+def verify_package(
+    path: str | Path,
+    *,
+    require_signature: bool = False,
+    trusted_keys: list[bytes] | None = None,
+    trusted_key_ids: list[str] | None = None,
+) -> SignatureInfo | None:
+    """Verify SIGNATURE on a .tir package.
+
+    Returns None when unsigned and require_signature is False.
+    """
+    path = Path(path)
+    members, sig_raw = _read_zip_members(path)
+    if sig_raw is None:
+        if require_signature:
+            raise TirSignatureError("package is unsigned (SIGNATURE missing)")
+        return None
+    return _verify_signature_bytes(
+        members,
+        sig_raw,
+        trusted_keys=trusted_keys,
+        trusted_key_ids=trusted_key_ids,
+    )
+
+
+def _verify_signature_bytes(
+    members: dict[str, bytes],
+    sig_raw: bytes,
+    *,
+    trusted_keys: list[bytes] | None,
+    trusted_key_ids: list[str] | None,
+) -> SignatureInfo:
+    try:
+        doc = json.loads(sig_raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise TirSignatureError(f"SIGNATURE JSON: {e}") from e
+    if doc.get("scheme") != SCHEME_V1:
+        raise TirSignatureError(f"unknown scheme {doc.get('scheme')!r}")
+    if doc.get("payload_alg") != PAYLOAD_ALG_V1:
+        raise TirSignatureError(f"unknown payload_alg {doc.get('payload_alg')!r}")
+    if doc.get("alg") != ALG_ED25519:
+        raise TirSignatureError(f"unknown alg {doc.get('alg')!r}")
+
+    want_hash = payload_hash_from_members(members)
+    got_hex = str(doc.get("payload_hash", "")).strip().lower()
+    if got_hex != want_hash.hex():
+        raise TirSignatureError("payload_hash mismatch")
+
+    try:
+        pub_raw = base64.b64decode(doc["public_key"], validate=True)
+    except Exception as e:
+        raise TirSignatureError("invalid public_key") from e
+    if len(pub_raw) != _PUBLIC_KEY_SIZE:
+        raise TirSignatureError("invalid public_key")
+
+    try:
+        sig = base64.b64decode(doc["signature"], validate=True)
+    except Exception as e:
+        raise TirSignatureError("invalid signature encoding") from e
+    if len(sig) != 64:
+        raise TirSignatureError("invalid signature encoding")
+
+    msg = domain_separated_message(want_hash)
+    pub = Ed25519PublicKey.from_public_bytes(pub_raw)
+    try:
+        pub.verify(sig, msg)
+    except InvalidSignature as e:
+        raise TirSignatureError("ed25519 verification failed") from e
+
+    signer = doc.get("signer") or {}
+    kid = str(signer.get("key_id") or "") or key_id(pub_raw)
+    if signer.get("key_id") and kid != key_id(pub_raw):
+        raise TirSignatureError("signer.key_id does not match public_key")
+
+    if trusted_keys and not any(k == pub_raw for k in trusted_keys):
+        raise TirSignatureError("public key not in trust store")
+    if trusted_key_ids and kid not in trusted_key_ids:
+        raise TirSignatureError(f"key_id {kid!r} not in trust store")
+
+    return SignatureInfo(
+        document=doc,
+        payload_hash=want_hash,
+        public_key=pub_raw,
+        key_id=kid,
+        signer_id=str(signer.get("id") or ""),
+    )
+
+
+def sign_package(
+    path: str | Path,
+    private_key: bytes,
+    meta: SignerMeta | None = None,
+) -> None:
+    """Write or replace the SIGNATURE member of an existing .tir package."""
+    if len(private_key) != _PRIVATE_KEY_SIZE and len(private_key) != _SEED_SIZE:
+        raise TirSignatureError("invalid ed25519 private key size")
+    # Match Go Sign: require full 64 byte private key for the public API.
+    if len(private_key) != _PRIVATE_KEY_SIZE:
+        raise TirSignatureError("invalid ed25519 private key size")
+
+    path = Path(path)
+    members, _existing = _read_zip_members(path)
+    payload = payload_hash_from_members(members)
+    priv = _private_key_from_bytes(private_key)
+    pub = priv.public_key().public_bytes_raw()
+    msg = domain_separated_message(payload)
+    sig = priv.sign(msg)
+
+    meta = meta or SignerMeta()
+    signed_at = meta.signed_at or datetime.now(UTC)
+    if signed_at.tzinfo is None:
+        signed_at = signed_at.replace(tzinfo=UTC)
+    signer: dict[str, str] = {"key_id": key_id(pub)}
+    if meta.id:
+        signer["id"] = meta.id
+    doc = {
+        "scheme": SCHEME_V1,
+        "payload_alg": PAYLOAD_ALG_V1,
+        "payload_hash": payload.hex(),
+        "alg": ALG_ED25519,
+        "public_key": base64.b64encode(pub).decode("ascii"),
+        "signature": base64.b64encode(sig).decode("ascii"),
+        "signed_at": signed_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "signer": signer,
+        "extensions": {},
+    }
+    doc_bytes = (json.dumps(doc, indent=2) + "\n").encode("utf-8")
+    _rewrite_zip_with_signature(path, members, doc_bytes)
+
+
+def _rewrite_zip_with_signature(
+    path: Path, members: dict[str, bytes], signature_json: bytes
+) -> None:
+    orig_mode = path.stat().st_mode & 0o777
+    parent = path.parent
+    fd, tmp_name = tempfile.mkstemp(prefix="tir-sign-", suffix=".tmp", dir=str(parent))
+    try:
+        with os.fdopen(fd, "wb") as raw:
+            with zipfile.ZipFile(raw, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                for name in sorted(members):
+                    zf.writestr(name, members[name])
+                zf.writestr(SIGNATURE_MEMBER, signature_json)
+            raw.flush()
+            os.fsync(raw.fileno())
+        os.chmod(tmp_name, orig_mode)
+        os.replace(tmp_name, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -106,15 +106,37 @@ def _signing_key_from_bytes(key: bytes) -> SigningKey:
 
 
 def _read_zip_members(path: Path) -> tuple[dict[str, bytes], bytes | None]:
+    # Local import avoids a cycle: tir.py imports this module at load time.
+    from trajectory_ir.package.tir import (
+        MAX_TOTAL_UNCOMPRESSED_BYTES,
+        MAX_UNCOMPRESSED_ENTRY_BYTES,
+        MAX_ZIP_ENTRIES,
+        TirLimitError,
+    )
+
     members: dict[str, bytes] = {}
     signature: bytes | None = None
     with zipfile.ZipFile(path, "r") as zf:
-        for info in zf.infolist():
+        infos = [i for i in zf.infolist() if not i.filename.endswith("/")]
+        if len(infos) > MAX_ZIP_ENTRIES:
+            raise TirLimitError(f"too many zip entries: {len(infos)} > {MAX_ZIP_ENTRIES}")
+        budget = MAX_TOTAL_UNCOMPRESSED_BYTES
+        for info in infos:
             name = info.filename
-            if name.endswith("/"):
-                continue
             _safe_member_name(name)
+            if info.file_size > MAX_UNCOMPRESSED_ENTRY_BYTES:
+                raise TirLimitError(
+                    f"zip member {name!r} uncompressed size {info.file_size} "
+                    f"exceeds limit {MAX_UNCOMPRESSED_ENTRY_BYTES}"
+                )
+            if info.file_size > budget:
+                raise TirLimitError(
+                    f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
+                )
             data = zf.read(name)
+            if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
+                raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
+            budget -= len(data)
             if name == SIGNATURE_MEMBER:
                 if signature is not None:
                     raise TirSignatureError("duplicate SIGNATURE member")

--- a/pkg/trajectory_ir/package/signature.py
+++ b/pkg/trajectory_ir/package/signature.py
@@ -20,11 +20,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-    Ed25519PrivateKey,
-    Ed25519PublicKey,
-)
+from nacl.exceptions import BadSignatureError
+from nacl.signing import SigningKey, VerifyKey
 
 SIGNATURE_MEMBER = "SIGNATURE"
 SCHEME_V1 = "trajir-pkg-sig-v1"
@@ -100,11 +97,11 @@ def _safe_member_name(name: str) -> None:
             raise TirSignatureError(f"unsafe zip path: {name!r}")
 
 
-def _private_key_from_bytes(key: bytes) -> Ed25519PrivateKey:
+def _signing_key_from_bytes(key: bytes) -> SigningKey:
     if len(key) == _PRIVATE_KEY_SIZE:
-        return Ed25519PrivateKey.from_private_bytes(key[:_SEED_SIZE])
+        return SigningKey(key[:_SEED_SIZE])
     if len(key) == _SEED_SIZE:
-        return Ed25519PrivateKey.from_private_bytes(key)
+        return SigningKey(key)
     raise TirSignatureError("invalid ed25519 private key size")
 
 
@@ -192,10 +189,9 @@ def _verify_signature_bytes(
         raise TirSignatureError("invalid signature encoding")
 
     msg = domain_separated_message(want_hash)
-    pub = Ed25519PublicKey.from_public_bytes(pub_raw)
     try:
-        pub.verify(sig, msg)
-    except InvalidSignature as e:
+        VerifyKey(pub_raw).verify(msg, sig)
+    except BadSignatureError as e:
         raise TirSignatureError("ed25519 verification failed") from e
 
     signer = doc.get("signer") or {}
@@ -232,10 +228,10 @@ def sign_package(
     path = Path(path)
     members, _existing = _read_zip_members(path)
     payload = payload_hash_from_members(members)
-    priv = _private_key_from_bytes(private_key)
-    pub = priv.public_key().public_bytes_raw()
+    sk = _signing_key_from_bytes(private_key)
+    pub = bytes(sk.verify_key)
     msg = domain_separated_message(payload)
-    sig = priv.sign(msg)
+    sig = sk.sign(msg).signature
 
     meta = meta or SignerMeta()
     signed_at = meta.signed_at or datetime.now(UTC)

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -8,9 +8,10 @@ Layout (master README §9):
     artifacts-manifest.json
     artifacts/          # fat only
     COMPAT.json
-    # SIGNATURE intentionally omitted (reserved, unimplemented)
+    SIGNATURE             # optional; trajir-pkg-sig-v1 (README 9.1)
 
 Import verifies every node id against runtime.nodes hashing (R05 spirit).
+When SIGNATURE is present, load also verifies the package signature.
 
 Security: load enforces zip path safety and size/count limits so untrusted
 packages cannot zip-bomb or path-traverse the reader.
@@ -28,6 +29,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from trajectory_ir.package.signature import (
+    SIGNATURE_MEMBER,
+    SignerMeta,
+    TirSignatureError,
+    sign_package,
+    verify_package,
+)
 from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.nodes import Node, NodeValidationError, node_id, payload_hash
 from trajectory_ir.runtime.redact import redact_payload
@@ -93,6 +101,7 @@ class TirPackage:
     seals: list[dict[str, Any]]
     artifacts_manifest: list[dict[str, Any]]
     artifact_bytes: dict[str, bytes]  # content_hash -> bytes (fat only)
+    signature: Any | None = None  # SignatureInfo when SIGNATURE verified
 
 
 def _content_hash(data: bytes) -> str:
@@ -225,6 +234,8 @@ def export_tir(
     tenant_id: str | None = None,
     redacted: bool = False,
     cas: Any | None = None,
+    sign_key: bytes | None = None,
+    signer_meta: SignerMeta | None = None,
 ) -> Path:
     """Export a trajectory from ``node_log`` to a ``.tir`` zip at ``dest``.
 
@@ -238,9 +249,14 @@ def export_tir(
         cas: Optional content addressed store. When set and ``mode`` is thin,
             every artifact content hash must already exist in the store
             (fail closed). Fat mode ignores this check (bytes are embedded).
+        sign_key: Optional full 64 byte Ed25519 private key. When set, writes
+            SIGNATURE after export (README 9.1). Wrong length fails closed.
+        signer_meta: Optional signer id / timestamp for SIGNATURE.
     """
     if mode not in ("thin", "fat"):
         raise TirError(f"unsupported mode {mode!r}; use thin or fat")
+    if sign_key is not None and len(sign_key) != 64:
+        raise TirSignatureError("invalid ed25519 private key size")
 
     if tenant_id is not None:
         nodes = node_log.list_nodes(trajectory_id, tenant_id=tenant_id)
@@ -350,6 +366,14 @@ def export_tir(
             os.unlink(tmp_name)
         raise
 
+    if sign_key is not None:
+        try:
+            sign_package(dest_path, sign_key, signer_meta)
+        except TirSignatureError:
+            with contextlib.suppress(OSError):
+                dest_path.unlink()
+            raise
+
     return dest_path
 
 
@@ -427,6 +451,8 @@ def _load_tir_impl(path: str | Path, *, verify: bool) -> TirPackage:
                 if len(artifact_bytes) > MAX_ARTIFACTS:
                     raise TirLimitError(f"too many embedded artifacts: > {MAX_ARTIFACTS}")
 
+        has_signature = SIGNATURE_MEMBER in name_set
+
     if verify:
         if not nodes:
             raise TirVerificationError("package has no nodes")
@@ -449,12 +475,22 @@ def _load_tir_impl(path: str | Path, *, verify: bool) -> TirPackage:
         if mode == "thin" and artifact_bytes:
             raise TirVerificationError("thin package must not embed artifact bytes")
 
+    # Signature check after hash/seal integrity (README 9.1 order).
+    # Present but invalid SIGNATURE fails even for load_tir_unverified (tamper).
+    sig_info = None
+    if has_signature:
+        try:
+            sig_info = verify_package(path)
+        except TirSignatureError as e:
+            raise TirVerificationError(str(e)) from e
+
     return TirPackage(
         manifest=manifest,
         nodes=nodes,
         seals=seals,
         artifacts_manifest=artifacts_manifest,
         artifact_bytes=artifact_bytes,
+        signature=sig_info,
     )
 
 

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from trajectory_ir.package.signature import (
+    SIGNATURE_MEMBER,
     SignerMeta,
     TirSignatureError,
     sign_package,
@@ -368,7 +369,9 @@ def export_tir(
     if sign_key is not None:
         try:
             sign_package(dest_path, sign_key, signer_meta)
-        except TirSignatureError:
+        except Exception:
+            # Any failure after the unsigned zip is on disk (crypto, IO, disk full)
+            # must not leave a half signed package behind.
             with contextlib.suppress(OSError):
                 dest_path.unlink()
             raise
@@ -475,10 +478,13 @@ def _load_tir_impl(path: str | Path, *, verify: bool) -> TirPackage:
         # Signature check after hash/seal integrity (README 9.1 order).
         # Use the already open archive only — never re open path (TOCTOU / CWE-367).
         # Present but invalid SIGNATURE fails even for load_tir_unverified (tamper).
-        try:
-            sig_info = verify_package_from_zip(zf)
-        except TirSignatureError as e:
-            raise TirVerificationError(str(e)) from e
+        # Unsigned packages skip the second decompress pass (match Go loadImpl).
+        sig_info = None
+        if SIGNATURE_MEMBER in name_set:
+            try:
+                sig_info = verify_package_from_zip(zf)
+            except TirSignatureError as e:
+                raise TirVerificationError(str(e)) from e
 
     return TirPackage(
         manifest=manifest,

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -30,11 +30,10 @@ from pathlib import Path
 from typing import Any, Literal
 
 from trajectory_ir.package.signature import (
-    SIGNATURE_MEMBER,
     SignerMeta,
     TirSignatureError,
     sign_package,
-    verify_package,
+    verify_package_from_zip,
 )
 from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.nodes import Node, NodeValidationError, node_id, payload_hash
@@ -451,36 +450,33 @@ def _load_tir_impl(path: str | Path, *, verify: bool) -> TirPackage:
                 if len(artifact_bytes) > MAX_ARTIFACTS:
                     raise TirLimitError(f"too many embedded artifacts: > {MAX_ARTIFACTS}")
 
-        has_signature = SIGNATURE_MEMBER in name_set
+        if verify:
+            if not nodes:
+                raise TirVerificationError("package has no nodes")
+            for n in nodes:
+                _verify_node_record(n)
+            expected_seals = _seals_from_nodes(nodes)
+            by_id = {s["node_id"]: s for s in seals}
+            for exp in expected_seals:
+                got = by_id.get(exp["node_id"])
+                if got is None:
+                    raise TirVerificationError(f"missing seal for decision node {exp['node_id']}")
+                if got.get("content_hash") != exp["content_hash"]:
+                    raise TirVerificationError(f"seal content_hash mismatch for {exp['node_id']}")
+            mode = manifest.get("mode", "thin")
+            if mode == "fat":
+                for entry in artifacts_manifest:
+                    h = entry["content_hash"]
+                    if h not in artifact_bytes:
+                        raise TirVerificationError(f"fat package missing artifact bytes {h}")
+            if mode == "thin" and artifact_bytes:
+                raise TirVerificationError("thin package must not embed artifact bytes")
 
-    if verify:
-        if not nodes:
-            raise TirVerificationError("package has no nodes")
-        for n in nodes:
-            _verify_node_record(n)
-        expected_seals = _seals_from_nodes(nodes)
-        by_id = {s["node_id"]: s for s in seals}
-        for exp in expected_seals:
-            got = by_id.get(exp["node_id"])
-            if got is None:
-                raise TirVerificationError(f"missing seal for decision node {exp['node_id']}")
-            if got.get("content_hash") != exp["content_hash"]:
-                raise TirVerificationError(f"seal content_hash mismatch for {exp['node_id']}")
-        mode = manifest.get("mode", "thin")
-        if mode == "fat":
-            for entry in artifacts_manifest:
-                h = entry["content_hash"]
-                if h not in artifact_bytes:
-                    raise TirVerificationError(f"fat package missing artifact bytes {h}")
-        if mode == "thin" and artifact_bytes:
-            raise TirVerificationError("thin package must not embed artifact bytes")
-
-    # Signature check after hash/seal integrity (README 9.1 order).
-    # Present but invalid SIGNATURE fails even for load_tir_unverified (tamper).
-    sig_info = None
-    if has_signature:
+        # Signature check after hash/seal integrity (README 9.1 order).
+        # Use the already open archive only — never re open path (TOCTOU / CWE-367).
+        # Present but invalid SIGNATURE fails even for load_tir_unverified (tamper).
         try:
-            sig_info = verify_package(path)
+            sig_info = verify_package_from_zip(zf)
         except TirSignatureError as e:
             raise TirVerificationError(str(e)) from e
 

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from trajectory_ir.package.errors import TirError
 from trajectory_ir.package.signature import (
     SIGNATURE_MEMBER,
     SignerMeta,
@@ -68,10 +69,6 @@ _REQUIRED_MEMBERS = frozenset(
 )
 
 # Redaction patterns live in runtime.redact (shared with R08 projection).
-
-
-class TirError(Exception):
-    """Base error for package operations."""
 
 
 class TirVerificationError(TirError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "dbos",
+    "pynacl",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
 dependencies = [
     "dbos",
     "pynacl",
+    # cffi 2.1+ reports MIT-0, which the license allowlist does not list yet.
+    "cffi>=1.14,<2.1",
 ]
 
 [project.optional-dependencies]

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from nacl.signing import SigningKey, VerifyKey
 
+from trajectory_ir.package.errors import TirError
 from trajectory_ir.package.signature import (
     TirSignatureError,
     domain_separated_message,
@@ -20,6 +21,17 @@ from trajectory_ir.package.signature import (
 )
 from trajectory_ir.package.tir import export_tir, load_tir
 from trajectory_ir.runtime.log import NodeLog
+
+
+def test_tir_signature_error_is_tir_error():
+    assert issubclass(TirSignatureError, TirError)
+    caught = False
+    try:
+        raise TirSignatureError("boom")
+    except TirError:
+        caught = True
+    assert caught
+
 
 _GOLDEN = (
     Path(__file__).resolve().parents[2]

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 
 import pytest
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from nacl.signing import SigningKey, VerifyKey
 
 from trajectory_ir.package.signature import (
     TirSignatureError,
@@ -35,9 +35,9 @@ _GOLDEN = (
 def _test_only_private_key() -> bytes:
     """Same seed as Go testOnlySeed: SHA-256 of the fixed note string."""
     seed = hashlib.sha256(b"trajir-pkg-sig-v1-test-vector-seed").digest()
-    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    sk = SigningKey(seed)
     # Go ed25519.PrivateKey is seed || public (64 bytes).
-    return seed + priv.public_key().public_bytes_raw()
+    return seed + bytes(sk.verify_key)
 
 
 def test_payload_and_domain_match_go_golden():
@@ -58,9 +58,7 @@ def test_verify_go_golden_signature():
     msg = domain_separated_message(payload)
     pub = base64.b64decode(golden["public_key_b64"])
     sig = base64.b64decode(golden["signature_b64"])
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-
-    Ed25519PublicKey.from_public_bytes(pub).verify(sig, msg)
+    VerifyKey(pub).verify(msg, sig)
 
 
 def test_sign_and_verify_roundtrip(tmp_path):

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -143,3 +143,45 @@ def test_verify_rejects_oversized_member(tmp_path, monkeypatch):
     monkeypatch.setattr(tirmod, "MAX_TOTAL_UNCOMPRESSED_BYTES", 100)
     with pytest.raises(TirLimitError):
         verify_package(bomb)
+
+
+@pytest.mark.parametrize("body", [b"null", b"42", b"[]", b'"x"'])
+def test_verify_rejects_non_object_signature_json(tmp_path, body):
+    import zipfile
+
+    from trajectory_ir.package.signature import verify_package_from_zip
+
+    path = tmp_path / "bad.tir"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", b"{}")
+        zf.writestr("SIGNATURE", body)
+    with (
+        zipfile.ZipFile(path, "r") as zf,
+        pytest.raises(TirSignatureError, match="must be an object"),
+    ):
+        verify_package_from_zip(zf)
+
+
+def test_load_verifies_from_open_archive(tmp_path, monkeypatch):
+    """load_tir must verify against the same open zip, not re open the path."""
+    import zipfile
+
+    import trajectory_ir.package.tir as tirmod
+
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "same.tir"
+    key = _test_only_private_key()
+    export_tir(log, "t1", out, mode="thin", sign_key=key)
+
+    opened: list[zipfile.ZipFile] = []
+    real = tirmod.verify_package_from_zip
+
+    def _track(zf, **kwargs):
+        opened.append(zf)
+        return real(zf, **kwargs)
+
+    monkeypatch.setattr(tirmod, "verify_package_from_zip", _track)
+    pkg = load_tir(out)
+    assert pkg.signature is not None
+    assert len(opened) == 1

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -124,3 +124,22 @@ def test_tamper_fails_verify(tmp_path):
         zf.writestr("SIGNATURE", sig)
     with pytest.raises(TirSignatureError):
         verify_package(rebuild)
+
+
+def test_verify_rejects_oversized_member(tmp_path, monkeypatch):
+    """Signature path must enforce the same zip budgets as tir.load."""
+    import zipfile
+
+    import trajectory_ir.package.tir as tirmod
+    from trajectory_ir.package.tir import TirLimitError
+
+    bomb = tmp_path / "bomb.tir"
+    with zipfile.ZipFile(bomb, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("manifest.json", b"{}")
+        zf.writestr("big.bin", b"x" * 1024)
+
+    # Shrink limits so a tiny fixture trips the same TirLimitError path.
+    monkeypatch.setattr(tirmod, "MAX_UNCOMPRESSED_ENTRY_BYTES", 100)
+    monkeypatch.setattr(tirmod, "MAX_TOTAL_UNCOMPRESSED_BYTES", 100)
+    with pytest.raises(TirLimitError):
+        verify_package(bomb)

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -223,3 +223,56 @@ def test_load_verifies_from_open_archive(tmp_path, monkeypatch):
     pkg = load_tir(out)
     assert pkg.signature is not None
     assert len(opened) == 1
+
+
+def test_load_unsigned_skips_signature_pass(tmp_path, monkeypatch):
+    """Unsigned packages must not pay for a second decompress (match Go)."""
+    import trajectory_ir.package.tir as tirmod
+
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "unsigned.tir"
+    export_tir(log, "t1", out, mode="thin")
+
+    calls = {"n": 0}
+    real = tirmod.verify_package_from_zip
+
+    def _count(zf, **kwargs):
+        calls["n"] += 1
+        return real(zf, **kwargs)
+
+    monkeypatch.setattr(tirmod, "verify_package_from_zip", _count)
+    pkg = load_tir(out)
+    assert pkg.signature is None
+    assert calls["n"] == 0
+
+
+def test_sign_rejects_naive_signed_at(tmp_path):
+    from datetime import datetime
+
+    from trajectory_ir.package.signature import SignerMeta
+
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "naive.tir"
+    export_tir(log, "t1", out, mode="thin")
+    key = _test_only_private_key()
+    with pytest.raises(TirSignatureError, match="timezone aware"):
+        sign_package(out, key, SignerMeta(signed_at=datetime(2026, 1, 1, 12, 0, 0)))
+
+
+def test_export_sign_failure_removes_unsigned_file(tmp_path, monkeypatch):
+    import trajectory_ir.package.tir as tirmod
+
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "gone.tir"
+    key = _test_only_private_key()
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(tirmod, "sign_package", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        export_tir(log, "t1", out, mode="thin", sign_key=key)
+    assert not out.exists()

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -145,6 +145,44 @@ def test_verify_rejects_oversized_member(tmp_path, monkeypatch):
         verify_package(bomb)
 
 
+def test_collect_zip_members_uses_bounded_read(tmp_path, monkeypatch):
+    """Member bytes must be read with an explicit cap (lying headers cannot OOM)."""
+    import zipfile
+
+    import trajectory_ir.package.tir as tirmod
+    from trajectory_ir.package.signature import _collect_zip_members
+
+    path = tmp_path / "bounded.tir"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("manifest.json", b"{}")
+        zf.writestr("a.bin", b"abcd")
+
+    monkeypatch.setattr(tirmod, "MAX_UNCOMPRESSED_ENTRY_BYTES", 100)
+    monkeypatch.setattr(tirmod, "MAX_TOTAL_UNCOMPRESSED_BYTES", 10_000)
+
+    read_sizes: list[int] = []
+    real_open = zipfile.ZipFile.open
+
+    def tracking_open(self, name, *args, **kwargs):
+        fp = real_open(self, name, *args, **kwargs)
+        real_read = fp.read
+
+        def capped_read(n=-1):
+            read_sizes.append(n)
+            return real_read(n)
+
+        fp.read = capped_read  # type: ignore[method-assign]
+        return fp
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", tracking_open)
+    with zipfile.ZipFile(path, "r") as zf:
+        members, sig = _collect_zip_members(zf)
+    assert sig is None
+    assert members["a.bin"] == b"abcd"
+    assert read_sizes
+    assert all(n == 101 for n in read_sizes)
+
+
 @pytest.mark.parametrize("body", [b"null", b"42", b"[]", b'"x"'])
 def test_verify_rejects_non_object_signature_json(tmp_path, body):
     import zipfile

--- a/test/unit/test_package_signature.py
+++ b/test/unit/test_package_signature.py
@@ -1,0 +1,128 @@
+"""trajir-pkg-sig-v1 Python parity tests (Phase C / #179)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from trajectory_ir.package.signature import (
+    TirSignatureError,
+    domain_separated_message,
+    key_id,
+    payload_hash_from_members,
+    sign_package,
+    verify_package,
+)
+from trajectory_ir.package.tir import export_tir, load_tir
+from trajectory_ir.runtime.log import NodeLog
+
+_GOLDEN = (
+    Path(__file__).resolve().parents[2]
+    / "go"
+    / "trajir"
+    / "tir"
+    / "testdata"
+    / "sig_v1"
+    / "payload_golden.json"
+)
+
+
+def _test_only_private_key() -> bytes:
+    """Same seed as Go testOnlySeed: SHA-256 of the fixed note string."""
+    seed = hashlib.sha256(b"trajir-pkg-sig-v1-test-vector-seed").digest()
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    # Go ed25519.PrivateKey is seed || public (64 bytes).
+    return seed + priv.public_key().public_bytes_raw()
+
+
+def test_payload_and_domain_match_go_golden():
+    golden = json.loads(_GOLDEN.read_text(encoding="utf-8"))
+    members = {name: base64.b64decode(b64) for name, b64 in golden["members_b64"].items()}
+    payload = payload_hash_from_members(members)
+    assert payload.hex() == golden["payload_hash_hex"]
+    msg = domain_separated_message(payload)
+    assert msg.hex() == golden["domain_message_hex"]
+    pub = base64.b64decode(golden["public_key_b64"])
+    assert key_id(pub) == golden["key_id"]
+
+
+def test_verify_go_golden_signature():
+    golden = json.loads(_GOLDEN.read_text(encoding="utf-8"))
+    members = {name: base64.b64decode(b64) for name, b64 in golden["members_b64"].items()}
+    payload = payload_hash_from_members(members)
+    msg = domain_separated_message(payload)
+    pub = base64.b64decode(golden["public_key_b64"])
+    sig = base64.b64decode(golden["signature_b64"])
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    Ed25519PublicKey.from_public_bytes(pub).verify(sig, msg)
+
+
+def test_sign_and_verify_roundtrip(tmp_path):
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "p.tir"
+    export_tir(log, "t1", out, mode="thin")
+    key = _test_only_private_key()
+    sign_package(out, key)
+    info = verify_package(out)
+    assert info is not None
+    assert info.key_id == key_id(key[32:])
+    pkg = load_tir(out)
+    assert pkg.signature is not None
+
+
+def test_export_sign_key_roundtrip(tmp_path):
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "signed.tir"
+    key = _test_only_private_key()
+    export_tir(log, "t1", out, mode="thin", sign_key=key)
+    info = verify_package(out)
+    assert info is not None
+
+
+def test_export_rejects_short_sign_key(tmp_path):
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "bad.tir"
+    with pytest.raises(TirSignatureError):
+        export_tir(log, "t1", out, mode="thin", sign_key=b"\x00" * 32)
+    assert not out.exists()
+
+
+def test_require_signature_rejects_unsigned(tmp_path):
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "u.tir"
+    export_tir(log, "t1", out, mode="thin")
+    with pytest.raises(TirSignatureError):
+        verify_package(out, require_signature=True)
+    assert verify_package(out) is None
+
+
+def test_tamper_fails_verify(tmp_path):
+    log = NodeLog(tmp_path / "nodes.sqlite")
+    log.append("DECISION", 1, {"plan": {"tool_calls": []}}, "t1", "demo", 1)
+    out = tmp_path / "t.tir"
+    key = _test_only_private_key()
+    export_tir(log, "t1", out, mode="thin", sign_key=key)
+    # Rebuild zip with mutated nodes but keep the old SIGNATURE bytes.
+    import zipfile
+
+    with zipfile.ZipFile(out, "r") as zf:
+        members = {n: zf.read(n) for n in zf.namelist() if not n.endswith("/")}
+    sig = members.pop("SIGNATURE")
+    members["nodes.ndjson"] = b'{"id":"tampered"}\n'
+    rebuild = tmp_path / "tampered.tir"
+    with zipfile.ZipFile(rebuild, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+        zf.writestr("SIGNATURE", sig)
+    with pytest.raises(TirSignatureError):
+        verify_package(rebuild)


### PR DESCRIPTION
## Summary

Starts #179 Phase C.

Python now has byte matched trajir-pkg-sig-v1 helpers against the Go golden file, plus sign_package / verify_package, optional export_tir(sign_key=...), and load checks SIGNATURE when it is present.

## What is in

- pkg/trajectory_ir/package/signature.py
- export_tir sign_key (64 byte key, wrong length fails closed)
- load_tir verifies SIGNATURE when present (tamper fails even on unverified load path for signature)
- unit tests including Go golden payload / domain / key id
- cryptography dependency

## Still open on #179

- Full conformance R09 R10 R11 jobs in CI
- Broader docs pass
- Security review before merge

## Test plan

- [x] pytest test/unit/test_package_signature.py
- [x] ruff check / format
- [ ] CI green

## Note

#197 Scorecard PR still needs workflow OAuth on the push token (cannot open that one from here yet).