### PR TITLE
fix: enforce budget during zip member read to prevent zip bomb OOM

### DIFF
--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -126,13 +126,16 @@ def _read_zip_member(zf: zipfile.ZipFile, name: str, *, budget: list[int]) -> by
             f"zip member {name!r} uncompressed size {info.file_size} "
             f"exceeds limit {MAX_UNCOMPRESSED_ENTRY_BYTES}"
         )
-    if info.file_size > budget[0]:
+    limit = min(MAX_UNCOMPRESSED_ENTRY_BYTES, budget[0])
+    with zf.open(name) as fp:
+        # Read exactly the active limit + 1 byte to detect overrun
+        data = fp.read(limit + 1)
+    if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
+        raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
+    if len(data) > budget[0]:
         raise TirLimitError(
             f"zip total uncompressed size would exceed limit {MAX_TOTAL_UNCOMPRESSED_BYTES}"
         )
-    data = zf.read(name)
-    if len(data) > MAX_UNCOMPRESSED_ENTRY_BYTES:
-        raise TirLimitError(f"zip member {name!r} expanded beyond per-entry limit")
     budget[0] -= len(data)
     return data
 

--- a/test/unit/test_zip_bomb.py
+++ b/test/unit/test_zip_bomb.py
@@ -1,0 +1,42 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from trajectory_ir.package.tir import (
+    TirLimitError,
+    _read_zip_member,
+)
+
+
+def test_read_zip_member_enforces_budget(tmp_path: Path):
+    zip_path = tmp_path / "bomb.zip"
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        # Create a file that is exactly 100 bytes long
+        zf.writestr("bomb.txt", b"x" * 100)
+
+    # Budget is 50 bytes. We expect reading this member to fail.
+    budget = [50]
+
+    with (
+        zipfile.ZipFile(zip_path, "r") as zf,
+        pytest.raises(TirLimitError, match="zip total uncompressed size would exceed limit"),
+    ):
+        _read_zip_member(zf, "bomb.txt", budget=budget)
+
+
+def test_read_zip_member_enforces_entry_limit(tmp_path: Path, monkeypatch):
+    import trajectory_ir.package.tir as tir
+
+    monkeypatch.setattr(tir, "MAX_UNCOMPRESSED_ENTRY_BYTES", 50)
+
+    zip_path = tmp_path / "bomb.zip"
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("bomb.txt", b"x" * 100)
+
+    budget = [1000]  # large enough
+    with (
+        zipfile.ZipFile(zip_path, "r") as zf,
+        pytest.raises(TirLimitError, match="exceeds limit"),
+    ):
+        _read_zip_member(zf, "bomb.txt", budget=budget)


### PR DESCRIPTION
Fixes #273

### Problem
The `.tir` package loading logic in `pkg/trajectory_ir/package/tir.py` attempted to defend against zip bombs by checking `info.file_size` against a budget limit. However, a malicious payload could forge the `file_size` in the zip header to claim a small footprint while actually containing gigabytes of highly compressed data. Because the code used `zf.read(name)`, Python's `zipfile` module would decompress the entire stream into memory until EOF regardless of the header size, leading to an Out of Memory (OOM) crash.

### Solution
- Replaced the vulnerable `zf.read(name)` with a bounded stream read: `fp.read(MAX_UNCOMPRESSED_ENTRY_BYTES + 1)`.
- This ensures that decompression strictly halts and evaluates the budget limit based on the actual bytes extracted, rather than relying on untrusted metadata declared in the zip header.

If an attacker forges the zip header, memory consumption is now actively bounded and safely aborted without crashing the process.
