### PR TITLE
fix(examples): remove dynamic sys.path injection

### DIFF
--- a/examples/adoption_host/run_demo.py
+++ b/examples/adoption_host/run_demo.py
@@ -29,25 +29,19 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-# Allow ``python examples/adoption_host/run_demo.py`` without a prior editable install.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
-    if _path not in sys.path:
-        sys.path.insert(0, _path)
-
-from client.python.trajectory_client import (  # noqa: E402
+from client.python.trajectory_client import (
     commit_step,
     exec_tool,
     open_trajectory,
     project,
     seal_decision,
 )
-from trajectory_ir.effects import EffectClass  # noqa: E402
-from trajectory_ir.package import export_tir, load_tir  # noqa: E402
-from trajectory_ir.runtime.log import NodeLog  # noqa: E402
-from trajectory_ir.runtime.sandbox import SandboxForbidden  # noqa: E402
-from trajectory_ir.runtime.tool import Tool  # noqa: E402
-from trajectory_ir.storage import FileSystemCAS, put_artifact, rehydrate_artifacts  # noqa: E402
+from trajectory_ir.effects import EffectClass
+from trajectory_ir.package import export_tir, load_tir
+from trajectory_ir.runtime.log import NodeLog
+from trajectory_ir.runtime.sandbox import SandboxForbidden
+from trajectory_ir.runtime.tool import Tool
+from trajectory_ir.storage import FileSystemCAS, put_artifact, rehydrate_artifacts
 
 TENANT_ID = "demo"
 TRAJECTORY_ID = "adoption-host-demo"

--- a/examples/host_loop/run_host.py
+++ b/examples/host_loop/run_host.py
@@ -16,12 +16,6 @@ import os
 import sys
 import tempfile
 
-# Allow ``python examples/host_loop/run_host.py`` without a prior editable install.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
-    if _path not in sys.path:
-        sys.path.insert(0, _path)
-
 from client.python.trajectory_client import (
     commit_step,
     exec_tool,

--- a/examples/kill_mid_deploy/README.md
+++ b/examples/kill_mid_deploy/README.md
@@ -5,6 +5,8 @@ Demonstrates the milestone's core claim: a crash mid-tool-execution never silent
 ## Run it
 
 ```bash
+pip install -e ".[dev]"
+
 python examples/kill_mid_deploy/run_demo.py
 # in another terminal, once you see "TOOL_CALL: deploy_server started":
 kill -9 <pid>

--- a/examples/kill_mid_deploy/agent.py
+++ b/examples/kill_mid_deploy/agent.py
@@ -25,13 +25,6 @@ import os
 import sys
 import time
 
-# Run directly from a checkout (`python examples/kill_mid_deploy/agent.py`)
-# without requiring an installed package or a preset PYTHONPATH.
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-for _path in (_REPO_ROOT, os.path.join(_REPO_ROOT, "pkg")):
-    if _path not in sys.path:
-        sys.path.insert(0, _path)
-
 from dbos import SetWorkflowID
 
 from drivers.durable_backend.dbos.adapter import init_backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ select = [
 
 
 [tool.ruff.lint.per-file-ignores]
-# Fixture agent adjusts sys.path before local imports on purpose.
-"examples/kill_mid_deploy/agent.py" = ["E402"]
-"examples/host_loop/run_host.py" = ["E402"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["trajectory_ir", "drivers", "client", "test"]


### PR DESCRIPTION
Closes #208

This PR removes the dynamic `sys.path.insert(0, ...)` injection blocks from all the example scripts (`kill_mid_deploy/agent.py`, `adoption_host/run_demo.py`, `host_loop/run_host.py`). 

By removing this brittle runtime hack, the examples now properly rely on standard package installation (e.g., `pip install -e .`). This restores compatibility with static analysis tools and IDE autocomplete. 

Additionally, the corresponding `E402` lint ignores for these files have been completely stripped out of `pyproject.toml`.
