### PR TITLE
fix: define __all__ export list to prevent public API namespace pollution

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -9,16 +9,16 @@ from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, 
 from trajectory_ir.runtime.tool import Tool
 
 __all__ = [
-    "Trajectory",
-    "ProjectContext",
     "Decision",
+    "ProjectContext",
     "ToolResult",
+    "Trajectory",
+    "commit_step",
+    "exec_tool",
     "open_trajectory",
     "project",
-    "seal_decision",
-    "exec_tool",
-    "commit_step",
     "resume",
+    "seal_decision",
 ]
 
 

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -8,6 +8,19 @@ from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.sandbox import RunMode, assert_tool_allowed_in_mode, normalize_run_mode
 from trajectory_ir.runtime.tool import Tool
 
+__all__ = [
+    "Trajectory",
+    "ProjectContext",
+    "Decision",
+    "ToolResult",
+    "open_trajectory",
+    "project",
+    "seal_decision",
+    "exec_tool",
+    "commit_step",
+    "resume",
+]
+
 
 @dataclass
 class Trajectory:


### PR DESCRIPTION
Fixes #234

### Problem
The primary SDK entrypoint (`client/python/trajectory_client.py`) did not define an `__all__` export list. As a result, internal imports and types like `dataclass`, `Any`, `RunMode`, and `NodeLog` were implicitly leaking into the public API surface. This pollutes the namespace, causing wildcard imports (`from trajectory_client import *`) to pull in unintended internal dependencies and confusing IDE autocompletion/static analyzers for downstream users.

### Solution
Added an explicit `__all__` export list to strictly encapsulate internal dependencies and define the intended public SDK APIs:
- `Trajectory`
- `ProjectContext`
- `Decision`
- `ToolResult`
- `open_trajectory`
- `project`
- `seal_decision`
- `exec_tool`
- `commit_step`
- `resume`

This guarantees a clean, predictable public API surface.
