### PR TITLE
fix(client): enforce strict tenant isolation in Resume

### DIFF
--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -128,7 +128,7 @@ func Resume(tenantID, trajectoryID string, opts Options) (*Trajectory, error) {
 	if err != nil {
 		return nil, err
 	}
-	rows, err := tr.log.ListNodesAllTenants(trajectoryID)
+	rows, err := tr.log.ListNodes(trajectoryID, tenantID)
 	if err != nil {
 		_ = tr.Close()
 		return nil, err

--- a/go/trajir/client/client_test.go
+++ b/go/trajir/client/client_test.go
@@ -227,3 +227,25 @@ func TestExecToolLogsToolCallOnError(t *testing.T) {
 		t.Fatalf("expected no TOOL_RESULT on error, got %v (err: %v)", hasResult, err)
 	}
 }
+
+func TestResumeTenantIsolation(t *testing.T) {
+	dir := t.TempDir()
+	opts := client.Options{WorkDir: dir}
+
+	trA, err := client.OpenTrajectory("tenant-A", "shared-traj", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := trA.Project(1, map[string]any{"goal": "x"}); err != nil {
+		t.Fatal(err)
+	}
+	_ = trA.Close()
+
+	_, err = client.Resume("tenant-B", "shared-traj", opts)
+	if err == nil {
+		t.Fatal("expected Resume to fail for a different tenant, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "no existing nodes") {
+		t.Fatalf("expected 'no existing nodes' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes a severe tenant isolation flaw in `client.Resume()` where it was previously validating trajectory existence using `ListNodesAllTenants(trajectoryID)`. This allowed a caller to successfully resume a trajectory created by a different tenant, resulting in mixed-tenant cross-contamination of the IR history upon subsequent appends.

By replacing the check with the tenant-scoped `ListNodes(trajectoryID, tenantID)` method, we ensure that a trajectory can only be resumed if it is genuinely owned by the requesting tenant.

## Changes
- **`go/trajir/client/client.go`**: Switched from `ListNodesAllTenants` to `ListNodes` in `Resume()` to enforce the tenant isolation boundary natively at the read path.
- **`go/trajir/client/client_test.go`**: Added `TestResumeTenantIsolation` to explicitly assert that attempting to resume a valid trajectory ID using a mismatched tenant ID safely fails with a "no existing nodes" error.

## Validation
- Ran `go test ./...` in the `go` module. All tests passed, including the new regression test. No existing public API signatures were altered.
