### PR TITLE
feat(ci): auto-label PRs with "Need Another Approval" on approval

### DIFF
--- a/.github/workflows/pr-approval-label.yml
+++ b/.github/workflows/pr-approval-label.yml
@@ -1,0 +1,26 @@
+name: PR Approval Label
+
+permissions:
+  contents: read
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  label-approval:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add "Need Another Approval" label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Need Another Approval']
+            })


### PR DESCRIPTION
## Summary
- Adds a `pull_request_review` workflow that fires on `submitted` reviews
- When a review's state is `approved`, it adds the `Need Another Approval` label to the PR via `actions/github-script`
- Every approval re-applies the label (no threshold/removal logic — GitHub is a no-op if the label is already present)

## Test plan
- [ ] Merge and open a test PR, submit an approving review, confirm the `Need Another Approval` label is added
- [ ] Submit a non-approving review (comment/request changes), confirm the label is NOT added
- [ ] `actionlint` passes on the new workflow file