### PR TITLE
docs: MkDocs demo site for conference showcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,10 @@ go/.tmp/
 go/.bin/
 *.test
 *.test.exe
+
+# MkDocs demo site build output
+website/site/
+
+# Local demo capture workdirs
+go/_demo_capture*/
+

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -279,6 +279,7 @@ Integration recipes and CI parity commands live in
 | Doc | Purpose |
 |-----|---------|
 | [go/QUICKSTART.md](go/QUICKSTART.md) | Phase 1B primary Go onboarding |
+| [website/README.md](website/README.md) | Demo / docs site (MkDocs) for talks and public showcase |
 | [docs/E2E_POSTGRES_CAS_THIN.md](docs/E2E_POSTGRES_CAS_THIN.md) | Full Postgres + CAS + thin package walkthrough |
 | [docs/PHASE_1A_STATUS.md](docs/PHASE_1A_STATUS.md) | What shipped in Phase 1A |
 | [docs/PHASE_1B_STATUS.md](docs/PHASE_1B_STATUS.md) | Go primary program (when present on branch) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | **Status** | `spec-v0.2-draft`. Supersedes the frozen `spec-v0.1` under the version bump process in §14. This revision narrows the project's scope from a standalone execution runtime to a semantics and portability layer over a pluggable, existing durable execution backend, see §3.1. |
 | **Precedence** | This document is authoritative. If any prior document, chat message, or verbal agreement conflicts with this file, this file wins. |
 
-**Project links:** [License (Apache-2.0)](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Contributing (DCO)](CONTRIBUTING.md) · [AI Usage Policy](AI_POLICY.md) · [Security](SECURITY.md) · [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Roadmap](docs/ROADMAP.md) · [Adopters](ADOPTERS.md) · [Third-party licenses](docs/THIRD_PARTY_LICENSES.md) · [Scope and non-goals](docs/SCOPE_AND_NON_GOALS.md) · [Quickstart (Go first)](go/QUICKSTART.md) · [CNCF Sandbox prep](docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md)
+**Project links:** [License (Apache-2.0)](LICENSE) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Contributing (DCO)](CONTRIBUTING.md) · [AI Usage Policy](AI_POLICY.md) · [Security](SECURITY.md) · [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Roadmap](docs/ROADMAP.md) · [Adopters](ADOPTERS.md) · [Third-party licenses](docs/THIRD_PARTY_LICENSES.md) · [Scope and non-goals](docs/SCOPE_AND_NON_GOALS.md) · [Quickstart (Go first)](go/QUICKSTART.md) · [Demo / docs site](website/README.md) · [CNCF Sandbox prep](docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md)
 
 ---
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,47 @@
+# Trajectory IR documentation / demo site
+
+MkDocs Material site for conference demos and public documentation.
+
+## Local preview
+
+```bash
+cd website
+python -m pip install -r requirements.txt
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000/`.
+
+## Refresh demo fixtures
+
+From repo root (requires Go):
+
+```powershell
+pwsh website/scripts/capture_demos.ps1
+```
+
+```bash
+bash website/scripts/capture_demos.sh
+```
+
+## Deploy
+
+Workflow template (checked in here because some OAuth tokens cannot push
+`.github/workflows/*` without the `workflow` scope):
+
+```bash
+cp website/docs-site.workflow.yml .github/workflows/docs-site.yml
+git add .github/workflows/docs-site.yml
+git commit -m "ci: enable docs site GitHub Pages workflow"
+git push
+```
+
+Or refresh credentials first:
+
+```bash
+gh auth refresh -h github.com -s workflow
+```
+
+Then enable **Settings → Pages → Build and deployment → GitHub Actions**.
+
+Expected URL shape: `https://coder-s-og-s.github.io/Trajectory-IR/`

--- a/website/docs-site.workflow.yml
+++ b/website/docs-site.workflow.yml
@@ -1,0 +1,59 @@
+name: Docs site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - ".github/workflows/docs-site.yml"
+  pull_request:
+    paths:
+      - "website/**"
+      - ".github/workflows/docs-site.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs
+        run: pip install -r website/requirements.txt
+
+      - name: Build site
+        working-directory: website
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/site
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -1,0 +1,35 @@
+# Architecture (talk-sized)
+
+## One diagram
+
+```text
++------------------------------------------------------------------+
+| Host applications / MCP clients                                  |
++------------------------+--------------------+--------------------+
+| Go client SDK          | Python client SDK  | MCP stdio tools    |
++------------------------+--------------------+--------------------+
+| Semantics core: nodes, seals, effects, resume matrix, projector  |
++------------------------+--------------------+--------------------+
+| Durable adapters       | NodeLog / CAS      | Package (.tir) IO  |
+| Temporal | DBOS        | SQLite / Postgres  | thin / fat / sign  |
++------------------------+--------------------+--------------------+
+| External engines and object stores                               |
++------------------------------------------------------------------+
+```
+
+## Boundary (say this out loud)
+
+| Layer | Owns |
+|---|---|
+| Temporal / DBOS / Restate | Crash detection, retries, leases, durable memo |
+| Trajectory IR | Node identity, seals, effect classes, block-and-gate, `.tir` portability |
+| Host app | Models, tools, product UX |
+
+## Non-goals (protect the pitch)
+
+- Not LangGraph / agent graph orchestration
+- Not a multi-tenant SaaS control plane
+- Not a long-term memory product
+- Not a reimplementation of Temporal
+
+Normative text: [README.md](https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/README.md), [SCOPE_AND_NON_GOALS.md](https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/docs/SCOPE_AND_NON_GOALS.md).

--- a/website/docs/demos/adoption-host.md
+++ b/website/docs/demos/adoption-host.md
@@ -1,0 +1,41 @@
+# Demo: Adoption host + thin `.tir`
+
+Shows a complete host-owned step using only the **public Go client**, then exports a **thin `.tir` package** with CAS and rehydrates the artifact.
+
+Source: [`go/examples/adoption_host`](https://github.com/Coder-s-OG-s/Trajectory-IR/tree/main/go/examples/adoption_host)
+
+## Story in one minute
+
+1. `OpenTrajectory` → `Project` → stub model → `SealDecision`
+2. Execute `build_manifest` (**PURE**) and `ship_release` (**NON_IDEMPOTENT_WRITE**)
+3. `CommitStep`
+4. With `-with-package`: put bytes in CAS, export thin `.tir`, rehydrate by content hash
+
+This is the **portability** beat for CNCF / cloud-native audiences: the audit artifact leaves the runtime.
+
+## Run it yourself
+
+From `go/`:
+
+```bash
+go run ./examples/adoption_host
+go run ./examples/adoption_host -with-package
+```
+
+## Captured output (fixture)
+
+```text
+--8<-- "adoption_host_package.txt"
+```
+
+!!! info "Read the node kinds"
+    `PROJECT_CONTEXT → DECISION → TOOL_CALL/RESULT → TOOL_CALL/RESULT → COMMIT_STEP` is the sealed step shape. The `.tir` preserves those identities for another runtime to verify.
+
+## Why thin packages matter
+
+| Mode | What travels |
+|---|---|
+| Thin | Manifest, nodes, seals, artifact **URIs / hashes** (CAS must hold bytes) |
+| Fat | Same metadata plus embedded `artifacts/cas/...` bytes |
+
+Default on stage: **thin + CAS** — closer to how operators share evidence without shipping giant archives.

--- a/website/docs/demos/index.md
+++ b/website/docs/demos/index.md
@@ -1,0 +1,37 @@
+# Demos
+
+These are the **conference-ready** Trajectory IR demos. They use the **Go primary SDK** and match Phase 1B messaging.
+
+| Demo | Claim it proves | Stage time | Command |
+|---|---|---|---|
+| [Kill mid deploy](kill-mid-deploy.md) | Seal + crash mid non-idempotent tool → honest gate, no silent re-deploy | 3–4 min | `go run ./examples/kill_mid_deploy ...` |
+| [Adoption host + `.tir`](adoption-host.md) | Host loop + thin package + CAS rehydrate | 2 min | `go run ./examples/adoption_host -with-package` |
+| [Sandbox mode](sandbox.md) | R06: reject real `NON_IDEMPOTENT_WRITE` in sandbox | 30–45 sec | `go run ./examples/adoption_host -sandbox` |
+
+## Recommended talk order
+
+```text
+1. Problem slide (duplicate deploy / re-inference after crash)
+2. Kill mid deploy (live or recorded)
+3. Adoption host -with-package (show portable .tir)
+4. Optional: sandbox reject
+5. Boundary slide (Temporal owns durability; IR owns seals + .tir)
+```
+
+## Captured terminal output
+
+Pages below embed **real captured stdout** from `go run` on this repository (fixtures under `website/fixtures/`). Refresh fixtures with:
+
+```powershell
+pwsh website/scripts/capture_demos.ps1
+```
+
+```bash
+bash website/scripts/capture_demos.sh
+```
+
+## What we are not demoing on stage
+
+- Full Temporal cluster boot (too heavy for a short talk; mention as production path)
+- Browser / WASM playground (not in scope yet)
+- Claiming CNCF Sandbox membership (prep only)

--- a/website/docs/demos/kill-mid-deploy.md
+++ b/website/docs/demos/kill-mid-deploy.md
@@ -1,0 +1,68 @@
+# Demo: Kill mid deploy
+
+**The hero demo.** Shows why Trajectory IR exists: a non-idempotent tool crashes mid-flight, and resume must not silently re-run the side effect or re-ask the model after the decision was sealed.
+
+Source: [`go/examples/kill_mid_deploy`](https://github.com/Coder-s-OG-s/Trajectory-IR/tree/main/go/examples/kill_mid_deploy)
+
+## Story in one minute
+
+1. Model produces a deploy plan → **DECISION sealed**
+2. `deploy_server` (`NON_IDEMPOTENT_WRITE`) starts
+3. Process is killed mid-tool
+4. On `-resume`: model is **not** called again; deploy is **not** blindly retried → `BLOCKED_NEEDS_GATE`
+5. Counters prove it: `model_count=1`, `deploy_count=0`
+
+## Run it yourself
+
+From `go/`:
+
+=== "First run (then kill)"
+
+    ```bash
+    go run ./examples/kill_mid_deploy \
+      -workdir ./kill_mid_deploy-data \
+      -crash-during=tool_call
+    ```
+
+    When you see `TOOL_CALL: deploy_server started`, kill the process (`Ctrl+C`, `kill -9`, or `Stop-Process` on Windows).
+
+=== "Resume"
+
+    ```bash
+    go run ./examples/kill_mid_deploy \
+      -workdir ./kill_mid_deploy-data \
+      -resume
+    ```
+
+## Captured output (fixture)
+
+### First run
+
+```text
+--8<-- "kill_mid_deploy_first.txt"
+```
+
+### Resume after kill
+
+```text
+--8<-- "kill_mid_deploy_resume.txt"
+```
+
+!!! success "What the audience should hear"
+    Durable engines keep the workflow alive. Trajectory IR makes the **agent decision and tool safety** honest across that resume: seals freeze the plan; block-and-gate stops a duplicate deploy.
+
+## Alternate mode (R01 style)
+
+Crash **after** seal, before tools complete:
+
+```bash
+go run ./examples/kill_mid_deploy \
+  -workdir ./kill_mid_deploy-data2 \
+  -crash-after=decision_sealed
+# kill after DECISION sealed
+go run ./examples/kill_mid_deploy \
+  -workdir ./kill_mid_deploy-data2 \
+  -resume
+```
+
+Expect `model_count=1` across both runs and a completed deploy on resume (`deploy_count=1`).

--- a/website/docs/demos/sandbox.md
+++ b/website/docs/demos/sandbox.md
@@ -1,0 +1,25 @@
+# Demo: Sandbox mode (R06)
+
+Fast safety demo. In sandbox mode, real `NON_IDEMPOTENT_WRITE` tools are rejected **before** side effects.
+
+Source: same adoption host with `-sandbox`
+
+## Run it yourself
+
+From `go/`:
+
+```bash
+go run ./examples/adoption_host -sandbox
+```
+
+## Captured output (fixture)
+
+```text
+--8<-- "adoption_host_sandbox.txt"
+```
+
+## Why show this
+
+- Maps cleanly to “what-if / dry-run” branches in agent systems
+- Aligns with MCP-style safety hints, with IR fail-closed defaults when metadata is missing
+- Thirty-second stage beat after the crash-resume story

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -1,0 +1,35 @@
+# Getting started
+
+Phase 1B default path is **Go**. Full detail lives in the repo:
+
+- [go/QUICKSTART.md](https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/go/QUICKSTART.md)
+- Root [QUICKSTART.md](https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/QUICKSTART.md) (Go first, Python reference below)
+
+## Prerequisites
+
+- Go 1.22+ (repo CI tracks current stable)
+- Git clone of [Coder-s-OG-s/Trajectory-IR](https://github.com/Coder-s-OG-s/Trajectory-IR)
+
+## First success (under 15 minutes)
+
+```bash
+git clone https://github.com/Coder-s-OG-s/Trajectory-IR.git
+cd Trajectory-IR/go
+go run ./examples/adoption_host -with-package
+```
+
+Then run the hero crash story:
+
+```bash
+go run ./examples/kill_mid_deploy \
+  -workdir ./kill_mid_deploy-data \
+  -crash-during=tool_call
+# kill when TOOL_CALL starts
+go run ./examples/kill_mid_deploy \
+  -workdir ./kill_mid_deploy-data \
+  -resume
+```
+
+## Python reference
+
+Python remains the Phase 1A reference / parity port (`examples/`, `client/python/`). Prefer Go for new demos and drivers unless you are explicitly working on Python parity.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,0 +1,37 @@
+# Trajectory IR
+
+**Portable, hash-verifiable intermediate representation for agent execution trajectories.**
+
+Trajectory IR sits **on top of** durable execution engines. It does not replace Temporal, DBOS, or Restate. It seals model decisions, classifies tool effects, and exports a runtime-independent `.tir` package that auditors and peer agents can verify by content hash.
+
+!!! tip "Live demos for talks and docs"
+    Start here: **[Demos](demos/index.md)** — crash-safe resume, portable `.tir` export, and sandbox rejection. These are the same Go examples we run on stage.
+
+## What you get
+
+| Capability | Why it matters |
+|---|---|
+| Sealed decisions | Resume does not silently re-ask the model for a sealed step |
+| Effect classes | Fail-closed mapping for tools (including MCP-aligned hints) |
+| Block-and-gate | Non-idempotent tools do not double-fire after a mid-flight crash |
+| `.tir` packages | Thin or fat portable evidence with hash verification |
+| Dual SDK | **Go primary**, Python reference / parity |
+
+## Stack at a glance
+
+- **Languages:** Go (primary SDK), Python (reference)
+- **Durable backends:** Temporal (Go production), DBOS (Python reference)
+- **Storage:** SQLite / Postgres NodeLog, filesystem or S3 / MinIO CAS
+- **Interop:** Model Context Protocol (MCP) stdio tools under `TRAJIR_MCP_ROOT`
+
+## CNCF note (honest)
+
+This project maintains a [CNCF Sandbox application outline](https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md) and process pack (maintainers, governance, roadmap, DCO, security).
+
+**We do not claim CNCF membership or “donated to CNCF” status** until the TOC votes Approved and the contribution agreement is signed. On stage and on this site we say: *open source, Apache 2.0, preparing for Sandbox*.
+
+## Next steps
+
+1. [Watch the demos](demos/index.md)
+2. [Run the Go quickstart](getting-started.md)
+3. [Speaker runbook](talk/speaker-runbook.md) for conference delivery

--- a/website/docs/talk/pitch.md
+++ b/website/docs/talk/pitch.md
@@ -1,0 +1,28 @@
+# Conference pitch (stable wording)
+
+## One sentence
+
+Trajectory IR is a portable, hash-verifiable intermediate representation for agent execution trajectories (typed nodes, sealed decisions, effect classes, thin/fat `.tir` packages) that runs **on top of** existing durable execution backends — not a replacement for Temporal, DBOS, or agent frameworks.
+
+## What the room should remember
+
+| Message | Proof in demo |
+|---|---|
+| Cloud-native fit | Agents on K8s/cloud need portable audit/export across runtimes |
+| Novel gap | Runtime-independent, effect-safe unit of “what the agent did” |
+| Non-overlap | Engines own crash/retry; we own seals + portability |
+| Spec-shaped | Conformance R01–R08; dual SDK (Go primary / Python reference) |
+
+## CNCF Sandbox wording (do not improvise)
+
+Use:
+
+> We are an Apache 2.0 open source project preparing a CNCF Sandbox application. We are not a CNCF project until the TOC approves and the contribution agreement is signed.
+
+Avoid:
+
+- “We are in CNCF Sandbox”
+- “Donated to the CNCF”
+- “Official CNCF project”
+
+Checklist and form map: [docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md](https://github.com/Coder-s-OG-s/Trajectory-IR/blob/main/docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md).

--- a/website/docs/talk/speaker-runbook.md
+++ b/website/docs/talk/speaker-runbook.md
@@ -1,0 +1,62 @@
+# Speaker runbook (KubeCon / KCD Ahmedabad)
+
+Audience assumption: cloud-native / platform / AI infra engineers. Time box: **20–30 minutes** including Q&A.
+
+## Pre-flight (day before)
+
+- [ ] Laptop on power; Go toolchain works: `cd go && go run ./examples/adoption_host`
+- [ ] Clean demo dirs removed so counters start fresh
+- [ ] Terminal font large (24+); dark theme; hide secrets in shell history
+- [ ] Backup: this docs site open on phone/hotspot with embedded fixtures
+- [ ] Slide deck has the boundary table (engines vs IR vs host)
+- [ ] Do **not** claim CNCF membership; say “Apache 2.0, preparing for CNCF Sandbox”
+
+## Stage sequence (optimized)
+
+| Minute | Beat | Action |
+|---|---|---|
+| 0–3 | Problem | Duplicate deploy / re-inference after crash; checkpoint lock-in |
+| 3–6 | Pitch | Portable IR on top of Temporal/DBOS; seals + effects + `.tir` |
+| 6–12 | Live A | [Kill mid deploy](../demos/kill-mid-deploy.md) |
+| 12–16 | Live B | [Adoption host `-with-package`](../demos/adoption-host.md) |
+| 16–18 | Optional | [Sandbox](../demos/sandbox.md) (skip if time-tight) |
+| 18–22 | Architecture | Layers + non-goals |
+| 22–30 | Q&A | Point to repo + this site |
+
+## Live command cheat sheet
+
+```bash
+cd go
+
+# A — crash mid tool
+go run ./examples/kill_mid_deploy -workdir ./kmd -crash-during=tool_call
+# kill when TOOL_CALL starts
+go run ./examples/kill_mid_deploy -workdir ./kmd -resume
+
+# B — portable package
+go run ./examples/adoption_host -with-package
+
+# C — sandbox
+go run ./examples/adoption_host -sandbox
+```
+
+## If live demo fails
+
+1. Switch to **fixture terminals** on this site (already captured stdout).
+2. Narrate counters: `model_count=1`, `deploy_count=0`, `BLOCKED_NEEDS_GATE`.
+3. Do not debug Temporal on stage.
+
+## Talking points that land with CNCF audiences
+
+- Complementary to durable execution, not competitive
+- Spec-shaped: conformance R01–R08
+- Go primary SDK; Python reference
+- Portable evidence (`.tir`) for audit / multi-agent handoff
+- Fail-closed effect classification
+
+## Links to hand out
+
+- Repo: `https://github.com/Coder-s-OG-s/Trajectory-IR`
+- Go quickstart: `go/QUICKSTART.md`
+- CNCF prep (honest): `docs/CNCF_SANDBOX_APPLICATION_OUTLINE.md`
+- This demo site (after Pages deploy): `https://coder-s-og-s.github.io/Trajectory-IR/`

--- a/website/fixtures/adoption_host_package.txt
+++ b/website/fixtures/adoption_host_package.txt
@@ -1,0 +1,9 @@
+adoption host step complete
+  tool results: [map[release:1.0.0 service:api status:ready] map[shipped:api:1.0.0]]
+  node kinds:   [PROJECT_CONTEXT DECISION TOOL_CALL TOOL_RESULT TOOL_CALL TOOL_RESULT COMMIT_STEP]
+thin package path complete
+  tir:          /tmp/adoption-run.tir
+  content_hash: c0c9a85f4abae44deba0e0dc11691be93629e66a7110a4dda28758483f2814f0
+  logical_path: outputs/release-report.json
+  node_count:   7
+  rehydrate:    369 bytes ok

--- a/website/fixtures/adoption_host_sandbox.txt
+++ b/website/fixtures/adoption_host_sandbox.txt
@@ -1,0 +1,1 @@
+sandbox correctly rejected non idempotent tool: SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE: tool "ship_release" effect=NON_IDEMPOTENT_WRITE is forbidden in sandbox mode

--- a/website/fixtures/kill_mid_deploy_first.txt
+++ b/website/fixtures/kill_mid_deploy_first.txt
@@ -1,0 +1,7 @@
+Trajectory IR Go demo: kill mid deploy
+workdir: ./kill_mid_deploy-data
+mode: first run
+INFERENCE: model produced a deploy plan
+DECISION sealed (plan frozen; resume must not re-ask the model for this step)
+TOOL_CALL: deploy_server started
+>>> Kill this process now (Ctrl+C or kill -9 / taskkill), then re-run with -resume

--- a/website/fixtures/kill_mid_deploy_resume.txt
+++ b/website/fixtures/kill_mid_deploy_resume.txt
@@ -1,0 +1,7 @@
+Trajectory IR Go demo: kill mid deploy
+workdir: ./kill_mid_deploy-data
+mode: resume
+DECISION sealed (plan frozen; resume must not re-ask the model for this step)
+BLOCKED_NEEDS_GATE: step 1: 'deploy_server' BLOCKED_NEEDS_GATE (crashed mid-execution, not retried)
+Honest resume: non idempotent deploy was not silently re-run.
+model_count=1 deploy_count=0

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,0 +1,81 @@
+site_name: Trajectory IR
+site_description: Portable, hash-verifiable intermediate representation for agent execution trajectories
+site_url: https://coder-s-og-s.github.io/Trajectory-IR/
+repo_url: https://github.com/Coder-s-OG-s/Trajectory-IR
+repo_name: Coder-s-OG-s/Trajectory-IR
+edit_uri: edit/main/website/docs/
+copyright: Apache 2.0 · Trajectory IR maintainers
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - content.code.copy
+    - content.tabs.link
+    - search.suggest
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - tags
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path:
+        - fixtures
+        - docs
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Coder-s-OG-s/Trajectory-IR
+
+nav:
+  - Home: index.md
+  - Demos:
+      - Overview: demos/index.md
+      - Kill mid deploy: demos/kill-mid-deploy.md
+      - Adoption host + .tir: demos/adoption-host.md
+      - Sandbox mode: demos/sandbox.md
+  - Getting started: getting-started.md
+  - Architecture: architecture.md
+  - Talk:
+      - Speaker runbook: talk/speaker-runbook.md
+      - Conference pitch: talk/pitch.md

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5.0,<10
+pymdown-extensions>=10.0

--- a/website/scripts/capture_demos.ps1
+++ b/website/scripts/capture_demos.ps1
@@ -1,0 +1,59 @@
+# Capture Go demo stdout into website/fixtures for docs embeds.
+# Run from repo root: pwsh website/scripts/capture_demos.ps1
+
+$ErrorActionPreference = "Stop"
+$Root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$Go = Join-Path $Root "go"
+$Fix = Join-Path $Root "website\fixtures"
+New-Item -ItemType Directory -Force -Path $Fix | Out-Null
+
+Push-Location $Go
+try {
+  Write-Host "Capturing adoption_host -with-package..."
+  $pkg = & go run ./examples/adoption_host -with-package 2>&1 | Out-String
+  # Normalize temp paths for stable fixtures
+  $pkg = $pkg -replace "(?m)tir:\s+.+$", "tir:          /tmp/adoption-run.tir"
+  Set-Content -Encoding utf8 (Join-Path $Fix "adoption_host_package.txt") $pkg.TrimEnd()
+
+  Write-Host "Capturing adoption_host -sandbox..."
+  $sb = & go run ./examples/adoption_host -sandbox 2>&1 | Out-String
+  Set-Content -Encoding utf8 (Join-Path $Fix "adoption_host_sandbox.txt") $sb.TrimEnd()
+
+  Write-Host "Capturing kill_mid_deploy (crash + resume)..."
+  $wd = Join-Path $Go "_demo_capture_site"
+  if (Test-Path $wd) { Remove-Item -Recurse -Force $wd }
+  New-Item -ItemType Directory -Force -Path $wd | Out-Null
+
+  $firstOut = Join-Path $wd "first.txt"
+  $firstErr = Join-Path $wd "first.err"
+  $p = Start-Process -FilePath "go" `
+    -ArgumentList @("run", "./examples/kill_mid_deploy", "-workdir", $wd, "-crash-during=tool_call") `
+    -WorkingDirectory $Go -PassThru -NoNewWindow `
+    -RedirectStandardOutput $firstOut -RedirectStandardError $firstErr
+
+  $deadline = (Get-Date).AddSeconds(90)
+  while ((Get-Date) -lt $deadline) {
+    if (Test-Path (Join-Path $wd "tool_started.marker")) { break }
+    Start-Sleep -Milliseconds 400
+  }
+  if (-not (Test-Path (Join-Path $wd "tool_started.marker"))) {
+    throw "Timed out waiting for TOOL_CALL start marker"
+  }
+
+  Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 1
+
+  $resume = & go run ./examples/kill_mid_deploy -workdir $wd -resume 2>&1 | Out-String
+  $first = (Get-Content $firstOut -Raw)
+
+  $first = $first -replace [regex]::Escape($wd), "./kill_mid_deploy-data"
+  $resume = $resume -replace [regex]::Escape($wd), "./kill_mid_deploy-data"
+
+  Set-Content -Encoding utf8 (Join-Path $Fix "kill_mid_deploy_first.txt") $first.TrimEnd()
+  Set-Content -Encoding utf8 (Join-Path $Fix "kill_mid_deploy_resume.txt") $resume.TrimEnd()
+
+  Write-Host "Fixtures written to $Fix"
+}
+finally {
+  Pop-Location
+}

--- a/website/scripts/capture_demos.sh
+++ b/website/scripts/capture_demos.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Capture Go demo stdout into website/fixtures for docs embeds.
+# Run from repo root: bash website/scripts/capture_demos.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+GO_DIR="$ROOT/go"
+FIX="$ROOT/website/fixtures"
+mkdir -p "$FIX"
+
+cd "$GO_DIR"
+
+echo "Capturing adoption_host -with-package..."
+go run ./examples/adoption_host -with-package 2>&1 \
+  | sed -E 's|tir:[[:space:]]+.+$|tir:          /tmp/adoption-run.tir|' \
+  > "$FIX/adoption_host_package.txt"
+
+echo "Capturing adoption_host -sandbox..."
+go run ./examples/adoption_host -sandbox 2>&1 > "$FIX/adoption_host_sandbox.txt" || true
+
+echo "Capturing kill_mid_deploy (crash + resume)..."
+WD="$GO_DIR/_demo_capture_site"
+rm -rf "$WD"
+mkdir -p "$WD"
+
+go run ./examples/kill_mid_deploy -workdir "$WD" -crash-during=tool_call \
+  >"$WD/first.txt" 2>"$WD/first.err" &
+PID=$!
+
+for _ in $(seq 1 225); do
+  if [[ -f "$WD/tool_started.marker" ]]; then
+    break
+  fi
+  sleep 0.4
+done
+
+if [[ ! -f "$WD/tool_started.marker" ]]; then
+  kill -9 "$PID" 2>/dev/null || true
+  echo "Timed out waiting for TOOL_CALL start marker" >&2
+  exit 1
+fi
+
+kill -9 "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+sleep 1
+
+go run ./examples/kill_mid_deploy -workdir "$WD" -resume 2>&1 >"$WD/resume.txt"
+
+sed "s|$WD|./kill_mid_deploy-data|g" "$WD/first.txt" > "$FIX/kill_mid_deploy_first.txt"
+sed "s|$WD|./kill_mid_deploy-data|g" "$WD/resume.txt" > "$FIX/kill_mid_deploy_resume.txt"
+
+echo "Fixtures written to $FIX"


### PR DESCRIPTION
## Summary

MkDocs Material site under `website/` for conference demos and public docs. Real captured Go demo output for kill mid deploy, adoption host + thin `.tir`, and sandbox. Speaker runbook included. Pages workflow ships as `website/docs-site.workflow.yml` so merge does not require `workflow` OAuth scope on the pusher.

Reopened with DCO sign-off after the earlier close on #298.

## Related issues

Adoption / demo surface for talks. Not CNCF membership.

## How I tested

```bash
cd website
python -m pip install -r requirements.txt
mkdocs build --strict
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

- [x] No. Docs/demo site only. Workflow file stays under `website/` as a copy-in template.

## AI assistance (if any)

Editor help on the site scaffold. Demo fixtures come from the Go examples.
