### PR TITLE
fix(redact): allow optional username in credential URI regex

### DIFF
--- a/pkg/trajectory_ir/runtime/redact.py
+++ b/pkg/trajectory_ir/runtime/redact.py
@@ -31,7 +31,7 @@ SECRET_VALUE_RE = re.compile(
     r"|AIza[0-9A-Za-z\-_]{35}"  # GCP API key
     r"|-----BEGIN[ A-Z]*PRIVATE KEY-----"  # PEM private key block
     r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"  # JWT
-    r"|[a-zA-Z][a-zA-Z0-9+.-]*://[^:@\s]+:[^@\s]+@)"  # credential URI (scheme://user:pass@)
+    r"|[a-zA-Z][a-zA-Z0-9+.-]*://[^:@\s]*:[^@\s]+@)"  # credential URI (scheme://user:pass@ or scheme://:pass@)
 )
 
 REDACTED = "[REDACTED]"

--- a/test/unit/test_redact.py
+++ b/test/unit/test_redact.py
@@ -70,6 +70,7 @@ def test_redact_value_credential_uri():
     assert redact_value("config", "mongodb+srv://admin:password@cluster") == REDACTED
     assert redact_value("config", "redis://default:hunter2@cache.internal:6379") == REDACTED
     assert redact_value("config", "amqp://guest:guest@rabbitmq:5672") == REDACTED
+    assert redact_value("config", "redis://:hunter2@cache.internal:6379") == REDACTED
 
 
 def test_redact_value_credential_uri_no_password():


### PR DESCRIPTION
## Summary
fixed a bug where `SECRET_VALUE_RE` explicitly required at least one character in the username block before the colon, missing password only connection strings (like Redis URIs). By making the username capture group optional (`*` instead of `+`), the engine now correctly redacts strings like `redis://:password@host` without introducing any false positives.

## Related issues
Closes #334

## How I tested

```bash
# Tested specifically against the redaction unit suite
pytest test/unit/test_redact.py -q
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [ ] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [ ] No
- [x] Yes  Yes (Modifies the core secret heuristic regex in `pkg/trajectory_ir/runtime/redact.py` the trailing password group + ensures it remains strict against false positives).

## AI assistance (if any)

Antigravity base model
