### PR TITLE
feat(ci): auto-label PRs with "Needs Review" on open

### DIFF
--- a/.github/workflows/pr-needs-review-label.yml
+++ b/.github/workflows/pr-needs-review-label.yml
@@ -4,11 +4,12 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   label-new-pr:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-needs-review-label.yml
+++ b/.github/workflows/pr-needs-review-label.yml
@@ -1,0 +1,25 @@
+name: PR Needs Review Label
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  label-new-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add "Needs Review" label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Needs Review']
+            })


### PR DESCRIPTION
## Summary
- Adds a `pull_request` workflow that fires on `opened`
- Applies the `Needs Review` label to every newly opened PR via `actions/github-script`
- Created the `Needs Review` label in the repo (green, "PR needs an initial review")

## Test plan
- [ ] Merge and open a test PR, confirm the `Needs Review` label is added automatically
- [ ] `actionlint` passes on the new workflow file