### PR TITLE
fix(packaging): add rfc8785 to core dependencies (#362)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,13 @@ jobs:
           .venv-smoke/bin/pip install dist/trajectory_ir-*.whl
           .venv-smoke/bin/python -c "\
           import trajectory_ir; \
-          from trajectory_ir.runtime.nodes import Node; \
+          from trajectory_ir.runtime.nodes import Node, payload_hash; \
+          from trajectory_ir.runtime.log import NodeLog; \
           from trajectory_ir.storage import FileSystemCAS, content_hash; \
           assert content_hash(b'') == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'; \
+          log = NodeLog(':memory:'); \
+          rec = log.append('DECISION', 1, {'plan': {}}, 't1', 'tenant1', seq=1); \
+          assert rec.id; \
           print('package smoke ok', getattr(trajectory_ir, '__file__', 'n/a'))"
 
       - name: Upload dist artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,15 @@ classifiers = [
 dependencies = [
     "dbos",
     "pynacl",
+    "rfc8785",
     # cffi 2.1+ reports MIT-0, which the license allowlist does not list yet.
     "cffi>=1.14,<2.1",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit", "rfc8785"]
-postgres = ["psycopg[binary]>=3.1", "rfc8785"]
-s3 = ["boto3", "rfc8785"]
+dev = ["pytest", "pytest-cov", "ruff", "mypy", "pip-audit"]
+postgres = ["psycopg[binary]>=3.1"]
+s3 = ["boto3"]
 rfc8785 = ["rfc8785"]
 
 [project.urls]

--- a/test/unit/test_rfc8785_optional.py
+++ b/test/unit/test_rfc8785_optional.py
@@ -1,5 +1,32 @@
 import subprocess
 import sys
+import tomllib
+from pathlib import Path
+
+
+def test_rfc8785_declared_in_core_dependencies():
+    """Ensure rfc8785 is in project.dependencies so standard wheel installs include it."""
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+    deps = data.get("project", {}).get("dependencies", [])
+    assert any("rfc8785" in dep for dep in deps), (
+        "rfc8785 must be declared in core project.dependencies"
+    )
+
+
+def test_payload_hash_and_size_units_with_rfc8785():
+    """Verify standard payload hashing and size units operate normally when installed."""
+    import rfc8785  # noqa: F401
+
+    from trajectory_ir.runtime.nodes import payload_hash
+    from trajectory_ir.runtime.projector import node_size_units
+
+    digest = payload_hash({"type": "test", "active": True})
+    assert isinstance(digest, str) and len(digest) == 64
+
+    units = node_size_units({"kind": "INPUT", "payload": {"type": "test", "active": True}})
+    assert isinstance(units, int) and units > 0
 
 
 def test_nodes_import_succeeds_without_rfc8785():


### PR DESCRIPTION
## Summary

Standard wheel and sdist installs (`pip install trajectory-ir` or `pip install .`) were non-functional because `rfc8785` was placed under optional dependencies rather than core dependencies. Any node write (`NodeLog.append`, `node_id`) immediately failed with `RuntimeError: rfc8785 is required for payload hashing but is not installed`.

This moves `rfc8785` into base `project.dependencies` in `pyproject.toml`, removes redundant entries from optional extras, adds packaging regression tests verifying the dependency contract and runtime hashing, and updates the CI wheel smoke test to verify node creation and hashing in an isolated environment.

## Related issues

Closes #362

## How I tested

```bash
# Unit and conformance tests
pytest test/unit/test_rfc8785_optional.py -v
pytest test/unit/ -q
pytest conformance/ -q

# Lint and formatting
ruff check .
ruff format --check .
mypy

# Wheel build and clean installation smoke test
python -m build
# Verified built wheel METADATA contains Requires-Dist: rfc8785
```

## Checklist

- [x] Commits are DCO signed (`git commit -s`)
- [x] New functionality includes tests in this PR
- [x] Change matches the master README (no invented APIs)
- [x] Relevant CI checks pass locally (or will pass on the PR)
- [x] If you changed `.github/workflows/**`, note it under Safety and expect extra review
- [x] AI assistance disclosed below if a tool wrote a meaningful share of the change

## Safety areas

Does this touch effect classes, resume / block-and-gate, seals, or secret handling?

- [x] No
- [ ] Yes (call it out here)

Note on `.github/workflows/ci.yml`: Updated the wheel smoke test step to verify node appending and payload hashing in the clean virtual environment.

## AI assistance (if any)

None.
