### PR TITLE
fix(sandbox): block AGENT_SPAWN and SENSITIVE in sandbox mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       - name: govulncheck
         working-directory: go
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...
 
   # ---- Deep gate: required, allowed to run slower ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `go/trajir/mcp` into a new `go/trajir/workdir` package. `trajir-mcp`'s
   CWE-73 root-confinement policy is unchanged and now calls the extracted
   package; no external behavior change.
+- Sandbox error string renamed from `SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE` to
+  `SANDBOX_FORBIDDEN` (#347). Callers matching the old substring should update.
 
 ### Fixed
 
@@ -209,7 +211,8 @@ First library-tagged release of the Phase 1A surface: dual-language IR, portable
   conformance + Go tests; only NON_IDEMPOTENT_WRITE is gated.
 - R04 default context projector (`project_context` / `trajir/projector`) with
   CONSTRAINT+pinned budget safety and `BUDGET_IMPOSSIBLE` (RFC 8785 size metric).
-- R06 sandbox mode (`RunMode.SANDBOX`) rejects NON_IDEMPOTENT_WRITE before side effects.
+- R06 sandbox mode (`RunMode.SANDBOX`) rejects `NON_IDEMPOTENT_WRITE`,
+  `AGENT_SPAWN`, and `SENSITIVE` before side effects.
 - R07 `graft_artifact_ref` / `trajir/graft` transfers artifact refs only (never THOUGHT).
 - R08 projection redaction (`runtime/redact`, `trajir/redact`); shared with `.tir` redacted export.
 - Maintainer release notes and process: `docs/RELEASE.md`, `docs/RELEASE_NOTES_0.1.0.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sandbox error string renamed from `SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE` to
+  `SANDBOX_FORBIDDEN` (#347). Callers matching the old substring should update.
+- Sandbox mode rejects `AGENT_SPAWN` and `SENSITIVE` effects in addition to
+  `NON_IDEMPOTENT_WRITE` (#347).
+
 ## [0.2.2] - 2026-09-07
 
 ### Added
@@ -50,8 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `go/trajir/mcp` into a new `go/trajir/workdir` package. `trajir-mcp`'s
   CWE-73 root-confinement policy is unchanged and now calls the extracted
   package; no external behavior change.
-- Sandbox error string renamed from `SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE` to
-  `SANDBOX_FORBIDDEN` (#347). Callers matching the old substring should update.
 
 ### Fixed
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -65,7 +65,8 @@ def echo(msg: str) -> str:
 
 
 traj = open_trajectory(tenant_id="demo", trajectory_id="qs-1", db_path="qs.sqlite")
-# Optional sandbox (R06): open_trajectory(..., mode="sandbox")  # rejects NON_IDEMPOTENT_WRITE
+# Optional sandbox (R06): open_trajectory(..., mode="sandbox")
+# rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, and SENSITIVE
 
 project(traj, step_n=1, context={"goal": "hello"})
 seal_decision(traj, step_n=1, plan={"tool_calls": [{"name": "echo", "args": {"msg": "hi"}}]})
@@ -138,8 +139,8 @@ from trajectory_ir.effects import EffectClass
 from trajectory_ir.runtime.tool import Tool
 
 traj = open_trajectory("demo", "sandbox-1", db_path="s.sqlite", mode="sandbox")
-# NON_IDEMPOTENT_WRITE → SandboxForbidden before the tool body runs
-# PURE / READ_ONLY / etc. still allowed
+# NON_IDEMPOTENT_WRITE, AGENT_SPAWN, SENSITIVE → SandboxForbidden
+# PURE / READ_ONLY / IDEMPOTENT_WRITE still allowed
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ These are runnable tests, not descriptions of intent. R01 and R02 are the hard g
 | R03 | A `PURE` tool may be recomputed freely on resume. Runnable: `conformance/r03_pure_recompute_test.py` (and Go `go test ./trajir/resume -run R03`). |
 | R04 | A `CONSTRAINT` node is never silently dropped under budget pressure; the system either includes it or raises a hard error. Runnable: `conformance/r04_constraint_budget_test.py` (and Go `go test ./trajir/projector`). |
 | R05 | Export and re import of a `.tir` package preserves all node hashes and seals exactly. Runnable: `conformance/r05_tir_roundtrip_test.py` (and Go `go test ./trajir/tir`). |
-| R06 | A sandbox/what if branch rejects any real `NON_IDEMPOTENT_WRITE` execution. Runnable: `conformance/r06_sandbox_test.py`. |
+| R06 | A sandbox/what-if branch rejects `NON_IDEMPOTENT_WRITE`, `AGENT_SPAWN`, and `SENSITIVE` effects before the tool body runs. Runnable: `conformance/r06_sandbox_test.py`. |
 | R07 | Grafting an artifact between agents transfers only the artifact reference, never private `THOUGHT` nodes. Runnable: `conformance/r07_graft_test.py`. |
 | R08 | Redaction removes secrets/flagged content from what gets projected into context. Runnable: `conformance/r08_projection_redaction_test.py`. |
 | R09 | Sign a thin package; verify succeeds; mutate one byte of `nodes.ndjson`; verify fails. Runnable: `conformance/r09_tir_signature_test.py`. |

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -73,7 +73,11 @@ def open_trajectory(
     *,
     mode: RunMode | str = RunMode.LIVE,
 ) -> Trajectory:
-    """Open a trajectory. ``mode="sandbox"`` rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, and SENSITIVE tools (R06)."""
+    """Open a trajectory.
+
+    ``mode="sandbox"`` rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN,
+    and SENSITIVE tools (R06).
+    """
     init_backend(app_name=trajectory_id)
     return Trajectory(
         trajectory_id=trajectory_id,

--- a/client/python/trajectory_client.py
+++ b/client/python/trajectory_client.py
@@ -73,7 +73,7 @@ def open_trajectory(
     *,
     mode: RunMode | str = RunMode.LIVE,
 ) -> Trajectory:
-    """Open a trajectory. ``mode=\"sandbox\"`` rejects NON_IDEMPOTENT_WRITE tools (R06)."""
+    """Open a trajectory. ``mode="sandbox"`` rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, and SENSITIVE tools (R06)."""
     init_backend(app_name=trajectory_id)
     return Trajectory(
         trajectory_id=trajectory_id,

--- a/conformance/r06_sandbox_test.py
+++ b/conformance/r06_sandbox_test.py
@@ -1,4 +1,4 @@
-"""Conformance R06: sandbox rejects real NON_IDEMPOTENT_WRITE."""
+"""Conformance R06: sandbox rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, SENSITIVE."""
 
 from __future__ import annotations
 
@@ -26,7 +26,47 @@ def test_r06_sandbox_rejects_non_idempotent(tmp_path) -> None:
     tool = Tool(name="deploy_server", fn=deploy, effect_class=EffectClass.NON_IDEMPOTENT_WRITE)
     with pytest.raises(SandboxForbidden) as ei:
         exec_tool(traj, 1, {"args": {"version": "1"}}, tool, seq=2)
-    assert "SANDBOX_REJECTS" in str(ei.value)
+    assert "SANDBOX_FORBIDDEN" in str(ei.value)
+    assert side["n"] == 0
+
+
+def test_r06_sandbox_rejects_agent_spawn(tmp_path) -> None:
+    side = {"n": 0}
+
+    def spawn_worker(task: str = "") -> dict:
+        side["n"] += 1
+        return {"spawned": task}
+
+    traj = open_trajectory(
+        "demo",
+        "r06-spawn",
+        db_path=str(tmp_path / "t.sqlite"),
+        mode=RunMode.SANDBOX,
+    )
+    tool = Tool(name="spawn_worker", fn=spawn_worker, effect_class=EffectClass.AGENT_SPAWN)
+    with pytest.raises(SandboxForbidden) as ei:
+        exec_tool(traj, 1, {"args": {"task": "work"}}, tool, seq=2)
+    assert "SANDBOX_FORBIDDEN" in str(ei.value)
+    assert side["n"] == 0
+
+
+def test_r06_sandbox_rejects_sensitive(tmp_path) -> None:
+    side = {"n": 0}
+
+    def read_api_key(name: str = "") -> str:
+        side["n"] += 1
+        return "secret"
+
+    traj = open_trajectory(
+        "demo",
+        "r06-sensitive",
+        db_path=str(tmp_path / "t.sqlite"),
+        mode=RunMode.SANDBOX,
+    )
+    tool = Tool(name="read_api_key", fn=read_api_key, effect_class=EffectClass.SENSITIVE)
+    with pytest.raises(SandboxForbidden) as ei:
+        exec_tool(traj, 1, {"args": {"name": "key"}}, tool, seq=2)
+    assert "SANDBOX_FORBIDDEN" in str(ei.value)
     assert side["n"] == 0
 
 
@@ -46,6 +86,25 @@ def test_r06_sandbox_allows_pure(tmp_path) -> None:
     tool = Tool(name="compute", fn=compute, effect_class=EffectClass.PURE)
     result = exec_tool(traj, 1, {"args": {"x": 1}}, tool, seq=2)
     assert result.result == 2
+    assert calls["n"] == 1
+
+
+def test_r06_sandbox_allows_read_only(tmp_path) -> None:
+    calls = {"n": 0}
+
+    def read_config(key: str = "") -> str:
+        calls["n"] += 1
+        return "value"
+
+    traj = open_trajectory(
+        "demo",
+        "r06-readonly",
+        db_path=str(tmp_path / "t.sqlite"),
+        mode=RunMode.SANDBOX,
+    )
+    tool = Tool(name="read_config", fn=read_config, effect_class=EffectClass.READ_ONLY)
+    result = exec_tool(traj, 1, {"args": {"key": "k"}}, tool, seq=2)
+    assert result.result == "value"
     assert calls["n"] == 1
 
 

--- a/examples/adoption_host/README.md
+++ b/examples/adoption_host/README.md
@@ -16,7 +16,7 @@ real LLM client without changing seal or tool execution.
 4. Optional `--with-package`: `put_artifact` into `FileSystemCAS`, thin
    `export_tir(..., cas=...)`, `load_tir` + `rehydrate_artifacts` with a
    byte match check
-5. Optional `--sandbox`: non idempotent tools are rejected before the body runs
+5. Optional `--sandbox`: non idempotent, agent spawn, and sensitive tools are rejected before the body runs
 
 ## How this differs from other examples
 

--- a/examples/adoption_host/run_demo.py
+++ b/examples/adoption_host/run_demo.py
@@ -265,7 +265,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--sandbox",
         action="store_true",
-        help="Open trajectory in sandbox mode (rejects NON_IDEMPOTENT_WRITE)",
+        help=(
+            "Open trajectory in sandbox mode (rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, SENSITIVE)"
+        ),
     )
     parser.add_argument(
         "--with-package",

--- a/examples/host_loop/README.md
+++ b/examples/host_loop/README.md
@@ -10,7 +10,7 @@ host process should call Trajectory IR.
 2. Stub model (no paid API; injectable function)
 3. `project` then `seal_decision` with concrete known args only
 4. `exec_tool` then `commit_step`
-5. Optional sandbox mode (`mode=sandbox`) so non idempotent tools are rejected
+5. Optional sandbox mode (`mode=sandbox`) so non idempotent, agent spawn, and sensitive tools are rejected
 
 ## Run
 

--- a/examples/host_loop/run_host.py
+++ b/examples/host_loop/run_host.py
@@ -111,7 +111,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--sandbox",
         action="store_true",
-        help="Open trajectory in sandbox mode (rejects NON_IDEMPOTENT_WRITE)",
+        help=(
+            "Open trajectory in sandbox mode (rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, SENSITIVE)"
+        ),
     )
     parser.add_argument(
         "--db",

--- a/go/examples/adoption_host/README.md
+++ b/go/examples/adoption_host/README.md
@@ -9,7 +9,7 @@ Optional filesystem CAS and thin `.tir` export with rehydrate check.
 2. `ExecTool` for PURE (`build_manifest`) and gated NON_IDEMPOTENT_WRITE (`ship_release`)
 3. `CommitStep`
 4. Optional `-with-package`: CAS put, thin export, rehydrate
-5. Optional `-sandbox`: non idempotent tools rejected
+5. Optional `-sandbox`: non idempotent, agent spawn, and sensitive tools rejected
 
 ## How this differs
 

--- a/go/examples/adoption_host/main.go
+++ b/go/examples/adoption_host/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	sandboxFlag := flag.Bool("sandbox", false, "reject NON_IDEMPOTENT_WRITE tools")
+	sandboxFlag := flag.Bool("sandbox", false, "reject NON_IDEMPOTENT_WRITE, AGENT_SPAWN, and SENSITIVE tools")
 	withPackage := flag.Bool("with-package", false, "after live step, CAS put + thin .tir + rehydrate")
 	workDir := flag.String("workdir", "", "directory for sqlite files (default: temp)")
 	casRoot := flag.String("cas-root", "", "CAS root when using -with-package (default: temp)")

--- a/go/trajir/client/client.go
+++ b/go/trajir/client/client.go
@@ -35,7 +35,7 @@ type Options struct {
 	WorkflowID string
 	// Backend overrides LocalSQLite when non nil. Caller owns Close unless Open created it.
 	Backend durable.Backend
-	// Mode is live (default) or sandbox (R06).
+	// Mode is live (default) or sandbox (R06: reject NON_IDEMPOTENT_WRITE, AGENT_SPAWN, SENSITIVE).
 	Mode sandbox.Mode
 }
 

--- a/go/trajir/effects/effects.go
+++ b/go/trajir/effects/effects.go
@@ -21,6 +21,10 @@ func RequiresBlockAndGate(e EffectClass) bool {
 	return e == NON_IDEMPOTENT_WRITE
 }
 
+func IsForbiddenInSandbox(e EffectClass) bool {
+	return e == NON_IDEMPOTENT_WRITE || e == AGENT_SPAWN || e == SENSITIVE
+}
+
 // ClassifyFromMCP maps MCP tool annotations to an EffectClass.
 // Missing or ambiguous input becomes NON_IDEMPOTENT_WRITE.
 //

--- a/go/trajir/effects/effects_test.go
+++ b/go/trajir/effects/effects_test.go
@@ -23,6 +23,29 @@ func TestRequiresBlockAndGate(t *testing.T) {
 	}
 }
 
+func TestIsForbiddenInSandbox(t *testing.T) {
+	forbidden := []effects.EffectClass{
+		effects.NON_IDEMPOTENT_WRITE,
+		effects.AGENT_SPAWN,
+		effects.SENSITIVE,
+	}
+	for _, e := range forbidden {
+		if !effects.IsForbiddenInSandbox(e) {
+			t.Fatalf("%s must be forbidden in sandbox", e)
+		}
+	}
+	allowed := []effects.EffectClass{
+		effects.PURE,
+		effects.READ_ONLY,
+		effects.IDEMPOTENT_WRITE,
+	}
+	for _, e := range allowed {
+		if effects.IsForbiddenInSandbox(e) {
+			t.Fatalf("%s must be allowed in sandbox", e)
+		}
+	}
+}
+
 func TestMissingAnnotationsFailClosed(t *testing.T) {
 	if got := effects.ClassifyFromMCP(map[string]any{}); got != effects.NON_IDEMPOTENT_WRITE {
 		t.Fatalf("got %s, want NON_IDEMPOTENT_WRITE", got)

--- a/go/trajir/resume/step.go
+++ b/go/trajir/resume/step.go
@@ -30,7 +30,7 @@ type RunStepConfig struct {
 	WorkflowID       string // durable memo scope; often same as TrajectoryID
 	Tools            map[string]Tool
 	OnDecisionSealed func() // optional test hook after DECISION is appended
-	// Mode is live (default) or sandbox (R06: reject NON_IDEMPOTENT_WRITE).
+	// Mode is live (default) or sandbox (R06: reject NON_IDEMPOTENT_WRITE, AGENT_SPAWN, SENSITIVE).
 	Mode sandbox.Mode
 }
 

--- a/go/trajir/sandbox/sandbox.go
+++ b/go/trajir/sandbox/sandbox.go
@@ -24,7 +24,7 @@ type Forbidden struct {
 
 func (e *Forbidden) Error() string {
 	return fmt.Sprintf(
-		"SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE: tool %q effect=%s is forbidden in sandbox mode",
+		"SANDBOX_FORBIDDEN: tool %q effect=%s is forbidden in sandbox mode",
 		e.ToolName,
 		e.Effect,
 	)
@@ -44,7 +44,7 @@ func NormalizeMode(mode string) (Mode, error) {
 
 // AssertToolAllowed raises Forbidden in sandbox for gated effects.
 func AssertToolAllowed(mode Mode, toolName string, effect effects.EffectClass) error {
-	if mode == ModeSandbox && effects.RequiresBlockAndGate(effect) {
+	if mode == ModeSandbox && effects.IsForbiddenInSandbox(effect) {
 		return &Forbidden{ToolName: toolName, Effect: effect}
 	}
 	return nil

--- a/go/trajir/sandbox/sandbox_test.go
+++ b/go/trajir/sandbox/sandbox_test.go
@@ -16,14 +16,48 @@ func TestSandboxRejectsNonIdempotent(t *testing.T) {
 	}
 }
 
+func TestSandboxRejectsAgentSpawn(t *testing.T) {
+	err := sandbox.AssertToolAllowed(sandbox.ModeSandbox, "spawn_worker", effects.AGENT_SPAWN)
+	var f *sandbox.Forbidden
+	if !errors.As(err, &f) {
+		t.Fatalf("want Forbidden, got %v", err)
+	}
+}
+
+func TestSandboxRejectsSensitive(t *testing.T) {
+	err := sandbox.AssertToolAllowed(sandbox.ModeSandbox, "read_api_key", effects.SENSITIVE)
+	var f *sandbox.Forbidden
+	if !errors.As(err, &f) {
+		t.Fatalf("want Forbidden, got %v", err)
+	}
+}
+
 func TestSandboxAllowsPure(t *testing.T) {
 	if err := sandbox.AssertToolAllowed(sandbox.ModeSandbox, "compute", effects.PURE); err != nil {
 		t.Fatal(err)
 	}
 }
 
+func TestSandboxAllowsReadOnly(t *testing.T) {
+	if err := sandbox.AssertToolAllowed(sandbox.ModeSandbox, "read_config", effects.READ_ONLY); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLiveAllowsNonIdempotent(t *testing.T) {
 	if err := sandbox.AssertToolAllowed(sandbox.ModeLive, "deploy", effects.NON_IDEMPOTENT_WRITE); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveAllowsAgentSpawn(t *testing.T) {
+	if err := sandbox.AssertToolAllowed(sandbox.ModeLive, "spawn_worker", effects.AGENT_SPAWN); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveAllowsSensitive(t *testing.T) {
+	if err := sandbox.AssertToolAllowed(sandbox.ModeLive, "read_api_key", effects.SENSITIVE); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -65,3 +99,4 @@ func TestForbiddenErrorText(t *testing.T) {
 		t.Fatal("empty error text")
 	}
 }
+

--- a/pkg/trajectory_ir/effects/__init__.py
+++ b/pkg/trajectory_ir/effects/__init__.py
@@ -1,7 +1,8 @@
 from trajectory_ir.effects.classify import (
     EffectClass,
     classify_from_mcp,
+    is_forbidden_in_sandbox,
     requires_block_and_gate,
 )
 
-__all__ = ["EffectClass", "classify_from_mcp", "requires_block_and_gate"]
+__all__ = ["EffectClass", "classify_from_mcp", "is_forbidden_in_sandbox", "requires_block_and_gate"]

--- a/pkg/trajectory_ir/effects/classify.py
+++ b/pkg/trajectory_ir/effects/classify.py
@@ -22,6 +22,14 @@ def requires_block_and_gate(effect: EffectClass) -> bool:
     return effect is EffectClass.NON_IDEMPOTENT_WRITE
 
 
+def is_forbidden_in_sandbox(effect: EffectClass) -> bool:
+    return effect in (
+        EffectClass.NON_IDEMPOTENT_WRITE,
+        EffectClass.AGENT_SPAWN,
+        EffectClass.SENSITIVE,
+    )
+
+
 def classify_from_mcp(annotations: Any) -> EffectClass:
     """Fail-closed per spec §7.2. Any missing or ambiguous annotation -> NON_IDEMPOTENT_WRITE.
 

--- a/pkg/trajectory_ir/resume/step.py
+++ b/pkg/trajectory_ir/resume/step.py
@@ -81,7 +81,8 @@ def make_run_step(
       when durable memo is absent (R03 for PURE). Prior TOOL_CALL rows alone
       must not raise ``BlockedNeedsGate`` for these classes.
 
-    Sandbox mode (R06): rejects NON_IDEMPOTENT_WRITE before the tool body runs.
+    Sandbox mode (R06): rejects NON_IDEMPOTENT_WRITE, AGENT_SPAWN, and
+    SENSITIVE before the tool body runs.
 
     Durable backend hooks default to the DBOS adapter. Pass Restate (or local
     memo) wrappers via ``durable_infer_fn`` / ``durable_tool_fn`` /

--- a/pkg/trajectory_ir/runtime/sandbox.py
+++ b/pkg/trajectory_ir/runtime/sandbox.py
@@ -1,15 +1,15 @@
 """Sandbox / what-if trajectory mode (README §10 R06).
 
-Live mode is the default. Sandbox mode allows planning and non-gated tools
-(PURE, READ_ONLY, etc.) but rejects real NON_IDEMPOTENT_WRITE side effects
-before the tool body runs.
+Live mode is the default. Sandbox mode allows planning and safe tools
+(PURE, READ_ONLY, IDEMPOTENT_WRITE) but rejects NON_IDEMPOTENT_WRITE,
+AGENT_SPAWN, and SENSITIVE effects before the tool body runs.
 """
 
 from __future__ import annotations
 
 from enum import StrEnum
 
-from trajectory_ir.effects import EffectClass, requires_block_and_gate
+from trajectory_ir.effects import EffectClass, is_forbidden_in_sandbox
 
 
 class RunMode(StrEnum):
@@ -24,7 +24,7 @@ class SandboxForbidden(Exception):
         self.tool_name = tool_name
         self.effect_class = effect_class
         super().__init__(
-            f"SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE: tool {tool_name!r} "
+            f"SANDBOX_FORBIDDEN: tool {tool_name!r} "
             f"effect={effect_class.value} is forbidden in sandbox mode"
         )
 
@@ -50,5 +50,5 @@ def assert_tool_allowed_in_mode(
 ) -> None:
     """Raise SandboxForbidden if this tool must not run under the given mode."""
     run_mode = normalize_run_mode(mode)
-    if run_mode is RunMode.SANDBOX and requires_block_and_gate(effect_class):
+    if run_mode is RunMode.SANDBOX and is_forbidden_in_sandbox(effect_class):
         raise SandboxForbidden(tool_name, effect_class)

--- a/test/unit/test_effects.py
+++ b/test/unit/test_effects.py
@@ -1,4 +1,9 @@
-from trajectory_ir.effects import EffectClass, classify_from_mcp, is_forbidden_in_sandbox, requires_block_and_gate
+from trajectory_ir.effects import (
+    EffectClass,
+    classify_from_mcp,
+    is_forbidden_in_sandbox,
+    requires_block_and_gate,
+)
 
 
 def test_missing_annotations_fail_closed():

--- a/test/unit/test_effects.py
+++ b/test/unit/test_effects.py
@@ -1,4 +1,4 @@
-from trajectory_ir.effects import EffectClass, classify_from_mcp, requires_block_and_gate
+from trajectory_ir.effects import EffectClass, classify_from_mcp, is_forbidden_in_sandbox, requires_block_and_gate
 
 
 def test_missing_annotations_fail_closed():
@@ -57,3 +57,12 @@ def test_requires_block_and_gate_only_non_idempotent():
     assert requires_block_and_gate(EffectClass.IDEMPOTENT_WRITE) is False
     assert requires_block_and_gate(EffectClass.AGENT_SPAWN) is False
     assert requires_block_and_gate(EffectClass.SENSITIVE) is False
+
+
+def test_is_forbidden_in_sandbox():
+    assert is_forbidden_in_sandbox(EffectClass.NON_IDEMPOTENT_WRITE) is True
+    assert is_forbidden_in_sandbox(EffectClass.AGENT_SPAWN) is True
+    assert is_forbidden_in_sandbox(EffectClass.SENSITIVE) is True
+    assert is_forbidden_in_sandbox(EffectClass.PURE) is False
+    assert is_forbidden_in_sandbox(EffectClass.READ_ONLY) is False
+    assert is_forbidden_in_sandbox(EffectClass.IDEMPOTENT_WRITE) is False

--- a/website/docs/demos/index.md
+++ b/website/docs/demos/index.md
@@ -6,7 +6,7 @@ These are the **conference-ready** Trajectory IR demos. They use the **Go primar
 |---|---|---|---|
 | [Kill mid deploy](kill-mid-deploy.md) | Seal + crash mid non-idempotent tool → honest gate, no silent re-deploy | 3–4 min | `go run ./examples/kill_mid_deploy ...` |
 | [Adoption host + `.tir`](adoption-host.md) | Host loop + thin package + CAS rehydrate | 2 min | `go run ./examples/adoption_host -with-package` |
-| [Sandbox mode](sandbox.md) | R06: reject real `NON_IDEMPOTENT_WRITE` in sandbox | 30–45 sec | `go run ./examples/adoption_host -sandbox` |
+| [Sandbox mode](sandbox.md) | R06: reject `NON_IDEMPOTENT_WRITE`, `AGENT_SPAWN`, and `SENSITIVE` in sandbox | 30–45 sec | `go run ./examples/adoption_host -sandbox` |
 
 ## Recommended talk order
 

--- a/website/docs/demos/sandbox.md
+++ b/website/docs/demos/sandbox.md
@@ -1,6 +1,6 @@
 # Demo: Sandbox mode (R06)
 
-Fast safety demo. In sandbox mode, real `NON_IDEMPOTENT_WRITE` tools are rejected **before** side effects.
+Fast safety demo. In sandbox mode, real `NON_IDEMPOTENT_WRITE`, `AGENT_SPAWN`, and `SENSITIVE` tools are rejected **before** side effects.
 
 Source: same adoption host with `-sandbox`
 

--- a/website/fixtures/adoption_host_sandbox.txt
+++ b/website/fixtures/adoption_host_sandbox.txt
@@ -1,1 +1,1 @@
-sandbox correctly rejected non idempotent tool: SANDBOX_REJECTS_NON_IDEMPOTENT_WRITE: tool "ship_release" effect=NON_IDEMPOTENT_WRITE is forbidden in sandbox mode
+sandbox correctly rejected non idempotent tool: SANDBOX_FORBIDDEN: tool "ship_release" effect=NON_IDEMPOTENT_WRITE is forbidden in sandbox mode


### PR DESCRIPTION
## Summary

Sandbox mode (R06) only checked `requires_block_and_gate()` / `RequiresBlockAndGate()`, which returns true only for `NON_IDEMPOTENT_WRITE`. Tools classified as `AGENT_SPAWN` or `SENSITIVE` passed through `assert_tool_allowed_in_mode` without error, breaking sandbox isolation.

This adds `is_forbidden_in_sandbox()` (Python) and `IsForbiddenInSandbox()` (Go) that return true for `NON_IDEMPOTENT_WRITE`, `AGENT_SPAWN`, and `SENSITIVE`. The sandbox check now uses these instead of the resume gating predicate. `requires_block_and_gate` / `RequiresBlockAndGate` remain unchanged for their original R02 resume purpose.

## Related issues

Closes #347

## How I tested

```bash
# Python
pytest conformance/r06_sandbox_test.py -v
pytest -v  # full suite: 230 passed

# Go
cd go && go test ./trajir/sandbox/... -count=1
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [ ] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes: adds `IsForbiddenInSandbox` / `is_forbidden_in_sandbox` to the effect classification layer and changes the sandbox mode predicate from `RequiresBlockAndGate` to the new function. `RequiresBlockAndGate` is untouched.

## AI assistance (if any)

None.