### PR TITLE
feat(client): add lightweight trajectory history inspection API

### DIFF
--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -15,6 +15,7 @@ __all__ = [
     "Trajectory",
     "commit_step",
     "exec_tool",
+    "history",
     "open_trajectory",
     "project",
     "resume",
@@ -219,3 +220,8 @@ def resume(
             f"found in {db_path!r}; use open_trajectory() to start a new one"
         )
     return traj
+
+
+def history(trajectory: Trajectory) -> list[dict[str, Any]]:
+    """Return this trajectory's logged nodes in order without changing state."""
+    return trajectory._log.list_nodes(trajectory.trajectory_id, tenant_id=trajectory.tenant_id)

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -291,6 +291,11 @@ func (t *Trajectory) Log() *nodelog.NodeLog { return t.log }
 // Backend exposes the durable backend for advanced tests.
 func (t *Trajectory) Backend() durable.Backend { return t.backend }
 
+// History returns this trajectory's logged nodes in order without changing state.
+func (t *Trajectory) History() ([]map[string]any, error) {
+	return t.log.ListNodes(t.TrajectoryID, t.TenantID)
+}
+
 func resolvePaths(opts Options) (nodesPath, memoPath string) {
 	base := opts.WorkDir
 	nodesPath = opts.NodesPath

--- a/go/trajir/client/client_test.go
+++ b/go/trajir/client/client_test.go
@@ -227,3 +227,30 @@ func TestExecToolLogsToolCallOnError(t *testing.T) {
 		t.Fatalf("expected no TOOL_RESULT on error, got %v (err: %v)", hasResult, err)
 	}
 }
+
+func TestTrajectoryHistory(t *testing.T) {
+	dir := t.TempDir()
+	tr, err := client.OpenTrajectory("demo", "t-hist", client.Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Close()
+
+	if _, err := tr.Project(1, map[string]any{"goal": "history"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tr.SealDecision(1, map[string]any{"plan": "test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	history, err := tr.History()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("expected 2 nodes in history, got %d", len(history))
+	}
+	if history[0]["kind"] != "PROJECT_CONTEXT" || history[1]["kind"] != "DECISION" {
+		t.Fatalf("unexpected node kinds in history: %v", history)
+	}
+}

--- a/test/unit/test_client_sdk.py
+++ b/test/unit/test_client_sdk.py
@@ -3,6 +3,7 @@ import pytest
 from client.python.trajectory_client import (
     commit_step,
     exec_tool,
+    history,
     open_trajectory,
     project,
     seal_decision,
@@ -86,3 +87,15 @@ def test_trajectory_context_manager_and_close(db_path):
     # Once context manager exits, the connection should be closed
     with pytest.raises(sqlite3.ProgrammingError):
         conn.execute("SELECT 1")
+
+
+def test_trajectory_history(db_path):
+    traj = open_trajectory(tenant_id="demo", trajectory_id="test-hist", db_path=db_path)
+    project(traj, step_n=1, context={"initial": True})
+    seal_decision(traj, step_n=1, plan={"plan": "reuse"})
+
+    nodes = history(traj)
+    assert len(nodes) == 2
+    assert nodes[0]["kind"] == "PROJECT_CONTEXT"
+    assert nodes[1]["kind"] == "DECISION"
+    assert nodes[0]["payload"] == {"initial": True}


### PR DESCRIPTION
## Overview
This PR introduces a lightweight, read-only inspection capability to the client SDKs, allowing callers to retrieve the sequence of completed events (nodes) for a given trajectory.

Previously, the client SDK only exposed mutation methods (`project`, `exec_tool`, `commit_step`, etc.). To inspect the execution state, a caller would have to bypass the client abstraction and interact with the underlying `NodeLog` directly.

## Changes
Added a single, focused API to both SDKs:
- **Go:** `Trajectory.History() ([]map[string]any, error)`
- **Python:** `history(trajectory: Trajectory) -> list[dict[str, Any]]`

## Architecture & Safety
- **Zero new state-management logic:** Both implementations delegate directly to the existing, tenant-isolated `NodeLog.list_nodes` abstraction.
- **Backward-compatible:** No existing function signatures or structural behaviors were modified.
- **Focused testing:** Unit tests (`TestTrajectoryHistory` and `test_trajectory_history`) were added to verify strict node ordering and correct metadata retrieval in both Go and Python.
