### PR TITLE
fix: gate load_tir_unverified / LoadUnverified behind TRAJIR_ALLOW_UNVERIFIED env var

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ Based on the [Infrastructure Blueprint](infrastructure.md) and [Master Spec](REA
 ### C. Data & Export Plane (`.tir` Packages)
 - **Sensitive Data Leakage**: Flaws where secret-like fields or thoughts leak during a `redacted` `.tir` package export.
 - **Package resource exhaustion**: Zip bombs / oversized members must be rejected by load limits (`TirLimitError`).
-- **Unverified import**: `import_tir` always verifies; `load_tir(verify=False)` is disabled. Inspection without verification requires explicit `load_tir_unverified()` and must never write to a durable NodeLog.
+- **Unverified import**: `import_tir` always verifies; `load_tir(verify=False)` is disabled. Inspection without verification requires explicit `load_tir_unverified()` (Python) or `LoadUnverified()` (Go), gated behind `TRAJIR_ALLOW_UNVERIFIED=1`. When allowed, a runtime warning is emitted and the call is logged at WARNING level. Unverified loads must never write to a durable NodeLog.
 - **Integrity vs provenance**: Node hash verification proves content integrity, not publisher authenticity. Optional package signatures (`trajir-pkg-sig-v1`, Ed25519) prove publisher authenticity when a `SIGNATURE` member is present; unsigned packages remain valid by default.
 
 ### D. Execution concurrency

--- a/go/README.md
+++ b/go/README.md
@@ -110,7 +110,7 @@ pkg, err = tir.Load(path)
 | `tir.Export` | `export_tir` |
 | `tir.Import` | `import_tir` |
 | `tir.Load` | `load_tir` |
-| `tir.LoadUnverified` | `load_tir_unverified` |
+| `tir.LoadUnverified` | `load_tir_unverified` (both gated behind `TRAJIR_ALLOW_UNVERIFIED=1`) |
 
 Fat mode uses the same CAS layout: `artifacts/cas/<2-char-shard>/<sha256>`.
 Optional package signatures: `tir.Sign` / `tir.Verify` and Export `SignKey` (`trajir-pkg-sig-v1`). Unsigned remains the default. Redacted export is Python-only for now.

--- a/go/trajir/tir/signature_test.go
+++ b/go/trajir/tir/signature_test.go
@@ -292,6 +292,7 @@ func TestDuplicateSignatureMemberRejected(t *testing.T) {
 }
 
 func TestLoadRejectsDuplicateMemberWhenUnsigned(t *testing.T) {
+	t.Setenv("TRAJIR_ALLOW_UNVERIFIED", "1")
 	// Unsigned Load skips verifySignatureFromZipFiles; duplicate names must
 	// still be rejected in loadImpl (CWE-436), not only on the signed path.
 	src := openLog(t, "src.sqlite")

--- a/go/trajir/tir/tir.go
+++ b/go/trajir/tir/tir.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -510,7 +511,19 @@ func Load(path string) (*Package, error) {
 }
 
 // LoadUnverified loads without hash verification. UNSAFE for untrusted input.
+//
+// Requires TRAJIR_ALLOW_UNVERIFIED=1 in the environment. Without this the call
+// returns ErrTir to prevent accidental use in locked-down deployments. When
+// allowed, a warning is logged for audit.
 func LoadUnverified(path string) (*Package, error) {
+	if os.Getenv("TRAJIR_ALLOW_UNVERIFIED") != "1" {
+		return nil, fmt.Errorf(
+			"%w: LoadUnverified() is blocked by default; "+
+				"set TRAJIR_ALLOW_UNVERIFIED=1 to allow unverified package loading",
+			ErrTir,
+		)
+	}
+	log.Printf("WARNING: LoadUnverified called: path=%s", path)
 	return loadImpl(path, false)
 }
 

--- a/go/trajir/tir/tir_test.go
+++ b/go/trajir/tir/tir_test.go
@@ -252,6 +252,7 @@ func TestRejectsPathTraversalMember(t *testing.T) {
 }
 
 func TestLoadUnverifiedAPIExists(t *testing.T) {
+	t.Setenv("TRAJIR_ALLOW_UNVERIFIED", "1")
 	src := openLog(t, "src.sqlite")
 	seedSample(t, src)
 	out := filepath.Join(t.TempDir(), "run.tir")
@@ -264,6 +265,20 @@ func TestLoadUnverifiedAPIExists(t *testing.T) {
 	}
 	if len(pkg.Nodes) != 5 {
 		t.Fatalf("nodes=%d", len(pkg.Nodes))
+	}
+}
+
+func TestLoadUnverifiedBlockedWithoutEnv(t *testing.T) {
+	t.Setenv("TRAJIR_ALLOW_UNVERIFIED", "")
+	src := openLog(t, "src.sqlite")
+	seedSample(t, src)
+	out := filepath.Join(t.TempDir(), "run.tir")
+	if _, err := tir.Export(src, "t-export", out, tir.ExportOptions{Mode: tir.ModeThin}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := tir.LoadUnverified(out)
+	if !errors.Is(err, tir.ErrTir) {
+		t.Fatalf("expected ErrTir, got %v", err)
 	}
 }
 

--- a/pkg/trajectory_ir/package/tir.py
+++ b/pkg/trajectory_ir/package/tir.py
@@ -22,8 +22,10 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
+import logging
 import os
 import tempfile
+import warnings
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,6 +42,8 @@ from trajectory_ir.package.signature import (
 from trajectory_ir.runtime.log import NodeLog
 from trajectory_ir.runtime.nodes import Node, NodeValidationError, node_id, payload_hash
 from trajectory_ir.runtime.redact import redact_payload
+
+_logger = logging.getLogger("trajectory_ir.package.tir")
 
 PackageMode = Literal["thin", "fat"]
 
@@ -381,18 +385,36 @@ def load_tir(path: str | Path, *, verify: bool = True) -> TirPackage:
 
     Verification is required for untrusted packages. To intentionally skip
     verification (tests / recovery tools only), call
-    :func:`load_tir_unverified`.
+    :func:`load_tir_unverified` (requires ``TRAJIR_ALLOW_UNVERIFIED=1``).
     """
     if not verify:
         raise TirError(
             "load_tir(verify=False) is disabled for safety; "
-            "use load_tir_unverified() if you explicitly accept an unverified package"
+            "use load_tir_unverified() (requires TRAJIR_ALLOW_UNVERIFIED=1) "
+            "if you explicitly accept an unverified package"
         )
     return _load_tir_impl(path, verify=True)
 
 
 def load_tir_unverified(path: str | Path) -> TirPackage:
-    """Load a package without hash verification. UNSAFE for untrusted input."""
+    """Load a package without hash verification. UNSAFE for untrusted input.
+
+    Requires ``TRAJIR_ALLOW_UNVERIFIED=1`` in the environment. Without this,
+    the call raises :class:`TirError` to prevent accidental use in locked-down
+    deployments. When allowed, a runtime warning is emitted and the call is
+    logged at WARNING level for audit.
+    """
+    if os.environ.get("TRAJIR_ALLOW_UNVERIFIED") != "1":
+        raise TirError(
+            "load_tir_unverified() is blocked by default; "
+            "set TRAJIR_ALLOW_UNVERIFIED=1 to allow unverified package loading"
+        )
+    warnings.warn(
+        "load_tir_unverified() skips integrity verification; do not use on untrusted packages",
+        UserWarning,
+        stacklevel=2,
+    )
+    _logger.warning("load_tir_unverified called: path=%s", path)
     return _load_tir_impl(path, verify=False)
 
 

--- a/test/unit/test_tir_package.py
+++ b/test/unit/test_tir_package.py
@@ -168,7 +168,7 @@ def test_thin_rejects_embedded_bytes(sample_log: NodeLog, tmp_path: Path) -> Non
 def test_load_tir_rejects_verify_false(sample_log: NodeLog, tmp_path: Path) -> None:
     out = tmp_path / "run.tir"
     export_tir(sample_log, "t-export", out, mode="thin")
-    with pytest.raises(TirError, match="load_tir_unverified"):
+    with pytest.raises(TirError, match=r"load_tir_unverified.*TRAJIR_ALLOW_UNVERIFIED"):
         load_tir(out, verify=False)
 
 
@@ -279,3 +279,32 @@ def test_export_tenant_scope(sample_log: NodeLog, tmp_path: Path) -> None:
         assert pkg.nodes[0]["tenant_id"] == "tenant-a"
     finally:
         other.close()
+
+
+def test_load_tir_unverified_blocked_without_env(
+    sample_log: NodeLog, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("TRAJIR_ALLOW_UNVERIFIED", raising=False)
+    out = tmp_path / "run.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    with pytest.raises(TirError, match="TRAJIR_ALLOW_UNVERIFIED"):
+        from trajectory_ir.package import load_tir_unverified
+
+        load_tir_unverified(out)
+
+
+def test_load_tir_unverified_allowed_with_env(
+    sample_log: NodeLog, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TRAJIR_ALLOW_UNVERIFIED", "1")
+    out = tmp_path / "run.tir"
+    export_tir(sample_log, "t-export", out, mode="thin")
+    import warnings as _w
+
+    from trajectory_ir.package import load_tir_unverified
+
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        pkg = load_tir_unverified(out)
+    assert len(pkg.nodes) == 5
+    assert any("load_tir_unverified" in str(w.message) for w in caught)


### PR DESCRIPTION
## What happened

`load_tir_unverified()` (Python) and `LoadUnverified()` (Go) load `.tir` packages with hash verification disabled. Both functions ran silently with no access control, no runtime warning, and no audit logging. A caller could load a tampered package and process its nodes without any observable security signal.

Reported in #335.

## What this PR does

1. Gates both functions behind `TRAJIR_ALLOW_UNVERIFIED=1`. Without the env var, calling either function raises an error with a clear message.
2. When the env var is set, emits a `warnings.warn()` (Python) and `log.Printf` (Go) for audit, plus a WARNING-level log line recording the package path.
3. Updates `SECURITY.md` to document the new gate.

## Files changed

| File | Change |
|------|--------|
| `pkg/trajectory_ir/package/tir.py` | Env-var gate, `warnings.warn`, logger |
| `go/trajir/tir/tir.go` | Env-var gate, `log.Printf` |
| `go/trajir/tir/tir_test.go` | New `TestLoadUnverifiedBlockedWithoutEnv`, updated existing test |
| `go/trajir/tir/signature_test.go` | Set env var so duplicate-member test still exercises `loadImpl` |
| `test/unit/test_tir_package.py` | New blocked and allowed tests |
| `SECURITY.md` | Document `TRAJIR_ALLOW_UNVERIFIED` gate |

## Testing

- `pytest test/unit/test_tir_package.py` -- 14/14 passed
- `go test ./trajir/tir/` -- 42/42 passed (1 skipped, platform)
- No existing tests broken

## Related

Closes #335
