### PR TITLE
fix: reject pipe characters in kind when hashing node_id

### DIFF
--- a/go/trajir/nodes/nodes.go
+++ b/go/trajir/nodes/nodes.go
@@ -88,6 +88,9 @@ func NodeID(tenantID, trajectoryID string, stepN *int, seq int, kind, phash stri
 	if err := ValidateIDComponent("trajectory_id", trajectoryID); err != nil {
 		return "", err
 	}
+	if err := ValidateIDComponent("kind", kind); err != nil {
+		return "", err
+	}
 	step := "None"
 	if stepN != nil {
 		step = strconv.Itoa(*stepN)

--- a/go/trajir/nodes/nodes_test.go
+++ b/go/trajir/nodes/nodes_test.go
@@ -153,6 +153,9 @@ func TestNodeIDRejectsInvalidComponents(t *testing.T) {
 	if _, err := nodes.NodeID("demo", "", nil, 0, "INPUT", "h"); err == nil {
 		t.Fatal("expected error for empty trajectory_id")
 	}
+	if _, err := nodes.NodeID("demo", "t1", nil, 0, "TOOL|CALL", "h"); err == nil {
+		t.Fatal("expected error for pipe in kind")
+	}
 }
 
 func TestNewNodeRejectsInvalidComponents(t *testing.T) {

--- a/pkg/trajectory_ir/runtime/nodes.py
+++ b/pkg/trajectory_ir/runtime/nodes.py
@@ -38,7 +38,7 @@ class NodeValidationError(ValueError):
 
 
 def validate_id_component(name: str, value: str) -> str:
-    """Validate a tenant_id or trajectory_id for safe node_id composition."""
+    """Validate a node_id preimage field (tenant, trajectory, or kind)."""
     if not isinstance(value, str) or not value:
         raise NodeValidationError(f"{name} must be a non-empty string")
     if any(ch in value for ch in _FORBIDDEN_ID_CHARS):
@@ -72,6 +72,7 @@ def node_id(
 ) -> str:
     validate_id_component("tenant_id", tenant_id)
     validate_id_component("trajectory_id", trajectory_id)
+    validate_id_component("kind", kind)
     raw = f"{tenant_id}|{trajectory_id}|{step_n}|{seq}|{kind}|{phash}".encode()
     return hashlib.sha256(raw).hexdigest()
 

--- a/test/unit/test_node_identity.py
+++ b/test/unit/test_node_identity.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 
-from trajectory_ir.runtime.nodes import Node, NodeValidationError
+from trajectory_ir.runtime.nodes import Node, NodeValidationError, node_id
 
 
 def test_identical_payload_different_key_order_same_hash():
@@ -92,3 +92,8 @@ def test_pipe_in_trajectory_id_rejected():
             seq=1,
             payload={"a": 1},
         )
+
+
+def test_pipe_in_kind_rejected_by_node_id():
+    with pytest.raises(NodeValidationError, match="delimiter"):
+        node_id("demo", "t1", 1, 0, "TOOL|CALL", "ab" * 32)


### PR DESCRIPTION
## Summary

`node_id` / `NodeID` already reject `|` in `tenant_id` and `trajectory_id`. `kind` is in the same preimage (`tenant|trajectory|step|seq|kind|phash`) and was only checked on `Node` / `NewNode`.

Calling the hasher directly with something like `TOOL|CALL` can move field boundaries. Kind is now run through the same `validate_id_component` / `ValidateIDComponent` path.

## Related issues

Closes #308

## How I tested

```bash
pytest test/unit/test_node_identity.py -q
cd go && go test ./trajir/nodes -count=1
```

Python: 7 passed. Go: ok.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] Yes. Node identity hashing only. Effect classes and resume are untouched.

## AI assistance (if any)

Editor help on the patch. Tests are mine.
