### PR TITLE
fix(core): make rfc8785 an optional dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Install package for fixture generation
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e ".[dev]"
 
       - name: Generate cross language .tir fixture (Python export_tir)
         run: python scripts/gen_tir_fixture.py

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -152,7 +152,7 @@ def _verify_node_record(rec: dict[str, Any]) -> None:
             rec["kind"],
             ph,
         )
-    except (NodeValidationError, KeyError, TypeError, ValueError) as e:
+    except (NodeValidationError, KeyError, TypeError, ValueError, RuntimeError) as e:
         raise TirVerificationError(f"node {rec.get('id')}: {e}") from e
     if rec.get("id") != expected:
         raise TirVerificationError(

--- a/pkg/trajectory_ir/runtime/nodes.py
+++ b/pkg/trajectory_ir/runtime/nodes.py
@@ -2,7 +2,10 @@ import hashlib
 import time
 from dataclasses import dataclass, field
 
-import rfc8785
+try:
+    import rfc8785
+except ImportError:
+    rfc8785 = None  # type: ignore[assignment]
 
 NODE_KINDS = frozenset(
     {
@@ -53,6 +56,8 @@ def payload_hash(payload: dict) -> str:
         raise NodeValidationError("payload must be an object")
     if "ts" in payload:
         raise NodeValidationError("wall-clock ts must never be hashed (spec §6.3)")
+    if rfc8785 is None:
+        raise RuntimeError("rfc8785 is required for payload hashing but is not installed")
     canon = rfc8785.dumps(payload)
     return hashlib.sha256(canon).hexdigest()
 

--- a/pkg/trajectory_ir/runtime/projector.py
+++ b/pkg/trajectory_ir/runtime/projector.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-import rfc8785
+try:
+    import rfc8785
+except ImportError:
+    rfc8785 = None  # type: ignore[assignment]
 
 SIZE_METRIC = "rfc8785_bytes"
 
@@ -55,6 +58,8 @@ def node_size_units(node: dict[str, Any]) -> int:
         payload = {}
     if not isinstance(payload, dict):
         raise TypeError("payload must be an object for size measurement")
+    if rfc8785 is None:
+        raise RuntimeError("rfc8785 is required for size measurement but is not installed")
     # RFC 8785 JCS — same stack as runtime.nodes.payload_hash (byte-stable vs Go jcs).
     canon = rfc8785.dumps({"kind": kind, "payload": payload})
     return len(canon)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,13 @@ classifiers = [
 ]
 dependencies = [
     "dbos",
-    "rfc8785",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
+dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit", "rfc8785"]
 postgres = ["psycopg[binary]>=3.1"]
 s3 = ["boto3"]
+rfc8785 = ["rfc8785"]
 
 [project.urls]
 Homepage = "https://github.com/Coder-s-OG-s/Trajectory-IR"
@@ -101,11 +101,13 @@ warn_unreachable = true
 strict_equality = true
 warn_redundant_casts = true
 no_implicit_reexport = true
+explicit_package_bases = true
 
 [[tool.mypy.overrides]]
 module = [
     "boto3",
     "botocore.*",
+    "rfc8785",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit", "rfc8785"]
-postgres = ["psycopg[binary]>=3.1"]
-s3 = ["boto3"]
+postgres = ["psycopg[binary]>=3.1", "rfc8785"]
+s3 = ["boto3", "rfc8785"]
 rfc8785 = ["rfc8785"]
 
 [project.urls]

--- a/test/unit/test_rfc8785_optional.py
+++ b/test/unit/test_rfc8785_optional.py
@@ -1,0 +1,54 @@
+import subprocess
+import sys
+
+
+def test_nodes_import_succeeds_without_rfc8785():
+    """Verify that importing nodes.py does not crash if rfc8785 is absent."""
+    code = (
+        "import sys\n"
+        "sys.modules['rfc8785'] = None\n"
+        "from trajectory_ir.runtime.nodes import payload_hash\n"
+        "print('import success')\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, f"Import failed: {result.stderr}"
+    assert "import success" in result.stdout
+
+    # Now verify payload_hash actually raises RuntimeError when used
+    code_raise = (
+        "import sys\n"
+        "sys.modules['rfc8785'] = None\n"
+        "from trajectory_ir.runtime.nodes import payload_hash\n"
+        "payload_hash({'kind': 'INPUT', 'payload': {}})\n"
+    )
+    result_raise = subprocess.run(
+        [sys.executable, "-c", code_raise], capture_output=True, text=True
+    )
+    assert result_raise.returncode != 0
+    assert "rfc8785 is required for payload hashing but is not installed" in result_raise.stderr
+
+
+def test_projector_import_succeeds_without_rfc8785():
+    """Verify that importing projector.py does not crash if rfc8785 is absent."""
+    code = (
+        "import sys\n"
+        "sys.modules['rfc8785'] = None\n"
+        "from trajectory_ir.runtime.projector import node_size_units\n"
+        "print('import success')\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, f"Import failed: {result.stderr}"
+    assert "import success" in result.stdout
+
+    # Now verify node_size_units actually raises RuntimeError when used
+    code_raise = (
+        "import sys\n"
+        "sys.modules['rfc8785'] = None\n"
+        "from trajectory_ir.runtime.projector import node_size_units\n"
+        "node_size_units({'kind': 'INPUT', 'payload': {}})\n"
+    )
+    result_raise = subprocess.run(
+        [sys.executable, "-c", code_raise], capture_output=True, text=True
+    )
+    assert result_raise.returncode != 0
+    assert "rfc8785 is required for size measurement but is not installed" in result_raise.stderr


### PR DESCRIPTION
Fixes #191

This PR optimizes `loadImpl` to only call `verifySignatureFromZipFiles` if a `SIGNATURE` member is actually present in the zip archive.

Previously, `verifySignatureFromZipFiles` was called unconditionally, which triggered `collectZipMembers` to re-decompress and read all entries into memory to compute the payload hash, effectively doubling decompression time and memory overhead even when there was no signature to verify.

By short-circuiting when `SIGNATURE` is absent, unsigned packages are processed with a single decompression pass. This does not change verification behavior, as `VerifyOptions{}` (which defaults to `RequireSignature: false`) already succeeded silently without a signature.
