### PR TITLE
Add Redacted option to Go tir.Export for parity with Python

### DIFF
--- a/go/trajir/tir/tir.go
+++ b/go/trajir/tir/tir.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/cas"
 	nodelog "github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/log"
 	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/nodes"
+	"github.com/Coder-s-OG-s/Trajectory-IR/go/trajir/redact"
 )
 
 // Package format constants match the Python reference.
@@ -109,6 +110,14 @@ type ExportOptions struct {
 	// length fails closed; it does not silently produce an unsigned package.
 	SignKey    ed25519.PrivateKey
 	SignerMeta SignerMeta
+	// Redacted, when true, strips thoughts and fields that match a secret-like
+	// key name or value shape before export (matches export_tir(redacted=True)
+	// in the Python reference). This is a keyword/pattern heuristic, not a
+	// general secret scanner: it will not catch every secret, so redacted
+	// output still needs a human review pass before being shared outside the
+	// tenant. Fat mode is forced down to thin in redacted output since
+	// embedded artifact bytes may themselves hold secrets.
+	Redacted bool
 }
 
 // contentHash returns SHA-256 hex of data.
@@ -196,6 +205,53 @@ func asPayload(v any) (map[string]any, error) {
 		return nil, fmt.Errorf("payload must be an object, got %T", v)
 	}
 	return m, nil
+}
+
+// redactNodeRecord returns a copy of a node record with thoughts/secrets
+// stripped, matching Python's _redact_node. payload_hash and id are
+// recomputed from the redacted payload since export produces a new,
+// differently-hashed package; ts is carried over unchanged (wall clock is
+// never part of node identity).
+func redactNodeRecord(rec map[string]any) (map[string]any, error) {
+	kind, _ := asString(rec["kind"])
+	payload, err := asPayload(rec["payload"])
+	if err != nil {
+		return nil, err
+	}
+	newPayload := redact.RedactPayload(kind, payload)
+	tenant, _ := asString(rec["tenant_id"])
+	traj, _ := asString(rec["trajectory_id"])
+	stepN, err := asStepN(rec["step_n"])
+	if err != nil {
+		return nil, err
+	}
+	seq, err := asInt(rec["seq"])
+	if err != nil {
+		return nil, err
+	}
+	ph, err := nodes.PayloadHash(newPayload)
+	if err != nil {
+		return nil, err
+	}
+	id, err := nodes.NodeID(tenant, traj, stepN, seq, kind, ph)
+	if err != nil {
+		return nil, err
+	}
+	var ts float64
+	if v, ok := rec["ts"].(float64); ok {
+		ts = v
+	}
+	return map[string]any{
+		"id":            id,
+		"trajectory_id": traj,
+		"tenant_id":     tenant,
+		"step_n":        rec["step_n"],
+		"seq":           seq,
+		"kind":          kind,
+		"payload":       newPayload,
+		"ts":            ts,
+		"payload_hash":  ph,
+	}, nil
 }
 
 // verifyNodeRecord recomputes id from fields; fails on mismatch.
@@ -333,6 +389,24 @@ func Export(nodeLog *nodelog.NodeLog, trajectoryID, dest string, opts ExportOpti
 		}
 	}
 
+	if opts.Redacted {
+		redactedList := make([]map[string]any, 0, len(nodeList))
+		for _, n := range nodeList {
+			rn, err := redactNodeRecord(n)
+			if err != nil {
+				return "", err
+			}
+			redactedList = append(redactedList, rn)
+		}
+		nodeList = redactedList
+		if mode == ModeFat {
+			// Fat artifacts may hold secrets; omit bytes in redacted mode.
+			mode = ModeThin
+			opts.Artifacts = nil
+			opts.ArtifactBytes = nil
+		}
+	}
+
 	artifactBytes := map[string][]byte{}
 	artifacts := opts.Artifacts
 	if artifacts == nil {
@@ -374,7 +448,7 @@ func Export(nodeLog *nodelog.NodeLog, trajectoryID, dest string, opts ExportOpti
 		"node_count":     len(nodeList),
 		"seal_count":     len(seals),
 		"signature":      nil,
-		"redacted":       false,
+		"redacted":       opts.Redacted,
 	}
 
 	artManifest := make([]map[string]any, 0, len(artifacts))

--- a/go/trajir/tir/tir_test.go
+++ b/go/trajir/tir/tir_test.go
@@ -139,6 +139,97 @@ func TestExportImportRoundTripFat(t *testing.T) {
 	}
 }
 
+func TestExportRedactedStripsThoughtsAndSecrets(t *testing.T) {
+	src := openLog(t, "src.sqlite")
+	seedSample(t, src)
+	step := 5
+	if _, err := src.Append("THOUGHT", &step, map[string]any{
+		"text": "the password is hunter2",
+	}, "t-export", "demo", 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.Append("TOOL_CALL", &step, map[string]any{
+		"tool": "curl",
+		"args": map[string]any{"api_key": "sk-abcdefghijklmnopqrstu"},
+	}, "t-export", "demo", 6); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "redacted.tir")
+	path, err := tir.Export(src, "t-export", out, tir.ExportOptions{Mode: tir.ModeThin, Redacted: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, err := tir.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pkg.Manifest["redacted"] != true {
+		t.Fatalf("manifest redacted=%v, want true", pkg.Manifest["redacted"])
+	}
+
+	var sawThought, sawSecretKey bool
+	for _, n := range pkg.Nodes {
+		kind, _ := n["kind"].(string)
+		payload, _ := n["payload"].(map[string]any)
+		switch kind {
+		case "THOUGHT":
+			sawThought = true
+			if payload["redacted"] != true || len(payload) != 1 {
+				t.Fatalf("THOUGHT payload not collapsed: %v", payload)
+			}
+		case "TOOL_CALL":
+			if args, ok := payload["args"].(map[string]any); ok {
+				if v, ok := args["api_key"]; ok {
+					sawSecretKey = true
+					if v != "[REDACTED]" {
+						t.Fatalf("api_key not redacted: %v", v)
+					}
+				}
+			}
+		}
+	}
+	if !sawThought {
+		t.Fatal("no THOUGHT node found in exported package")
+	}
+	if !sawSecretKey {
+		t.Fatal("no api_key field found to verify redaction")
+	}
+}
+
+func TestExportRedactedForcesFatToThin(t *testing.T) {
+	src := openLog(t, "src.sqlite")
+	seedSample(t, src)
+
+	blob := []byte("print('hello')\n")
+	sum := sha256.Sum256(blob)
+	h := hex.EncodeToString(sum[:])
+
+	out := filepath.Join(t.TempDir(), "redacted-fat.tir")
+	path, err := tir.Export(src, "t-export", out, tir.ExportOptions{
+		Mode:          tir.ModeFat,
+		Redacted:      true,
+		Artifacts:     []tir.ArtifactRef{{LogicalPath: "src/main.py", ContentHash: h}},
+		ArtifactBytes: map[string][]byte{h: blob},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, err := tir.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pkg.Manifest["mode"] != "thin" {
+		t.Fatalf("mode=%v, want thin (redacted must force fat down to thin)", pkg.Manifest["mode"])
+	}
+	if len(pkg.ArtifactsManifest) != 0 {
+		t.Fatalf("artifacts manifest not empty: %v", pkg.ArtifactsManifest)
+	}
+	if len(pkg.ArtifactBytes) != 0 {
+		t.Fatalf("artifact bytes not empty: %v", pkg.ArtifactBytes)
+	}
+}
+
 func TestImportDetectsTamperedNode(t *testing.T) {
 	src := openLog(t, "src.sqlite")
 	seedSample(t, src)


### PR DESCRIPTION
Closes #315

The Go ExportOptions struct had no field to request redaction, so exported packages always shipped raw THOUGHT payloads and secret-shaped fields, even though go/trajir/redact already implements the same scrubbing logic used in projection and was never wired into export. manifest.json also hardcoded "redacted": false regardless of caller intent.

Added a Redacted bool to ExportOptions. When set:
- every node is run through redact.RedactPayload before export (THOUGHT payloads collapse to {"redacted": true}, keys/values matching secret patterns become [REDACTED])
- payload_hash and id are recomputed from the redacted payload since it changes the content being hashed
- fat mode is forced down to thin and artifacts/artifact bytes are dropped, since embedded artifact bytes can hold secrets too, matching what export_tir(redacted=True) does in Python
- manifest.json now reports the real redacted value instead of a hardcoded false

Added two tests: one exporting a trajectory with a THOUGHT node and an api_key field and checking both get scrubbed and the manifest flag flips to true, and one confirming fat mode gets forced to thin with an empty artifacts manifest when redaction is requested.

Ran go build, go vet, and go test ./... across the whole module, all passing.