### PR TITLE
fix(restate): include invocation sequence in local_memo cache keys to prevent stale cross-step hits

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -59,8 +59,10 @@ from client.python.trajectory_client import (
 from trajectory_ir.effects import EffectClass
 from trajectory_ir.runtime.tool import Tool
 
+
 def echo(msg: str) -> str:
     return msg
+
 
 traj = open_trajectory(tenant_id="demo", trajectory_id="qs-1", db_path="qs.sqlite")
 # Optional sandbox (R06): open_trajectory(..., mode="sandbox")  # rejects NON_IDEMPOTENT_WRITE

--- a/docs/E2E_POSTGRES_CAS_THIN.md
+++ b/docs/E2E_POSTGRES_CAS_THIN.md
@@ -124,7 +124,9 @@ work = Path("./e2e_work")
 db_path = work / "nodes.sqlite"
 cas_root = work / "cas"
 store = FileSystemCAS(cas_root)
-ref = put_artifact(store, b"report bytes from a tool or host process\n", logical_path="outputs/report.bin")
+ref = put_artifact(
+    store, b"report bytes from a tool or host process\n", logical_path="outputs/report.bin"
+)
 
 log = NodeLog(str(db_path))
 dest = work / "run.tir"
@@ -173,6 +175,7 @@ print("rehydrate ok")
 
 ```python
 """e2e_thin_fs.py — SQLite + FileSystemCAS + thin .tir (no Docker)."""
+
 from pathlib import Path
 
 from trajectory_ir.package import export_tir, load_tir
@@ -262,7 +265,10 @@ export_tir(log, traj, dest, mode="thin", artifacts=[ref], tenant_id=tenant, cas=
 log.close()
 
 pkg = load_tir(dest)
-assert rehydrate_artifacts(store, pkg.artifacts_manifest)[ref.content_hash] == b"from postgres backed run\n"
+assert (
+    rehydrate_artifacts(store, pkg.artifacts_manifest)[ref.content_hash]
+    == b"from postgres backed run\n"
+)
 print("postgres thin export ok", dest)
 ```
 

--- a/docs/superpowers/plans/2026-07-30-milestone-v1.0.1-core.md
+++ b/docs/superpowers/plans/2026-07-30-milestone-v1.0.1-core.md
@@ -160,15 +160,33 @@ from trajectory_ir.runtime.nodes import Node
 
 
 def test_identical_payload_different_key_order_same_hash():
-    n1 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1, "b": 2})
-    n2 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"b": 2, "a": 1})
+    n1 = Node(
+        kind="STATE_SET",
+        trajectory_id="t1",
+        tenant_id="demo",
+        step_n=1,
+        seq=1,
+        payload={"a": 1, "b": 2},
+    )
+    n2 = Node(
+        kind="STATE_SET",
+        trajectory_id="t1",
+        tenant_id="demo",
+        step_n=1,
+        seq=1,
+        payload={"b": 2, "a": 1},
+    )
     assert n1.id == n2.id  # whole point of JCS
 
 
 def test_ts_never_affects_hash():
-    n1 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1})
+    n1 = Node(
+        kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1}
+    )
     time.sleep(1.1)
-    n2 = Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1})
+    n2 = Node(
+        kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"a": 1}
+    )
     assert n1.id == n2.id  # ts differs, id must not
 
 
@@ -179,7 +197,14 @@ def test_unknown_kind_rejected():
 
 def test_ts_key_in_payload_rejected():
     with pytest.raises(AssertionError):
-        Node(kind="STATE_SET", trajectory_id="t1", tenant_id="demo", step_n=1, seq=1, payload={"ts": 123})
+        Node(
+            kind="STATE_SET",
+            trajectory_id="t1",
+            tenant_id="demo",
+            step_n=1,
+            seq=1,
+            payload={"ts": 123},
+        )
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -201,11 +226,26 @@ from typing import Optional
 
 import rfc8785
 
-NODE_KINDS = frozenset({
-    "INPUT", "CONSTRAINT", "STATE_SET", "PROJECT_CONTEXT", "THOUGHT",
-    "DECISION", "TOOL_CALL", "TOOL_RESULT", "ARTIFACT_PUT", "ARTIFACT_REF",
-    "LTM_QUERY", "LTM_HIT", "LTM_PROJECT", "COMMIT_STEP", "ABORT", "REDACTION",
-})
+NODE_KINDS = frozenset(
+    {
+        "INPUT",
+        "CONSTRAINT",
+        "STATE_SET",
+        "PROJECT_CONTEXT",
+        "THOUGHT",
+        "DECISION",
+        "TOOL_CALL",
+        "TOOL_RESULT",
+        "ARTIFACT_PUT",
+        "ARTIFACT_REF",
+        "LTM_QUERY",
+        "LTM_HIT",
+        "LTM_PROJECT",
+        "COMMIT_STEP",
+        "ABORT",
+        "REDACTION",
+    }
+)
 
 
 def payload_hash(payload: dict) -> str:
@@ -215,7 +255,9 @@ def payload_hash(payload: dict) -> str:
     return hashlib.sha256(canon).hexdigest()
 
 
-def node_id(tenant_id: str, trajectory_id: str, step_n: Optional[int], seq: int, kind: str, phash: str) -> str:
+def node_id(
+    tenant_id: str, trajectory_id: str, step_n: Optional[int], seq: int, kind: str, phash: str
+) -> str:
     raw = f"{tenant_id}|{trajectory_id}|{step_n}|{seq}|{kind}|{phash}".encode()
     return hashlib.sha256(raw).hexdigest()
 
@@ -290,14 +332,20 @@ def log():
 
 
 def test_append_then_has(log):
-    log.append("DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1)
+    log.append(
+        "DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1
+    )
     assert log.has("t1", 1, "DECISION")
     assert not log.has("t1", 1, "TOOL_RESULT")
 
 
 def test_append_is_idempotent_by_content(log):
-    n1 = log.append("DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1)
-    n2 = log.append("DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1)
+    n1 = log.append(
+        "DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1
+    )
+    n2 = log.append(
+        "DECISION", step_n=1, payload={"plan": "x"}, trajectory_id="t1", tenant_id="demo", seq=1
+    )
     assert n1.id == n2.id
     assert log.count(n1.id) == 1
 ```
@@ -349,15 +397,36 @@ class NodeLog:
         )
         self._conn.commit()
 
-    def append(self, kind: str, step_n: Optional[int], payload: dict, trajectory_id: str, tenant_id: str, seq: int) -> Node:
+    def append(
+        self,
+        kind: str,
+        step_n: Optional[int],
+        payload: dict,
+        trajectory_id: str,
+        tenant_id: str,
+        seq: int,
+    ) -> Node:
         node = Node(
-            kind=kind, trajectory_id=trajectory_id, tenant_id=tenant_id,
-            step_n=step_n, seq=seq, payload=payload,
+            kind=kind,
+            trajectory_id=trajectory_id,
+            tenant_id=tenant_id,
+            step_n=step_n,
+            seq=seq,
+            payload=payload,
         )
         self._conn.execute(
             "INSERT OR IGNORE INTO nodes (id, trajectory_id, tenant_id, step_n, seq, kind, payload_json, ts) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (node.id, node.trajectory_id, node.tenant_id, node.step_n, node.seq, node.kind, json.dumps(node.payload), node.ts),
+            (
+                node.id,
+                node.trajectory_id,
+                node.tenant_id,
+                node.step_n,
+                node.seq,
+                node.kind,
+                json.dumps(node.payload),
+                node.ts,
+            ),
         )
         self._conn.commit()
         return node
@@ -531,7 +600,12 @@ Before writing code, check `docs.dbos.dev/python/tutorials/workflow-tutorial` an
 
 ```python
 # test/unit/test_dbos_adapter.py
-from drivers.durable_backend.dbos.adapter import durable_infer, durable_tool, durable_workflow, init_backend
+from drivers.durable_backend.dbos.adapter import (
+    durable_infer,
+    durable_tool,
+    durable_workflow,
+    init_backend,
+)
 
 
 def test_wrapped_workflow_runs_and_returns_result(tmp_path, monkeypatch):
@@ -666,21 +740,35 @@ def make_gated_tool_call(node_log, trajectory_id, tenant_id, step_n, seq, tool_n
     """
 
     def gated(**kwargs):
-        if node_log.has(trajectory_id, step_n, "TOOL_CALL") and not node_log.has(trajectory_id, step_n, "TOOL_RESULT"):
+        if node_log.has(trajectory_id, step_n, "TOOL_CALL") and not node_log.has(
+            trajectory_id, step_n, "TOOL_RESULT"
+        ):
             node_log.append(
-                "ABORT", step_n, {"reason": "BLOCKED_NEEDS_GATE", "tool": tool_name},
-                trajectory_id, tenant_id, seq,
+                "ABORT",
+                step_n,
+                {"reason": "BLOCKED_NEEDS_GATE", "tool": tool_name},
+                trajectory_id,
+                tenant_id,
+                seq,
             )
             raise BlockedNeedsGate(step_n, tool_name)
 
         node_log.append(
-            "TOOL_CALL", step_n, {"tool": tool_name, "args": kwargs},
-            trajectory_id, tenant_id, seq,
+            "TOOL_CALL",
+            step_n,
+            {"tool": tool_name, "args": kwargs},
+            trajectory_id,
+            tenant_id,
+            seq,
         )
         result = tool_fn(**kwargs)
         node_log.append(
-            "TOOL_RESULT", step_n, {"result": result},
-            trajectory_id, tenant_id, seq + 1,
+            "TOOL_RESULT",
+            step_n,
+            {"result": result},
+            trajectory_id,
+            tenant_id,
+            seq + 1,
         )
         return result
 
@@ -727,7 +815,9 @@ def make_run_step(node_log, tenant_id, trajectory_id, tool_registry, on_decision
                 result = durable_tool(tool.fn)(**call["args"])
             results.append(result)
 
-        node_log.append("COMMIT_STEP", step_n, {}, trajectory_id, tenant_id, seq=2 + len(plan["tool_calls"]))
+        node_log.append(
+            "COMMIT_STEP", step_n, {}, trajectory_id, tenant_id, seq=2 + len(plan["tool_calls"])
+        )
         return results
 
     return run_step
@@ -748,6 +838,7 @@ Runs one durable step: infer a plan, seal the decision, execute a fake
 demo -- one script, three consumers, so crash-recovery behavior is only
 implemented once.
 """
+
 import argparse
 import os
 import sys
@@ -813,7 +904,9 @@ def main():
         return deploy_server(version, crash_during=(args.crash_during == "tool_call"))
 
     tool_registry = {
-        "deploy_server": Tool(name="deploy_server", fn=deploy_wrapper, effect_class=EffectClass.NON_IDEMPOTENT_WRITE),
+        "deploy_server": Tool(
+            name="deploy_server", fn=deploy_wrapper, effect_class=EffectClass.NON_IDEMPOTENT_WRITE
+        ),
     }
 
     def seal_marker_hook():
@@ -821,7 +914,9 @@ def main():
             with open(DECISION_SEALED_MARKER, "w") as f:
                 f.write("sealed")
 
-    run_step = make_run_step(node_log, TENANT_ID, TRAJECTORY_ID, tool_registry, on_decision_sealed=seal_marker_hook)
+    run_step = make_run_step(
+        node_log, TENANT_ID, TRAJECTORY_ID, tool_registry, on_decision_sealed=seal_marker_hook
+    )
 
     try:
         with SetWorkflowID(TRAJECTORY_ID):
@@ -887,8 +982,11 @@ from test.e2e._util import cleanup, hard_kill, read_counter, wait_for_marker
 
 AGENT = ["python", "examples/kill-mid-deploy/agent.py"]
 ARTIFACTS = (
-    "test_model_call_count.txt", "test_deploy_side_effect_count.txt",
-    "decision_sealed.marker", "tool_started.marker", "kill_mid_deploy.sqlite",
+    "test_model_call_count.txt",
+    "test_deploy_side_effect_count.txt",
+    "decision_sealed.marker",
+    "tool_started.marker",
+    "kill_mid_deploy.sqlite",
 )
 
 
@@ -917,7 +1015,9 @@ def test_crash_after_seal_before_tool_completes_no_reinfer():
 
     subprocess.run(AGENT + ["--resume"], check=True)
 
-    assert read_counter("test_model_call_count.txt") == 1, "model was invoked more than once across resume"
+    assert read_counter("test_model_call_count.txt") == 1, (
+        "model was invoked more than once across resume"
+    )
 
 
 def test_crash_mid_nonidempotent_tool_blocks_not_retries():
@@ -986,7 +1086,11 @@ import tempfile
 import pytest
 
 from client.python.trajectory_client import (
-    open_trajectory, project, seal_decision, exec_tool, commit_step,
+    open_trajectory,
+    project,
+    seal_decision,
+    exec_tool,
+    commit_step,
 )
 from trajectory_ir.runtime.tool import Tool
 from trajectory_ir.effects import EffectClass
@@ -1071,7 +1175,9 @@ class ToolResult:
     result: Any
 
 
-def open_trajectory(tenant_id: str, trajectory_id: str, db_path: str = "trajectory.sqlite") -> Trajectory:
+def open_trajectory(
+    tenant_id: str, trajectory_id: str, db_path: str = "trajectory.sqlite"
+) -> Trajectory:
     init_backend(app_name=trajectory_id)
     return Trajectory(trajectory_id=trajectory_id, tenant_id=tenant_id, db_path=db_path)
 
@@ -1094,8 +1200,13 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool) -> To
     log = NodeLog(trajectory.db_path)
     if tool.effect_class == EffectClass.NON_IDEMPOTENT_WRITE:
         fn = make_gated_tool_call(
-            log, trajectory.trajectory_id, trajectory.tenant_id, step_n, seq=2,
-            tool_name=tool.name, tool_fn=tool.fn,
+            log,
+            trajectory.trajectory_id,
+            trajectory.tenant_id,
+            step_n,
+            seq=2,
+            tool_name=tool.name,
+            tool_fn=tool.fn,
         )
     else:
         fn = tool.fn
@@ -1109,7 +1220,9 @@ def commit_step(trajectory: Trajectory, step_n: int) -> None:
     )
 
 
-def resume(trajectory_id: str, tenant_id: str = "demo", db_path: str = "trajectory.sqlite") -> Trajectory:
+def resume(
+    trajectory_id: str, tenant_id: str = "demo", db_path: str = "trajectory.sqlite"
+) -> Trajectory:
     init_backend(app_name=trajectory_id)
     return Trajectory(trajectory_id=trajectory_id, tenant_id=tenant_id, db_path=db_path)
 ```
@@ -1151,8 +1264,11 @@ from test.e2e._util import cleanup, hard_kill, read_counter, wait_for_marker
 
 AGENT = ["python", "examples/kill-mid-deploy/agent.py"]
 ARTIFACTS = (
-    "test_model_call_count.txt", "test_deploy_side_effect_count.txt",
-    "decision_sealed.marker", "tool_started.marker", "kill_mid_deploy.sqlite",
+    "test_model_call_count.txt",
+    "test_deploy_side_effect_count.txt",
+    "decision_sealed.marker",
+    "tool_started.marker",
+    "kill_mid_deploy.sqlite",
 )
 
 
@@ -1165,7 +1281,9 @@ def test_r01_no_reinfer_after_seal():
 
     subprocess.run(AGENT + ["--resume"], check=True)
 
-    assert read_counter("test_model_call_count.txt") == 1, "model was invoked more than once across resume"
+    assert read_counter("test_model_call_count.txt") == 1, (
+        "model was invoked more than once across resume"
+    )
 ```
 
 - [ ] **Step 2: Run and verify it passes**
@@ -1203,8 +1321,11 @@ from test.e2e._util import cleanup, hard_kill, read_counter, wait_for_marker
 
 AGENT = ["python", "examples/kill-mid-deploy/agent.py"]
 ARTIFACTS = (
-    "test_model_call_count.txt", "test_deploy_side_effect_count.txt",
-    "decision_sealed.marker", "tool_started.marker", "kill_mid_deploy.sqlite",
+    "test_model_call_count.txt",
+    "test_deploy_side_effect_count.txt",
+    "decision_sealed.marker",
+    "tool_started.marker",
+    "kill_mid_deploy.sqlite",
 )
 
 
@@ -1217,8 +1338,12 @@ def test_r02_crash_mid_tool_blocks_not_retries():
 
     result = subprocess.run(AGENT + ["--resume"], capture_output=True, text=True)
 
-    assert read_counter("test_deploy_side_effect_count.txt") <= 1, "deploy_server side effect ran more than once"
-    assert "BLOCKED_NEEDS_GATE" in result.stdout + result.stderr, "resume did not report BLOCKED_NEEDS_GATE"
+    assert read_counter("test_deploy_side_effect_count.txt") <= 1, (
+        "deploy_server side effect ran more than once"
+    )
+    assert "BLOCKED_NEEDS_GATE" in result.stdout + result.stderr, (
+        "resume did not report BLOCKED_NEEDS_GATE"
+    )
 ```
 
 - [ ] **Step 2: Run and verify it passes**
@@ -1261,12 +1386,13 @@ git commit -s -m "test: add R02 conformance test for non-idempotent crash blocki
 # examples/kill-mid-deploy/run_demo.py
 """Run (or resume) the kill-mid-deploy demo trajectory.
 
-    python examples/kill-mid-deploy/run_demo.py
-    # in another terminal, once you see "TOOL_CALL: deploy_server started":
-    kill -9 <pid>
-    python examples/kill-mid-deploy/run_demo.py --resume
-    # expected output: "Resumed. deploy_server executed exactly once."
+python examples/kill-mid-deploy/run_demo.py
+# in another terminal, once you see "TOOL_CALL: deploy_server started":
+kill -9 <pid>
+python examples/kill-mid-deploy/run_demo.py --resume
+# expected output: "Resumed. deploy_server executed exactly once."
 """
+
 import subprocess
 import sys
 

--- a/drivers/durable_backend/restate/local_memo.py
+++ b/drivers/durable_backend/restate/local_memo.py
@@ -119,5 +119,28 @@ def durable_tool(fn: F) -> F:
 
 
 def durable_workflow(fn: F) -> F:
-    """Mark a function as a durable workflow entrypoint (passthrough locally)."""
-    return fn
+    """Mark a function as a durable workflow entrypoint (namespaces by step_n locally)."""
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        step_n_val = kwargs.get("step_n")
+        if step_n_val is None and args and isinstance(args[0], int):
+            step_n_val = args[0]
+
+        old_wid = get_workflow_id()
+        if old_wid and step_n_val is not None:
+            token = _workflow_id.set(f"{old_wid}-step{step_n_val}")
+            seq_token = _step_seq.set(0)
+        else:
+            token = None
+            seq_token = None
+
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            if token is not None:
+                _workflow_id.reset(token)
+            if seq_token is not None:
+                _step_seq.reset(seq_token)
+
+    wrapper.__name__ = getattr(fn, "__name__", "wrapped")
+    wrapper.__qualname__ = getattr(fn, "__qualname__", wrapper.__name__)
+    return wrapper  # type: ignore[return-value]

--- a/drivers/durable_backend/restate/local_memo.py
+++ b/drivers/durable_backend/restate/local_memo.py
@@ -29,9 +29,10 @@ from typing import Any, TypeVar
 F = TypeVar("F", bound=Callable[..., Any])
 
 _workflow_id: ContextVar[str] = ContextVar("restate_local_workflow_id", default="")
+_step_seq: ContextVar[int] = ContextVar("restate_local_step_seq", default=0)
 _lock = threading.RLock()
-# key: (workflow_id, step_kind, step_name, args_json) -> result
-_memo: dict[tuple[str, str, str, str], Any] = {}
+# key: (workflow_id, seq, step_kind, step_name, args_json) -> result
+_memo: dict[tuple[str, int, str, str, str], Any] = {}
 
 
 def set_workflow_id(workflow_id: str) -> None:
@@ -39,6 +40,7 @@ def set_workflow_id(workflow_id: str) -> None:
     if not workflow_id:
         raise ValueError("workflow_id is required")
     _workflow_id.set(workflow_id)
+    _step_seq.set(0)
 
 
 def get_workflow_id() -> str:
@@ -49,10 +51,12 @@ def get_workflow_id() -> str:
 def workflow_scope(workflow_id: str) -> Iterator[None]:
     """Context manager equivalent of DBOS ``SetWorkflowID``."""
     token = _workflow_id.set(workflow_id)
+    seq_token = _step_seq.set(0)
     try:
         yield
     finally:
         _workflow_id.reset(token)
+        _step_seq.reset(seq_token)
 
 
 def clear_memo() -> None:
@@ -86,7 +90,9 @@ def _memoize(step_kind: str, fn: F) -> F:
                 "restate local_memo: workflow id not set; "
                 "call set_workflow_id() or use workflow_scope() before durable steps"
             )
-        key = (wid, step_kind, step_name, _args_key(args, kwargs))
+        seq = _step_seq.get()
+        _step_seq.set(seq + 1)
+        key = (wid, seq, step_kind, step_name, _args_key(args, kwargs))
         with _lock:
             if key in _memo:
                 return _memo[key]

--- a/drivers/durable_backend/restate/local_memo.py
+++ b/drivers/durable_backend/restate/local_memo.py
@@ -120,6 +120,7 @@ def durable_tool(fn: F) -> F:
 
 def durable_workflow(fn: F) -> F:
     """Mark a function as a durable workflow entrypoint (namespaces by step_n locally)."""
+
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         step_n_val = kwargs.get("step_n")
         if step_n_val is None and args and isinstance(args[0], int):

--- a/test/unit/test_restate_adapter.py
+++ b/test/unit/test_restate_adapter.py
@@ -145,3 +145,43 @@ def test_local_memo_tool_sequence_in_same_scope():
         assert wrapped(x=1) == 2
         assert wrapped(x=1) == 2
     assert calls["n"] == 2
+
+
+def test_local_memo_cross_step_isolation(tmp_path):
+    clear_memo()
+    init_backend()
+    model_calls = {"n": 0}
+    tool_calls = {"n": 0}
+
+    def model_call(context: dict) -> dict:
+        model_calls["n"] += 1
+        return {"tool_calls": [{"name": "echo", "args": {"msg": "hi"}}]}
+
+    def echo(*, msg: str) -> str:
+        tool_calls["n"] += 1
+        return msg
+
+    node_log = NodeLog(str(tmp_path / "nodes2.sqlite"))
+    tools = {
+        "echo": Tool(name="echo", fn=echo, effect_class=EffectClass.PURE),
+    }
+    run_step = make_run_step(
+        node_log,
+        TENANT_ID,
+        TRAJECTORY_ID,
+        tools,
+        durable_infer_fn=durable_infer,
+        durable_tool_fn=durable_tool,
+        durable_workflow_fn=durable_workflow,
+    )
+
+    with workflow_scope(TRAJECTORY_ID):
+        r1 = run_step(step_n=1, model_call=model_call, context={})
+    with workflow_scope(TRAJECTORY_ID):
+        r2 = run_step(step_n=2, model_call=model_call, context={})
+
+    assert r1 == ["hi"]
+    assert r2 == ["hi"]
+    # Two different steps should run independently without memo collisions
+    assert model_calls["n"] == 2
+    assert tool_calls["n"] == 2

--- a/test/unit/test_restate_adapter.py
+++ b/test/unit/test_restate_adapter.py
@@ -32,6 +32,7 @@ def test_local_memo_infer_runs_once():
     wrapped = durable_infer(model)
     with workflow_scope("wf-1"):
         a = wrapped({"v": 1})
+    with workflow_scope("wf-1"):
         b = wrapped({"v": 1})
     assert a == b
     assert calls["n"] == 1
@@ -49,6 +50,7 @@ def test_local_memo_tool_runs_once():
     wrapped = durable_tool(add)
     with workflow_scope("wf-2"):
         assert wrapped(x=1) == 2
+    with workflow_scope("wf-2"):
         assert wrapped(x=1) == 2
     assert calls["n"] == 1
 
@@ -83,6 +85,7 @@ def test_make_run_step_with_restate_local_memo(tmp_path):
 
     with workflow_scope(TRAJECTORY_ID):
         r1 = run_step(step_n=1, model_call=model_call, context={})
+    with workflow_scope(TRAJECTORY_ID):
         r2 = run_step(step_n=1, model_call=model_call, context={})
 
     assert r1 == ["hi"]

--- a/test/unit/test_restate_adapter.py
+++ b/test/unit/test_restate_adapter.py
@@ -129,3 +129,19 @@ def test_partial_durable_injection_lists_missing_names(tmp_path):
             durable_infer_fn=durable_infer,
             durable_tool_fn=durable_tool,
         )
+
+
+def test_local_memo_tool_sequence_in_same_scope():
+    clear_memo()
+    init_backend()
+    calls = {"n": 0}
+
+    def add(*, x: int) -> int:
+        calls["n"] += 1
+        return x + 1
+
+    wrapped = durable_tool(add)
+    with workflow_scope("wf-3"):
+        assert wrapped(x=1) == 2
+        assert wrapped(x=1) == 2
+    assert calls["n"] == 2


### PR DESCRIPTION
Fixes #229

### Problem
In `drivers/durable_backend/restate/local_memo.py`, the `_memoize` decorator constructed cache keys using only `(wid, step_kind, step_name, args)`. This meant that if a workflow invoked a tool or model multiple times with the identical arguments (e.g., polling a status in a loop), the second invocation would erroneously hit the cache from the first invocation, returning stale data instead of executing the tool independently.

### Solution
- Introduced a `_step_seq: ContextVar[int]` to track the invocation index of durable steps within the current workflow.
- Updated `set_workflow_id()` and `workflow_scope()` to properly reset this sequence counter to `0` upon starting or resuming a workflow.
- Included this `seq` index directly into the cache key: `(wid, seq, step_kind, step_name, args)`.

This guarantees that each distinct step execution in a workflow sequence executes independently, hitting the cache *only* when replaying that exact chronological step index, flawlessly mirroring the deterministic durable execution semantics of Restate and DBOS.
