### PR TITLE
fix(ci): pin govulncheck to v1.7.0 to unblock Go CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       - name: govulncheck
         working-directory: go
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           govulncheck ./...
 
   # ---- Deep gate: required, allowed to run slower ----


### PR DESCRIPTION
## Summary
- The `govulncheck` step in the Go CI job installs `golang.org/x/vuln/cmd/govulncheck@latest`, which recently resolved to v1.8.0 — that version requires `go >= 1.26.0`, but CI is pinned to Go 1.25.13 with `GOTOOLCHAIN=local`, so the install fails on every PR (unrelated to the PR's own diff).
- Pins the install to `v1.7.0` (requires `go 1.25.0`, compatible with CI's toolchain) instead of floating on `@latest`, so a future incompatible release can't break CI again the same way.

## Test plan
- [ ] Confirm the "Go" CI check passes on this PR
- [ ] Re-run/verify CI on a previously-blocked PR (e.g. #353) once this merges