### PR TITLE
fix(client): reuse a single NodeLog per Trajectory instead of leaking one per call

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from drivers.durable_backend.dbos.adapter import init_backend
@@ -28,6 +28,24 @@ class Trajectory:
     tenant_id: str
     db_path: str
     mode: RunMode = RunMode.LIVE
+    _log: NodeLog = field(init=False, repr=False, compare=False)
+    _closed: bool = field(init=False, repr=False, compare=False, default=False)
+
+    def __post_init__(self):
+        self._log = NodeLog(self.db_path)
+        self._closed = False
+
+    def close(self) -> None:
+        """Close the underlying NodeLog SQLite connection idempotently."""
+        if not self._closed:
+            self._closed = True
+            self._log.close()
+
+    def __enter__(self) -> "Trajectory":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
 
 
 @dataclass
@@ -72,7 +90,7 @@ def project(trajectory: Trajectory, step_n: int, context: dict) -> ProjectContex
     ``trajectory_ir.runtime.project_context`` first, then pass its
     ``ProjectResult.context`` here.
     """
-    NodeLog(trajectory.db_path).append(
+    trajectory._log.append(
         "PROJECT_CONTEXT",
         step_n,
         context,
@@ -84,7 +102,7 @@ def project(trajectory: Trajectory, step_n: int, context: dict) -> ProjectContex
 
 
 def seal_decision(trajectory: Trajectory, step_n: int, plan: dict) -> Decision:
-    NodeLog(trajectory.db_path).append(
+    trajectory._log.append(
         "DECISION",
         step_n,
         {"plan": plan},
@@ -114,7 +132,7 @@ def exec_tool(trajectory: Trajectory, step_n: int, call: dict, tool: Tool, seq: 
         tool_name=tool.name,
         effect_class=tool.effect_class,
     )
-    log = NodeLog(trajectory.db_path)
+    log = trajectory._log
     if requires_block_and_gate(tool.effect_class):
         fn = make_gated_tool_call(
             log,
@@ -149,7 +167,7 @@ def commit_step(trajectory: Trajectory, step_n: int, seq: int) -> None:
         seq: Sequence number for commit (should be 2 + 2*num_tool_calls to follow
             after all tool calls)
     """
-    NodeLog(trajectory.db_path).append(
+    trajectory._log.append(
         "COMMIT_STEP",
         step_n,
         {},
@@ -182,14 +200,22 @@ def resume(
     rather than silently behave like ``open_trajectory``.
     """
     init_backend(app_name=trajectory_id)
-    if not NodeLog(db_path).list_nodes_all_tenants(trajectory_id):
-        raise ValueError(
-            f"cannot resume trajectory_id={trajectory_id!r}: no existing nodes "
-            f"found in {db_path!r}; use open_trajectory() to start a new one"
-        )
-    return Trajectory(
+    traj = Trajectory(
         trajectory_id=trajectory_id,
         tenant_id=tenant_id,
         db_path=db_path,
         mode=normalize_run_mode(mode),
     )
+    try:
+        nodes = traj._log.list_nodes_all_tenants(trajectory_id)
+    except Exception:
+        traj.close()
+        raise
+
+    if not nodes:
+        traj.close()
+        raise ValueError(
+            f"cannot resume trajectory_id={trajectory_id!r}: no existing nodes "
+            f"found in {db_path!r}; use open_trajectory() to start a new one"
+        )
+    return traj

--- a/test/unit/test_client_sdk.py
+++ b/test/unit/test_client_sdk.py
@@ -61,3 +61,28 @@ def test_exec_tool_two_non_idempotent_writes_same_step_distinct_seq(db_path):
     # Both should be logged without either being falsely blocked
     assert NodeLog(db_path).has("test-t5", "demo", 1, "TOOL_CALL", seq=2)
     assert NodeLog(db_path).has("test-t5", "demo", 1, "TOOL_CALL", seq=4)
+
+
+def test_trajectory_reuses_single_nodelog_connection(db_path, monkeypatch):
+    traj = open_trajectory(tenant_id="demo", trajectory_id="test-reuse", db_path=db_path)
+    initial_log = traj._log
+
+    project(traj, step_n=1, context={"initial": True})
+    seal_decision(traj, step_n=1, plan={"plan": "reuse"})
+    tool = Tool(name="echo", fn=lambda x: x, effect_class=EffectClass.READ_ONLY)
+    exec_tool(traj, step_n=1, call={"args": {"x": 10}}, tool=tool, seq=2)
+    commit_step(traj, step_n=1, seq=4)
+
+    assert traj._log is initial_log
+
+
+def test_trajectory_context_manager_and_close(db_path):
+    import sqlite3
+
+    with open_trajectory(tenant_id="demo", trajectory_id="test-cm", db_path=db_path) as traj:
+        project(traj, step_n=1, context={"data": 123})
+        conn = traj._log._conn
+
+    # Once context manager exits, the connection should be closed
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")

--- a/test/unit/test_client_sdk_resume_alias.py
+++ b/test/unit/test_client_sdk_resume_alias.py
@@ -34,6 +34,39 @@ def test_resume_raises_on_trajectory_with_no_history(tmp_path):
         resume("brand-new-trajectory", db_path=db_path)
 
 
+def test_resume_raises_on_empty_history_and_closes_connection(tmp_path, monkeypatch):
+    import sqlite3
+
+    from client.python.trajectory_client import Trajectory
+
+    db_path = str(tmp_path / "trajectory.sqlite")
+    closed_conns = []
+
+    orig_close = Trajectory.close
+
+    def spy_close(self):
+        closed_conns.append(self._log._conn)
+        orig_close(self)
+
+    monkeypatch.setattr(Trajectory, "close", spy_close)
+
+    with pytest.raises(ValueError, match="no existing nodes"):
+        resume("brand-new-trajectory", db_path=db_path)
+
+    assert len(closed_conns) == 1
+    with pytest.raises(sqlite3.ProgrammingError):
+        closed_conns[0].execute("SELECT 1")
+
+
+def test_trajectory_close_is_idempotent(tmp_path):
+    db_path = str(tmp_path / "trajectory.sqlite")
+    traj = open_trajectory("demo", "t1", db_path=db_path)
+    traj.close()
+    # Calling close again must be a safe no-op
+    traj.close()
+    assert traj._closed is True
+
+
 def test_resume_reattaches_after_history_exists(tmp_path):
     db_path = str(tmp_path / "trajectory.sqlite")
     trajectory = open_trajectory("demo", "t1", db_path=db_path)


### PR DESCRIPTION
## Problem

project(), seal_decision(), exec_tool(), commit_step(), and esume() in client/python/trajectory_client.py each constructed a fresh NodeLog(trajectory.db_path) inline. NodeLog.__init__ opens a sqlite3.connect(db_path, check_same_thread=False) handle that is only released when the garbage collector finalizes the object via __del__.

Over a multi-step agent session (e.g. 50+ steps with multiple tool calls per step), this accumulated hundreds of open SQLite file handles against the same database file. On Windows this causes [WinError 32] The process cannot access the file because it is being used by another process during cleanup; on any platform it risks file descriptor exhaustion and stale lock contention.

## Fix

Store a shared NodeLog instance on the Trajectory dataclass via a ield(init=False, repr=False, compare=False) initialized in __post_init__. All helper functions now reference 	rajectory._log instead of constructing a throwaway NodeLog. esume() builds the Trajectory first and queries 	raj._log for the emptiness check so the verification runs on the shared connection instead of leaking its own.

The _log field is excluded from __init__, __repr__, and __eq__ so the public construction interface is unchanged and existing callers are unaffected.

## Testing

- All 142 unit tests pass (2 skipped: Postgres live + pip-audit).
- All 18 conformance tests pass.
- Ruff clean, mypy clean.
- Manual verification: with gc.disable(), 30 SDK operations against the same db_path now hold exactly one sqlite3.Connection, down from 30+.

## Spec reference

None specific; general resource management.

Closes #289