### PR TITLE
chore: prepare v0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-07
+
 ### Added
 
 - MCP: in-tree Trajectory IR server (`go/trajir/mcp`, `go/cmd/trajir-mcp`) with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trajectory-ir"
-version = "0.2.1"
+version = "0.2.2"
 description = "Portable, hash-verifiable intermediate representation for agent runs (seals, effects, .tir packages)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bumps the version to 0.2.2 and closes out the Unreleased changelog section, so a release tag can be cut for this commit. This unblocks the trajirctl prep work: it needs a go/v0.2.2 module tag alongside the usual v0.2.2 tag so the new trajirctl repo can depend on a real semver version instead of a commit SHA.

## Related issues

Prep work item from the trajirctl design spec (§2.2), not tied to a numbered issue.

## How I tested

No code changes, only version metadata and changelog. Confirmed pyproject.toml parses correctly and the CHANGELOG still renders as valid Keep a Changelog format.

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes (call it out here)

## AI assistance (if any)

I used Claude to help draft the changelog reorganization, then reviewed it myself before opening this PR.