### PR TITLE
build(deps): update pymdown-extensions requirement from >=10.0 to >=11.0.2

### DIFF
--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs-material>=9.7.7,<10
-pymdown-extensions>=10.0
+pymdown-extensions>=11.0.2


### PR DESCRIPTION
Rebased re-creation of #341, which conflicted with #340 after it merged. Same content change: bump pymdown-extensions lower bound to 11.0.2.