### PR TITLE
fix(client): scope Python resume() to the calling tenant

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -207,7 +207,7 @@ def resume(
         mode=normalize_run_mode(mode),
     )
     try:
-        nodes = traj._log.list_nodes_all_tenants(trajectory_id)
+        nodes = traj._log.list_nodes(trajectory_id, tenant_id=tenant_id)
     except Exception:
         traj.close()
         raise

--- a/drivers/postgres/log.py
+++ b/drivers/postgres/log.py
@@ -324,6 +324,8 @@ class PostgresNodeLog:
         *,
         tenant_id: str,
     ) -> list[dict[str, Any]]:
+        if not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
         return self._list_nodes(trajectory_id, tenant_id=tenant_id)
 
     def list_nodes_all_tenants(self, trajectory_id: str) -> list[dict[str, Any]]:

--- a/pkg/trajectory_ir/runtime/log.py
+++ b/pkg/trajectory_ir/runtime/log.py
@@ -246,6 +246,8 @@ class NodeLog:
         tenants (e.g. ``export_tir``'s own mixed-tenant check) must use
         ``list_nodes_all_tenants`` explicitly instead.
         """
+        if not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
         return self._list_nodes(trajectory_id, tenant_id=tenant_id)
 
     def list_nodes_all_tenants(self, trajectory_id: str) -> list[dict[str, Any]]:

--- a/test/unit/test_client_sdk_resume_alias.py
+++ b/test/unit/test_client_sdk_resume_alias.py
@@ -79,6 +79,19 @@ def test_resume_reattaches_after_history_exists(tmp_path):
     assert resumed.db_path == db_path
 
 
+def test_resume_rejects_other_tenant_on_same_trajectory_id(tmp_path):
+    db_path = str(tmp_path / "trajectory.sqlite")
+    trajectory = open_trajectory("tenant-A", "shared-traj", db_path=db_path)
+    seal_decision(trajectory, step_n=1, plan={"tool_calls": []})
+
+    with pytest.raises(ValueError, match="no existing nodes"):
+        resume("shared-traj", tenant_id="tenant-B", db_path=db_path)
+
+    resumed = resume("shared-traj", tenant_id="tenant-A", db_path=db_path)
+    assert resumed.tenant_id == "tenant-A"
+    assert resumed.trajectory_id == "shared-traj"
+
+
 def test_resume_does_not_replay_already_claimed_gated_tool_call(tmp_path):
     """Simulates a crash/restart mid-step: resume() reattaches, and re-driving
     the same exec_tool call for a NON_IDEMPOTENT_WRITE tool blocks instead of


### PR DESCRIPTION
## Summary

Python `resume()` was asking the log "does this trajectory_id exist for anyone?" via `list_nodes_all_tenants`. Tenant B could attach to tenant A's run in a shared sqlite file and then write nodes under B.

It now uses `list_nodes(..., tenant_id=tenant_id)`, same boundary as Go #306. Empty result still raises the existing "no existing nodes" error, so we do not leak that another tenant already has the id.

## Related issues

Closes #309
Related: #306

## How I tested

```bash
pytest test/unit/test_client_sdk_resume_alias.py -q
```

6 passed, including a new test that tenant-B cannot resume tenant-A's `shared-traj`.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] Yes. Client `resume()` existence check only. Gate / seal code is unchanged.

## AI assistance (if any)

Editor help on the patch. I wrote the test and ran it.
